### PR TITLE
feat: Django structural alignment with Laravel

### DIFF
--- a/escalated/management/commands/install.py
+++ b/escalated/management/commands/install.py
@@ -1,0 +1,81 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.utils.translation import gettext as _
+
+
+class Command(BaseCommand):
+    help = "Set up Escalated: run migrations, seed data, and configure defaults."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--no-input",
+            action="store_true",
+            help="Run non-interactively with defaults (for CI).",
+        )
+
+    def handle(self, *args, **options):
+        no_input = options["no_input"]
+
+        # Step 1: Run migrations
+        self.stdout.write(_("Running migrations..."))
+        call_command("migrate", verbosity=0)
+        self.stdout.write(self.style.SUCCESS(_("Migrations complete.")))
+
+        # Step 2: Seed permissions
+        self.stdout.write(_("Seeding permissions..."))
+        call_command("seed_permissions", verbosity=0)
+        self.stdout.write(self.style.SUCCESS(_("Permissions seeded.")))
+
+        # Step 3: Create default department
+        from escalated.models import Department
+
+        dept, created = Department.objects.get_or_create(
+            slug="general",
+            defaults={"name": "General", "description": "Default support department"},
+        )
+        if created:
+            self.stdout.write(self.style.SUCCESS(_("Created default 'General' department.")))
+        else:
+            self.stdout.write(_("Default department already exists."))
+
+        # Step 4: Create default SLA policy
+        from escalated.models import SlaPolicy
+
+        if not SlaPolicy.objects.filter(is_default=True).exists():
+            SlaPolicy.objects.create(
+                name="Default",
+                description="Default SLA policy",
+                is_default=True,
+                first_response_hours={
+                    "low": 24, "medium": 8, "high": 4, "urgent": 1, "critical": 0.5,
+                },
+                resolution_hours={
+                    "low": 72, "medium": 24, "high": 8, "urgent": 4, "critical": 2,
+                },
+            )
+            self.stdout.write(self.style.SUCCESS(_("Created default SLA policy.")))
+        else:
+            self.stdout.write(_("Default SLA policy already exists."))
+
+        # Step 5: Create superuser (interactive only)
+        if not no_input:
+            from django.contrib.auth import get_user_model
+
+            User = get_user_model()
+            if not User.objects.filter(is_superuser=True).exists():
+                self.stdout.write(_("\nNo superuser found. Creating one now:"))
+                call_command("createsuperuser")
+            else:
+                self.stdout.write(_("Superuser already exists."))
+
+        # Summary
+        from escalated.conf import get_setting
+
+        prefix = get_setting("ROUTE_PREFIX")
+        api_prefix = get_setting("API_PREFIX")
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS(_("Installation complete!")))
+        self.stdout.write(_(f"  Admin panel:     /{prefix}/admin/"))
+        self.stdout.write(_(f"  Agent dashboard: /{prefix}/agent/"))
+        self.stdout.write(_(f"  Customer portal: /{prefix}/customer/"))
+        self.stdout.write(_(f"  REST API:        /{api_prefix}/"))

--- a/escalated/management/commands/plugin.py
+++ b/escalated/management/commands/plugin.py
@@ -1,0 +1,71 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from escalated.plugin_models import EscalatedPlugin
+
+
+class Command(BaseCommand):
+    help = "Manage Escalated plugins: list, activate, deactivate."
+
+    def add_arguments(self, parser):
+        subparsers = parser.add_subparsers(dest="subcommand", help="Plugin subcommand")
+
+        subparsers.add_parser("list", help="List all plugins")
+
+        activate_parser = subparsers.add_parser("activate", help="Activate a plugin")
+        activate_parser.add_argument("slug", type=str)
+
+        deactivate_parser = subparsers.add_parser("deactivate", help="Deactivate a plugin")
+        deactivate_parser.add_argument("slug", type=str)
+
+    def handle(self, *args, **options):
+        subcommand = options.get("subcommand")
+
+        if subcommand == "list":
+            return self._list()
+        elif subcommand == "activate":
+            return self._activate(options["slug"])
+        elif subcommand == "deactivate":
+            return self._deactivate(options["slug"])
+        else:
+            self.stdout.write(self.style.ERROR("Usage: plugin <list|activate|deactivate>"))
+
+    def _list(self):
+        plugins = EscalatedPlugin.objects.all().order_by("slug")
+        if not plugins.exists():
+            self.stdout.write("No plugins installed. 0 plugins found.")
+            return
+
+        self.stdout.write(f"\n{'Slug':<40} {'Status':<10}")
+        self.stdout.write("-" * 55)
+        for p in plugins:
+            status = self.style.SUCCESS("active") if p.is_active else self.style.WARNING("inactive")
+            self.stdout.write(f"{p.slug:<40} {status}")
+        self.stdout.write(f"\n{plugins.count()} plugins found.")
+
+    def _activate(self, slug):
+        try:
+            plugin = EscalatedPlugin.objects.get(slug=slug)
+        except EscalatedPlugin.DoesNotExist:
+            raise CommandError(f"Plugin '{slug}' not found.")
+
+        if plugin.is_active:
+            self.stdout.write(f"Plugin '{slug}' is already active.")
+            return
+
+        plugin.is_active = True
+        plugin.save(update_fields=["is_active"])
+        self.stdout.write(self.style.SUCCESS(f"Plugin '{slug}' activated."))
+
+    def _deactivate(self, slug):
+        try:
+            plugin = EscalatedPlugin.objects.get(slug=slug)
+        except EscalatedPlugin.DoesNotExist:
+            raise CommandError(f"Plugin '{slug}' not found.")
+
+        if not plugin.is_active:
+            self.stdout.write(f"Plugin '{slug}' is already inactive.")
+            return
+
+        plugin.is_active = False
+        plugin.save(update_fields=["is_active"])
+        self.stdout.write(self.style.SUCCESS(f"Plugin '{slug}' deactivated."))

--- a/escalated/management/commands/purge_expired_data.py
+++ b/escalated/management/commands/purge_expired_data.py
@@ -1,0 +1,77 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from escalated.models import ApiToken, ImportJob, WebhookDelivery
+
+
+class Command(BaseCommand):
+    help = "Purge expired API tokens, old webhook deliveries, and stale import jobs."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=30,
+            help="Delete webhook deliveries older than this many days (default: 30).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be purged without making changes.",
+        )
+
+    def handle(self, *args, **options):
+        days = options["days"]
+        dry_run = options["dry_run"]
+        now = timezone.now()
+        threshold = now - timedelta(days=days)
+        total_purged = 0
+
+        # 1. Expired API tokens
+        expired_tokens = ApiToken.objects.filter(expires_at__lt=now, expires_at__isnull=False)
+        token_count = expired_tokens.count()
+
+        # 2. Old webhook deliveries
+        old_deliveries = WebhookDelivery.objects.filter(created_at__lt=threshold)
+        delivery_count = old_deliveries.count()
+
+        # 3. Stale import jobs (failed/pending > 7 days)
+        stale_threshold = now - timedelta(days=7)
+        stale_imports = ImportJob.objects.filter(
+            status__in=["pending", "failed"],
+            created_at__lt=stale_threshold,
+        )
+        import_count = stale_imports.count()
+
+        if dry_run:
+            self.stdout.write(
+                f"[DRY RUN] Would purge: "
+                f"{token_count} expired tokens, "
+                f"{delivery_count} webhook deliveries (>{days}d), "
+                f"{import_count} stale import jobs."
+            )
+            return
+
+        if token_count:
+            deleted, _ = expired_tokens.delete()
+            total_purged += deleted
+            self.stdout.write(f"Purged {deleted} expired API tokens.")
+
+        if delivery_count:
+            deleted, _ = old_deliveries.delete()
+            total_purged += deleted
+            self.stdout.write(f"Purged {deleted} webhook deliveries older than {days} days.")
+
+        if import_count:
+            deleted, _ = stale_imports.delete()
+            total_purged += deleted
+            self.stdout.write(f"Purged {deleted} stale import jobs.")
+
+        if total_purged == 0:
+            self.stdout.write("No expired data to purge.")
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(f"Purge complete: {total_purged} total records removed.")
+            )

--- a/escalated/management/commands/run_automations.py
+++ b/escalated/management/commands/run_automations.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+from django.utils.translation import gettext as _
+
+from escalated.services.automation_runner import AutomationRunner
+
+
+class Command(BaseCommand):
+    help = "Run time-based automations against open tickets"
+
+    def handle(self, *args, **options):
+        self.stdout.write(_("Running automations against open tickets..."))
+
+        runner = AutomationRunner()
+        count = runner.run()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                _("Automations complete: %(count)d ticket(s) affected") % {"count": count}
+            )
+        )

--- a/escalated/policies/__init__.py
+++ b/escalated/policies/__init__.py
@@ -1,0 +1,53 @@
+"""
+Policy-based authorization for Escalated views.
+
+Policies wrap the low-level permission functions from escalated.permissions
+into a structured, decorator-friendly pattern matching Laravel's policy classes.
+"""
+
+import functools
+
+from django.http import JsonResponse
+
+
+class PolicyDenied(Exception):
+    pass
+
+
+def check_policy(policy_class, action, obj_arg=None, lookup_model=None, lookup_field="pk"):
+    """
+    View decorator that resolves an object and checks a policy method.
+
+    Usage:
+        @check_policy(TicketPolicy, 'update', obj_arg='reference',
+                       lookup_model=Ticket, lookup_field='reference')
+        def ticket_update(request, reference):
+            ticket = request.policy_object
+            ...
+
+    If obj_arg is None, calls the policy method with just (user,).
+    Otherwise resolves the object and calls with (user, obj).
+    """
+    def decorator(view_func):
+        @functools.wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            obj = None
+            if obj_arg and lookup_model:
+                lookup_value = kwargs.get(obj_arg)
+                if lookup_value is None and args:
+                    lookup_value = args[0]
+                try:
+                    obj = lookup_model.objects.get(**{lookup_field: lookup_value})
+                except lookup_model.DoesNotExist:
+                    return JsonResponse({"message": "Not found."}, status=404)
+
+            method = getattr(policy_class, action)
+            allowed = method(request.user, obj) if obj is not None else method(request.user)
+            if not allowed:
+                return JsonResponse({"message": "Forbidden."}, status=403)
+
+            if obj is not None:
+                request.policy_object = obj
+            return view_func(request, *args, **kwargs)
+        return wrapper
+    return decorator

--- a/escalated/policies/article_policy.py
+++ b/escalated/policies/article_policy.py
@@ -1,0 +1,19 @@
+from escalated.permissions import is_admin
+
+
+class ArticlePolicy:
+    @staticmethod
+    def view(user, article=None):
+        return True
+
+    @staticmethod
+    def create(user):
+        return is_admin(user)
+
+    @staticmethod
+    def update(user, article):
+        return is_admin(user)
+
+    @staticmethod
+    def delete(user, article):
+        return is_admin(user)

--- a/escalated/policies/canned_response_policy.py
+++ b/escalated/policies/canned_response_policy.py
@@ -1,0 +1,27 @@
+from escalated.permissions import is_admin
+
+
+class CannedResponsePolicy:
+    @staticmethod
+    def view(user, canned_response=None):
+        if not user or not user.is_authenticated:
+            return False
+        return True
+
+    @staticmethod
+    def create(user):
+        if not user or not user.is_authenticated:
+            return False
+        return True
+
+    @staticmethod
+    def update(user, canned_response):
+        if is_admin(user):
+            return True
+        return canned_response.created_by == user and not canned_response.is_shared
+
+    @staticmethod
+    def delete(user, canned_response):
+        if is_admin(user):
+            return True
+        return canned_response.created_by == user and not canned_response.is_shared

--- a/escalated/policies/department_policy.py
+++ b/escalated/policies/department_policy.py
@@ -1,0 +1,21 @@
+from escalated.permissions import is_admin, is_agent
+
+
+class DepartmentPolicy:
+    @staticmethod
+    def view(user, department=None):
+        if not user or not user.is_authenticated:
+            return False
+        return is_admin(user) or is_agent(user)
+
+    @staticmethod
+    def create(user):
+        return is_admin(user)
+
+    @staticmethod
+    def update(user, department):
+        return is_admin(user)
+
+    @staticmethod
+    def delete(user, department):
+        return is_admin(user)

--- a/escalated/policies/escalation_rule_policy.py
+++ b/escalated/policies/escalation_rule_policy.py
@@ -1,0 +1,19 @@
+from escalated.permissions import is_admin
+
+
+class EscalationRulePolicy:
+    @staticmethod
+    def view(user, rule=None):
+        return is_admin(user)
+
+    @staticmethod
+    def create(user):
+        return is_admin(user)
+
+    @staticmethod
+    def update(user, rule):
+        return is_admin(user)
+
+    @staticmethod
+    def delete(user, rule):
+        return is_admin(user)

--- a/escalated/policies/macro_policy.py
+++ b/escalated/policies/macro_policy.py
@@ -1,0 +1,27 @@
+from escalated.permissions import is_admin
+
+
+class MacroPolicy:
+    @staticmethod
+    def view(user, macro=None):
+        if not user or not user.is_authenticated:
+            return False
+        return True
+
+    @staticmethod
+    def create(user):
+        if not user or not user.is_authenticated:
+            return False
+        return True
+
+    @staticmethod
+    def update(user, macro):
+        if is_admin(user):
+            return True
+        return macro.created_by == user and not macro.is_shared
+
+    @staticmethod
+    def delete(user, macro):
+        if is_admin(user):
+            return True
+        return macro.created_by == user and not macro.is_shared

--- a/escalated/policies/sla_policy_policy.py
+++ b/escalated/policies/sla_policy_policy.py
@@ -1,0 +1,19 @@
+from escalated.permissions import is_admin
+
+
+class SlaPolicyPolicy:
+    @staticmethod
+    def view(user, sla_policy=None):
+        return is_admin(user)
+
+    @staticmethod
+    def create(user):
+        return is_admin(user)
+
+    @staticmethod
+    def update(user, sla_policy):
+        return is_admin(user)
+
+    @staticmethod
+    def delete(user, sla_policy):
+        return is_admin(user)

--- a/escalated/policies/tag_policy.py
+++ b/escalated/policies/tag_policy.py
@@ -1,0 +1,21 @@
+from escalated.permissions import is_admin, is_agent
+
+
+class TagPolicy:
+    @staticmethod
+    def view(user, tag=None):
+        if not user or not user.is_authenticated:
+            return False
+        return is_admin(user) or is_agent(user)
+
+    @staticmethod
+    def create(user):
+        return is_admin(user)
+
+    @staticmethod
+    def update(user, tag):
+        return is_admin(user)
+
+    @staticmethod
+    def delete(user, tag):
+        return is_admin(user)

--- a/escalated/policies/ticket_policy.py
+++ b/escalated/policies/ticket_policy.py
@@ -1,0 +1,47 @@
+from escalated.permissions import (
+    is_admin,
+    is_agent,
+    can_view_ticket,
+    can_update_ticket,
+    can_reply_ticket,
+    can_add_note,
+    can_close_ticket,
+)
+
+
+class TicketPolicy:
+    @staticmethod
+    def view(user, ticket):
+        return can_view_ticket(user, ticket)
+
+    @staticmethod
+    def create(user):
+        if not user or not user.is_authenticated:
+            return False
+        return True
+
+    @staticmethod
+    def update(user, ticket):
+        return can_update_ticket(user, ticket)
+
+    @staticmethod
+    def delete(user, ticket):
+        return is_admin(user)
+
+    @staticmethod
+    def reply(user, ticket):
+        return can_reply_ticket(user, ticket)
+
+    @staticmethod
+    def add_note(user, ticket):
+        return can_add_note(user, ticket)
+
+    @staticmethod
+    def close(user, ticket):
+        return can_close_ticket(user, ticket)
+
+    @staticmethod
+    def assign(user, ticket):
+        if not user or not user.is_authenticated:
+            return False
+        return is_admin(user) or is_agent(user)

--- a/escalated/services/automation_runner.py
+++ b/escalated/services/automation_runner.py
@@ -40,10 +40,17 @@ class AutomationRunner:
 
             if field == "hours_since_created":
                 threshold = timezone.now() - timedelta(hours=int(value))
-                query = query.filter(created_at__lte=threshold) if operator in (">", ">=") else query.filter(created_at__gte=threshold)
+                op = self._resolve_operator(operator)
+                query = query.filter(**{f"created_at{op}": threshold})
             elif field == "hours_since_updated":
                 threshold = timezone.now() - timedelta(hours=int(value))
-                query = query.filter(updated_at__lte=threshold) if operator in (">", ">=") else query.filter(updated_at__gte=threshold)
+                op = self._resolve_operator(operator)
+                query = query.filter(**{f"updated_at{op}": threshold})
+            elif field == "hours_since_assigned":
+                # Approximation: use updated_at where assigned_to is set
+                threshold = timezone.now() - timedelta(hours=int(value))
+                op = self._resolve_operator(operator)
+                query = query.filter(assigned_to__isnull=False).filter(**{f"updated_at{op}": threshold})
             elif field == "status":
                 query = query.filter(status=value)
             elif field == "priority":
@@ -53,11 +60,15 @@ class AutomationRunner:
                     query = query.filter(assigned_to__isnull=True)
                 elif value == "assigned":
                     query = query.filter(assigned_to__isnull=False)
+            elif field == "ticket_type":
+                query = query.filter(ticket_type=value)
+            elif field == "subject_contains":
+                query = query.filter(subject__icontains=value)
 
         return query
 
     def _execute_actions(self, automation, ticket):
-        from escalated.models import Reply, Tag
+        from escalated.models import Reply, Tag, Ticket
 
         for action in automation.actions or []:
             action_type = action.get("type", "")
@@ -85,6 +96,11 @@ class AutomationRunner:
                         is_pinned=False,
                         metadata={"system_note": True, "automation_id": automation.pk},
                     )
+                elif action_type == "set_ticket_type":
+                    valid_types = [choice.value for choice in Ticket.TicketType]
+                    if value in valid_types:
+                        ticket.ticket_type = value
+                        ticket.save(update_fields=["ticket_type", "updated_at"])
             except Exception as e:
                 logger.warning(
                     "Escalated automation action failed",
@@ -95,3 +111,18 @@ class AutomationRunner:
                         "error": str(e),
                     },
                 )
+
+    @staticmethod
+    def _resolve_operator(operator):
+        """
+        Resolve a condition operator to a Django ORM lookup suffix.
+        For hours_since fields, > hours means < datetime (older).
+        """
+        mapping = {
+            ">": "__lte",   # more hours ago = earlier datetime
+            ">=": "__lte",
+            "<": "__gte",
+            "<=": "__gte",
+            "=": "",
+        }
+        return mapping.get(operator, "__lte")

--- a/escalated/services/sso_service.py
+++ b/escalated/services/sso_service.py
@@ -1,3 +1,16 @@
+import base64
+import hashlib
+import hmac
+import json
+import struct
+import time
+import xml.etree.ElementTree as ET
+
+
+class SsoValidationError(Exception):
+    pass
+
+
 class SsoService:
     CONFIG_KEYS = [
         "sso_provider",
@@ -21,6 +34,11 @@ class SsoService:
         "sso_attr_role": "role",
         "sso_jwt_secret": "",
         "sso_jwt_algorithm": "HS256",
+    }
+
+    SAML_NS = {
+        "saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+        "samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
     }
 
     def get_config(self):
@@ -59,3 +77,195 @@ class SsoService:
             return EscalatedSetting.objects.get(key="sso_provider").value
         except EscalatedSetting.DoesNotExist:
             return "none"
+
+    # -----------------------------------------------------------------
+    # SAML Assertion Validation
+    # -----------------------------------------------------------------
+
+    def validate_saml_assertion(self, saml_response):
+        """
+        Validate a base64-encoded SAML response and extract user attributes.
+
+        Returns dict with 'email', 'name', 'role', 'attributes'.
+        Raises SsoValidationError on failure.
+        """
+        config = self.get_config()
+
+        try:
+            xml_bytes = base64.b64decode(saml_response)
+        except Exception:
+            raise SsoValidationError("Invalid SAML response: base64 decode failed.")
+
+        try:
+            root = ET.fromstring(xml_bytes)
+        except ET.ParseError:
+            raise SsoValidationError("Invalid SAML response: malformed XML.")
+
+        # Check issuer
+        entity_id = config.get("sso_entity_id", "").strip()
+        if entity_id:
+            issuer_el = root.find(".//saml:Issuer", self.SAML_NS)
+            if issuer_el is None:
+                raise SsoValidationError("SAML assertion missing Issuer element.")
+            issuer = (issuer_el.text or "").strip()
+            if issuer != entity_id:
+                raise SsoValidationError(
+                    f"SAML Issuer mismatch: expected '{entity_id}', got '{issuer}'."
+                )
+
+        # Validate conditions
+        conditions_el = root.find(".//saml:Conditions", self.SAML_NS)
+        if conditions_el is not None:
+            self._validate_saml_conditions(conditions_el)
+
+        # Extract attributes
+        attr_email = config.get("sso_attr_email", "email")
+        attr_name = config.get("sso_attr_name", "name")
+        attr_role = config.get("sso_attr_role", "role")
+
+        attributes = self._extract_saml_attributes(root)
+
+        email = attributes.get(attr_email)
+        if not email:
+            # Fall back to NameID
+            name_id_el = root.find(".//saml:Subject/saml:NameID", self.SAML_NS)
+            if name_id_el is not None:
+                email = (name_id_el.text or "").strip()
+
+        if not email:
+            raise SsoValidationError("SAML assertion missing email attribute.")
+
+        return {
+            "email": email,
+            "name": attributes.get(attr_name, ""),
+            "role": attributes.get(attr_role, ""),
+            "attributes": attributes,
+        }
+
+    def _validate_saml_conditions(self, conditions_el):
+        now = time.time()
+        skew = 120
+
+        not_before = conditions_el.get("NotBefore")
+        if not_before:
+            from email.utils import parsedate_to_datetime
+            import datetime
+
+            try:
+                dt = datetime.datetime.fromisoformat(not_before.replace("Z", "+00:00"))
+                if dt.timestamp() > (now + skew):
+                    raise SsoValidationError("SAML assertion is not yet valid.")
+            except (ValueError, TypeError):
+                pass
+
+        not_on_or_after = conditions_el.get("NotOnOrAfter")
+        if not_on_or_after:
+            import datetime
+
+            try:
+                dt = datetime.datetime.fromisoformat(not_on_or_after.replace("Z", "+00:00"))
+                if dt.timestamp() < (now - skew):
+                    raise SsoValidationError("SAML assertion has expired.")
+            except (ValueError, TypeError):
+                pass
+
+    def _extract_saml_attributes(self, root):
+        attributes = {}
+        for attr_el in root.findall(
+            ".//saml:AttributeStatement/saml:Attribute", self.SAML_NS
+        ):
+            name = attr_el.get("Name", "")
+            value_el = attr_el.find("saml:AttributeValue", self.SAML_NS)
+            if value_el is not None:
+                attributes[name] = (value_el.text or "").strip()
+        return attributes
+
+    # -----------------------------------------------------------------
+    # JWT Token Validation
+    # -----------------------------------------------------------------
+
+    def validate_jwt_token(self, token):
+        """
+        Validate a JWT token and extract user attributes.
+
+        Returns dict with 'email', 'name', 'role', 'claims'.
+        Raises SsoValidationError on failure.
+        """
+        config = self.get_config()
+
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise SsoValidationError("Invalid JWT: expected 3 segments.")
+
+        header_b64, payload_b64, signature_b64 = parts
+
+        # Decode header
+        try:
+            header = json.loads(self._base64url_decode(header_b64))
+        except (json.JSONDecodeError, Exception):
+            raise SsoValidationError("Invalid JWT: malformed header.")
+
+        # Decode payload
+        try:
+            payload = json.loads(self._base64url_decode(payload_b64))
+        except (json.JSONDecodeError, Exception):
+            raise SsoValidationError("Invalid JWT: malformed payload.")
+
+        # Verify signature
+        secret = config.get("sso_jwt_secret", "")
+        algorithm = config.get("sso_jwt_algorithm", "HS256")
+
+        if not secret:
+            raise SsoValidationError("JWT secret is not configured.")
+
+        signature = self._base64url_decode(signature_b64)
+        signing_input = f"{header_b64}.{payload_b64}".encode()
+
+        if not self._verify_jwt_signature(signing_input, signature, secret, algorithm):
+            raise SsoValidationError("Invalid JWT: signature verification failed.")
+
+        # Check expiration
+        now = time.time()
+        skew = 60
+
+        exp = payload.get("exp")
+        if exp is not None and exp < (now - skew):
+            raise SsoValidationError("JWT has expired.")
+
+        nbf = payload.get("nbf")
+        if nbf is not None and nbf > (now + skew):
+            raise SsoValidationError("JWT is not yet valid.")
+
+        # Extract user attributes
+        attr_email = config.get("sso_attr_email", "email")
+        attr_name = config.get("sso_attr_name", "name")
+        attr_role = config.get("sso_attr_role", "role")
+
+        email = payload.get(attr_email) or payload.get("email") or payload.get("sub")
+        if not email:
+            raise SsoValidationError("JWT missing email claim.")
+
+        return {
+            "email": email,
+            "name": payload.get(attr_name) or payload.get("name", ""),
+            "role": payload.get(attr_role) or payload.get("role", ""),
+            "claims": payload,
+        }
+
+    def _verify_jwt_signature(self, signing_input, signature, secret, algorithm):
+        hmac_algos = {
+            "HS256": hashlib.sha256,
+            "HS384": hashlib.sha384,
+            "HS512": hashlib.sha512,
+        }
+        if algorithm in hmac_algos:
+            expected = hmac.new(
+                secret.encode(), signing_input, hmac_algos[algorithm]
+            ).digest()
+            return hmac.compare_digest(expected, signature)
+
+        raise SsoValidationError(f"Unsupported JWT algorithm: {algorithm}")
+
+    def _base64url_decode(self, s):
+        s += "=" * (-len(s) % 4)
+        return base64.urlsafe_b64decode(s)

--- a/escalated/validators.py
+++ b/escalated/validators.py
@@ -1,0 +1,226 @@
+"""
+Form-based request validators for Escalated API views.
+
+Each validator parses a JSON request body and returns either
+(cleaned_data, None) on success or (None, JsonResponse) on failure,
+matching the existing error format.
+"""
+
+import json
+import re
+
+from django import forms
+from django.http import JsonResponse
+
+from escalated.models import Ticket
+
+
+class BaseValidator(forms.Form):
+    """Base class for JSON request validators."""
+
+    @classmethod
+    def validate_request(cls, request):
+        """
+        Parse JSON body, validate, return (cleaned_data, None) or (None, JsonResponse).
+        """
+        try:
+            raw = json.loads(request.body) if request.body else {}
+        except (json.JSONDecodeError, ValueError, TypeError):
+            return None, JsonResponse({"message": "Invalid JSON."}, status=400)
+
+        if not isinstance(raw, dict):
+            return None, JsonResponse({"message": "Invalid JSON."}, status=400)
+
+        form = cls(raw)
+        if not form.is_valid():
+            errors = {
+                field: msgs[0] if isinstance(msgs, list) else msgs
+                for field, msgs in form.errors.items()
+            }
+            return None, JsonResponse(
+                {"message": "Validation failed.", "errors": errors},
+                status=422,
+            )
+        return form.cleaned_data, None
+
+
+class CreateTicketValidator(BaseValidator):
+    subject = forms.CharField(max_length=255, required=True)
+    description = forms.CharField(required=True)
+    priority = forms.ChoiceField(
+        choices=Ticket.Priority.choices,
+        required=False,
+        initial="medium",
+    )
+    department_id = forms.IntegerField(required=False)
+    tags = forms.JSONField(required=False)
+
+    def clean_priority(self):
+        return self.cleaned_data.get("priority") or "medium"
+
+    def clean_tags(self):
+        tags = self.cleaned_data.get("tags")
+        if tags is not None and not isinstance(tags, list):
+            raise forms.ValidationError("Must be a list of tag IDs.")
+        return tags or []
+
+
+class UpdateTicketValidator(BaseValidator):
+    subject = forms.CharField(max_length=255, required=False)
+    description = forms.CharField(required=False)
+    priority = forms.ChoiceField(choices=Ticket.Priority.choices, required=False)
+    department_id = forms.IntegerField(required=False)
+
+
+class ReplyToTicketValidator(BaseValidator):
+    body = forms.CharField(required=True)
+    is_internal_note = forms.BooleanField(required=False, initial=False)
+
+    def clean_is_internal_note(self):
+        return self.cleaned_data.get("is_internal_note") or False
+
+
+class AssignTicketValidator(BaseValidator):
+    agent_id = forms.IntegerField(required=True)
+
+
+class ChangeStatusValidator(BaseValidator):
+    status = forms.ChoiceField(choices=Ticket.Status.choices, required=True)
+
+
+class ChangePriorityValidator(BaseValidator):
+    priority = forms.ChoiceField(choices=Ticket.Priority.choices, required=True)
+
+
+class UpdateTagsValidator(BaseValidator):
+    tag_ids = forms.JSONField(required=True)
+
+    def clean_tag_ids(self):
+        value = self.cleaned_data.get("tag_ids")
+        if not isinstance(value, list):
+            raise forms.ValidationError("Must be a list of tag IDs.")
+        return value
+
+
+class BulkActionValidator(BaseValidator):
+    ALLOWED_ACTIONS = [
+        "change_status", "change_priority", "assign",
+        "add_tags", "remove_tags", "delete",
+    ]
+
+    ticket_ids = forms.JSONField(required=True)
+    action = forms.ChoiceField(
+        choices=[(a, a) for a in ALLOWED_ACTIONS],
+        required=True,
+    )
+    value = forms.CharField(required=False)
+
+    def clean_ticket_ids(self):
+        value = self.cleaned_data.get("ticket_ids")
+        if not isinstance(value, list) or len(value) == 0:
+            raise forms.ValidationError("Must be a non-empty list of ticket IDs.")
+        return value
+
+
+class StoreDepartmentValidator(BaseValidator):
+    name = forms.CharField(max_length=255, required=True)
+    description = forms.CharField(required=False)
+    is_active = forms.BooleanField(required=False, initial=True)
+
+    def clean_is_active(self):
+        return self.cleaned_data.get("is_active", True)
+
+
+class StoreTagValidator(BaseValidator):
+    name = forms.CharField(max_length=100, required=True)
+    color = forms.CharField(max_length=7, required=True)
+
+    def clean_color(self):
+        color = self.cleaned_data.get("color", "")
+        if not re.match(r"^#[0-9a-fA-F]{6}$", color):
+            raise forms.ValidationError("Must be a valid hex color (e.g. #ef4444).")
+        return color
+
+
+class StoreCannedResponseValidator(BaseValidator):
+    title = forms.CharField(max_length=255, required=True)
+    body = forms.CharField(required=True)
+    category = forms.CharField(max_length=100, required=False)
+    is_shared = forms.BooleanField(required=False, initial=False)
+
+    def clean_is_shared(self):
+        return self.cleaned_data.get("is_shared") or False
+
+
+class StoreMacroValidator(BaseValidator):
+    name = forms.CharField(max_length=255, required=True)
+    description = forms.CharField(required=False)
+    actions = forms.JSONField(required=True)
+    is_shared = forms.BooleanField(required=False, initial=False)
+
+    def clean_actions(self):
+        value = self.cleaned_data.get("actions")
+        if not isinstance(value, list) or len(value) == 0:
+            raise forms.ValidationError("Must be a non-empty list of actions.")
+        return value
+
+    def clean_is_shared(self):
+        return self.cleaned_data.get("is_shared") or False
+
+
+class StoreSlaPolicyValidator(BaseValidator):
+    name = forms.CharField(max_length=255, required=True)
+    description = forms.CharField(required=False)
+    first_response_hours = forms.JSONField(required=False)
+    resolution_hours = forms.JSONField(required=False)
+    business_hours_only = forms.BooleanField(required=False, initial=False)
+    is_default = forms.BooleanField(required=False, initial=False)
+
+    def clean_first_response_hours(self):
+        value = self.cleaned_data.get("first_response_hours")
+        if value is not None and not isinstance(value, dict):
+            raise forms.ValidationError("Must be a dict of priority to hours.")
+        return value or {}
+
+    def clean_resolution_hours(self):
+        value = self.cleaned_data.get("resolution_hours")
+        if value is not None and not isinstance(value, dict):
+            raise forms.ValidationError("Must be a dict of priority to hours.")
+        return value or {}
+
+    def clean_business_hours_only(self):
+        return self.cleaned_data.get("business_hours_only") or False
+
+    def clean_is_default(self):
+        return self.cleaned_data.get("is_default") or False
+
+
+class StoreEscalationRuleValidator(BaseValidator):
+    TRIGGER_TYPES = ["time_based", "condition_based", "sla_breach"]
+
+    trigger_type = forms.ChoiceField(
+        choices=[(t, t) for t in TRIGGER_TYPES],
+        required=True,
+    )
+    conditions = forms.JSONField(required=True)
+    actions = forms.JSONField(required=True)
+    is_active = forms.BooleanField(required=False, initial=True)
+    order = forms.IntegerField(required=False, initial=0)
+
+    def clean_conditions(self):
+        value = self.cleaned_data.get("conditions")
+        if not isinstance(value, list):
+            raise forms.ValidationError("Must be a list of conditions.")
+        return value
+
+    def clean_actions(self):
+        value = self.cleaned_data.get("actions")
+        if not isinstance(value, list):
+            raise forms.ValidationError("Must be a list of actions.")
+        return value
+
+    def clean_is_active(self):
+        return self.cleaned_data.get("is_active", True)
+
+    def clean_order(self):
+        return self.cleaned_data.get("order") or 0

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -2893,17 +2893,24 @@ def automations_create(request):
     if check:
         return check
     if request.method == "POST":
+        errors = {}
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/Automations/Form", props={"errors": {"name": _("Name is required.")}})
+            errors["name"] = _("Name is required.")
         try:
             conditions = json.loads(request.POST.get("conditions", "[]"))
         except (json.JSONDecodeError, TypeError):
             conditions = []
+        if not isinstance(conditions, list) or len(conditions) < 1:
+            errors["conditions"] = _("At least one condition is required.")
         try:
             actions = json.loads(request.POST.get("actions", "[]"))
         except (json.JSONDecodeError, TypeError):
             actions = []
+        if not isinstance(actions, list) or len(actions) < 1:
+            errors["actions"] = _("At least one action is required.")
+        if errors:
+            return render(request, "Escalated/Admin/Automations/Form", props={"errors": errors})
         max_pos = Automation.objects.aggregate(max_pos=Max("position"))["max_pos"] or 0
         Automation.objects.create(
             name=name,
@@ -2926,15 +2933,27 @@ def automations_edit(request, automation_id):
     except Automation.DoesNotExist:
         return HttpResponseNotFound(_("Automation not found"))
     if request.method == "POST":
-        automation.name = request.POST.get("name", automation.name)
+        errors = {}
+        name = request.POST.get("name", "").strip()
+        if not name:
+            errors["name"] = _("Name is required.")
         try:
-            automation.conditions = json.loads(request.POST.get("conditions", "[]"))
+            conditions = json.loads(request.POST.get("conditions", "[]"))
         except (json.JSONDecodeError, TypeError):
-            pass
+            conditions = automation.conditions
+        if not isinstance(conditions, list) or len(conditions) < 1:
+            errors["conditions"] = _("At least one condition is required.")
         try:
-            automation.actions = json.loads(request.POST.get("actions", "[]"))
+            actions = json.loads(request.POST.get("actions", "[]"))
         except (json.JSONDecodeError, TypeError):
-            pass
+            actions = automation.actions
+        if not isinstance(actions, list) or len(actions) < 1:
+            errors["actions"] = _("At least one action is required.")
+        if errors:
+            return render(request, "Escalated/Admin/Automations/Form", props={"automation": AutomationSerializer.serialize(automation), "errors": errors})
+        automation.name = name
+        automation.conditions = conditions
+        automation.actions = actions
         automation.active = request.POST.get("active", "true") == "true"
         automation.save()
         return redirect("escalated:admin_automations_index")

--- a/escalated/views/api.py
+++ b/escalated/views/api.py
@@ -35,6 +35,14 @@ from escalated.models import (
 )
 from escalated.permissions import is_agent, is_admin
 from escalated.services.ticket_service import TicketService
+from escalated.validators import (
+    CreateTicketValidator,
+    ReplyToTicketValidator,
+    ChangeStatusValidator,
+    ChangePriorityValidator,
+    AssignTicketValidator,
+    UpdateTagsValidator,
+)
 
 User = get_user_model()
 
@@ -342,46 +350,23 @@ def ticket_create(request):
     JSON body:
         subject (required), description (required), priority, department_id, tags (array of IDs)
     """
-    data = _json_body(request)
-
-    # Validation
-    subject = (data.get("subject") or "").strip()
-    description = (data.get("description") or "").strip()
-
-    if not subject:
-        return JsonResponse(
-            {"message": "Validation failed.", "errors": {"subject": "Subject is required."}},
-            status=422,
-        )
-    if not description:
-        return JsonResponse(
-            {"message": "Validation failed.", "errors": {"description": "Description is required."}},
-            status=422,
-        )
-
-    priority = data.get("priority", "medium")
-    valid_priorities = [p.value for p in Ticket.Priority]
-    if priority not in valid_priorities:
-        return JsonResponse(
-            {"message": "Validation failed.", "errors": {"priority": "Invalid priority."}},
-            status=422,
-        )
+    data, error = CreateTicketValidator.validate_request(request)
+    if error:
+        return error
 
     service = TicketService()
     ticket_data = {
-        "subject": subject,
-        "description": description,
-        "priority": priority,
+        "subject": data["subject"],
+        "description": data["description"],
+        "priority": data["priority"],
         "channel": "api",
     }
 
-    department_id = data.get("department_id")
-    if department_id:
-        ticket_data["department_id"] = department_id
+    if data.get("department_id"):
+        ticket_data["department_id"] = data["department_id"]
 
-    tag_ids = data.get("tags", [])
-    if tag_ids:
-        ticket_data["tag_ids"] = tag_ids
+    if data.get("tags"):
+        ticket_data["tag_ids"] = data["tags"]
 
     ticket = service.create(request.user, ticket_data)
 
@@ -412,25 +397,20 @@ def ticket_reply(request, reference):
     JSON body:
         body (required), is_internal_note (optional bool)
     """
-    ticket, error = _resolve_ticket(reference)
+    ticket, resolve_error = _resolve_ticket(reference)
+    if resolve_error:
+        return resolve_error
+
+    data, error = ReplyToTicketValidator.validate_request(request)
     if error:
         return error
 
-    data = _json_body(request)
-    body = (data.get("body") or "").strip()
-    if not body:
-        return JsonResponse(
-            {"message": "Validation failed.", "errors": {"body": "Body is required."}},
-            status=422,
-        )
-
-    is_note = data.get("is_internal_note", False)
     service = TicketService()
 
-    if is_note:
-        reply = service.add_note(ticket, request.user, body)
+    if data["is_internal_note"]:
+        reply = service.add_note(ticket, request.user, data["body"])
     else:
-        reply = service.reply(ticket, request.user, {"body": body})
+        reply = service.reply(ticket, request.user, {"body": data["body"]})
 
     user = request.user
     return JsonResponse(
@@ -445,7 +425,7 @@ def ticket_reply(request, reference):
                 },
                 "created_at": reply.created_at.isoformat(),
             },
-            "message": "Note added." if is_note else "Reply sent.",
+            "message": "Note added." if data["is_internal_note"] else "Reply sent.",
         },
         status=201,
     )
@@ -462,23 +442,18 @@ def ticket_status(request, reference):
     JSON body:
         status (required)
     """
-    ticket, error = _resolve_ticket(reference)
+    ticket, resolve_error = _resolve_ticket(reference)
+    if resolve_error:
+        return resolve_error
+
+    data, error = ChangeStatusValidator.validate_request(request)
     if error:
         return error
 
-    data = _json_body(request)
-    new_status = data.get("status")
-    valid_statuses = [s.value for s in Ticket.Status]
-    if new_status not in valid_statuses:
-        return JsonResponse(
-            {"message": "Validation failed.", "errors": {"status": "Invalid status."}},
-            status=422,
-        )
-
     service = TicketService()
-    service.change_status(ticket, request.user, new_status)
+    service.change_status(ticket, request.user, data["status"])
 
-    return JsonResponse({"message": "Status updated.", "status": new_status})
+    return JsonResponse({"message": "Status updated.", "status": data["status"]})
 
 
 @csrf_exempt
@@ -492,23 +467,18 @@ def ticket_priority(request, reference):
     JSON body:
         priority (required)
     """
-    ticket, error = _resolve_ticket(reference)
+    ticket, resolve_error = _resolve_ticket(reference)
+    if resolve_error:
+        return resolve_error
+
+    data, error = ChangePriorityValidator.validate_request(request)
     if error:
         return error
 
-    data = _json_body(request)
-    new_priority = data.get("priority")
-    valid_priorities = [p.value for p in Ticket.Priority]
-    if new_priority not in valid_priorities:
-        return JsonResponse(
-            {"message": "Validation failed.", "errors": {"priority": "Invalid priority."}},
-            status=422,
-        )
-
     service = TicketService()
-    service.change_priority(ticket, request.user, new_priority)
+    service.change_priority(ticket, request.user, data["priority"])
 
-    return JsonResponse({"message": "Priority updated.", "priority": new_priority})
+    return JsonResponse({"message": "Priority updated.", "priority": data["priority"]})
 
 
 @csrf_exempt
@@ -522,21 +492,17 @@ def ticket_assign(request, reference):
     JSON body:
         agent_id (required, integer)
     """
-    ticket, error = _resolve_ticket(reference)
+    ticket, resolve_error = _resolve_ticket(reference)
+    if resolve_error:
+        return resolve_error
+
+    data, error = AssignTicketValidator.validate_request(request)
     if error:
         return error
 
-    data = _json_body(request)
-    agent_id = data.get("agent_id")
-    if not agent_id:
-        return JsonResponse(
-            {"message": "Validation failed.", "errors": {"agent_id": "Agent ID is required."}},
-            status=422,
-        )
-
     try:
-        agent = User.objects.get(pk=int(agent_id))
-    except (User.DoesNotExist, ValueError, TypeError):
+        agent = User.objects.get(pk=data["agent_id"])
+    except User.DoesNotExist:
         return JsonResponse({"message": "Agent not found."}, status=404)
 
     service = TicketService()
@@ -617,19 +583,15 @@ def ticket_tags(request, reference):
     JSON body:
         tag_ids (required, array of integers)
     """
-    ticket, error = _resolve_ticket(reference)
+    ticket, resolve_error = _resolve_ticket(reference)
+    if resolve_error:
+        return resolve_error
+
+    data, error = UpdateTagsValidator.validate_request(request)
     if error:
         return error
 
-    data = _json_body(request)
-    tag_ids = data.get("tag_ids")
-    if tag_ids is None or not isinstance(tag_ids, list):
-        return JsonResponse(
-            {"message": "Validation failed.", "errors": {"tag_ids": "tag_ids array is required."}},
-            status=422,
-        )
-
-    new_tag_ids = set(int(t) for t in tag_ids)
+    new_tag_ids = set(int(t) for t in data["tag_ids"])
     current_tag_ids = set(ticket.tags.values_list("pk", flat=True))
 
     to_add = list(new_tag_ids - current_tag_ids)

--- a/tests/integration/test_commands.py
+++ b/tests/integration/test_commands.py
@@ -1,0 +1,126 @@
+import pytest
+from datetime import timedelta
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils import timezone
+
+from tests.factories import UserFactory, ApiTokenFactory, WebhookFactory
+
+
+@pytest.mark.django_db
+class TestInstallCommand:
+    def test_no_input_runs_cleanly(self):
+        out = StringIO()
+        call_command("install", "--no-input", stdout=out)
+        output = out.getvalue()
+        assert "Installation complete" in output
+
+    def test_seeds_permissions(self):
+        from escalated.models import Permission
+
+        out = StringIO()
+        call_command("install", "--no-input", stdout=out)
+        assert Permission.objects.count() > 0
+
+    def test_creates_default_department(self):
+        from escalated.models import Department
+
+        out = StringIO()
+        call_command("install", "--no-input", stdout=out)
+        assert Department.objects.filter(slug="general").exists()
+
+    def test_creates_default_sla_policy(self):
+        from escalated.models import SlaPolicy
+
+        out = StringIO()
+        call_command("install", "--no-input", stdout=out)
+        assert SlaPolicy.objects.filter(is_default=True).exists()
+
+    def test_idempotent(self):
+        out = StringIO()
+        call_command("install", "--no-input", stdout=out)
+        call_command("install", "--no-input", stdout=out)
+        from escalated.models import Department
+
+        assert Department.objects.filter(slug="general").count() == 1
+
+
+@pytest.mark.django_db
+class TestPurgeExpiredDataCommand:
+    def test_dry_run(self):
+        out = StringIO()
+        call_command("purge_expired_data", "--dry-run", stdout=out)
+        assert "DRY RUN" in out.getvalue()
+
+    def test_purges_expired_tokens(self, db):
+        from escalated.models import ApiToken
+
+        user = UserFactory()
+        expired = ApiTokenFactory(user=user)
+        ApiToken.objects.filter(pk=expired.pk).update(
+            expires_at=timezone.now() - timedelta(days=1)
+        )
+
+        out = StringIO()
+        call_command("purge_expired_data", stdout=out)
+        assert not ApiToken.objects.filter(pk=expired.pk).exists()
+
+    def test_purges_old_webhook_deliveries(self, db):
+        from escalated.models import WebhookDelivery
+
+        webhook = WebhookFactory()
+        old = WebhookDelivery.objects.create(
+            webhook=webhook,
+            event="ticket.created",
+            payload={"test": True},
+            response_code=200,
+        )
+        WebhookDelivery.objects.filter(pk=old.pk).update(
+            created_at=timezone.now() - timedelta(days=60)
+        )
+
+        out = StringIO()
+        call_command("purge_expired_data", "--days", "30", stdout=out)
+        assert not WebhookDelivery.objects.filter(pk=old.pk).exists()
+
+    def test_keeps_fresh_data(self, db):
+        from escalated.models import ApiToken
+
+        user = UserFactory()
+        fresh = ApiTokenFactory(user=user)
+        # No expiry set — should be kept
+        out = StringIO()
+        call_command("purge_expired_data", stdout=out)
+        assert ApiToken.objects.filter(pk=fresh.pk).exists()
+
+
+@pytest.mark.django_db
+class TestPluginCommand:
+    def test_list_empty(self):
+        out = StringIO()
+        call_command("plugin", "list", stdout=out)
+        output = out.getvalue()
+        assert "No plugins" in output or "0 plugins" in output.lower()
+
+    def test_list_with_plugin(self, db):
+        from escalated.plugin_models import EscalatedPlugin
+
+        EscalatedPlugin.objects.create(slug="test-plugin", is_active=True)
+        out = StringIO()
+        call_command("plugin", "list", stdout=out)
+        assert "test-plugin" in out.getvalue()
+
+    def test_activate_nonexistent(self):
+        with pytest.raises(CommandError, match="not found"):
+            call_command("plugin", "activate", "nonexistent")
+
+    def test_deactivate(self, db):
+        from escalated.plugin_models import EscalatedPlugin
+
+        EscalatedPlugin.objects.create(slug="test-plugin", is_active=True)
+        out = StringIO()
+        call_command("plugin", "deactivate", "test-plugin", stdout=out)
+        plugin = EscalatedPlugin.objects.get(slug="test-plugin")
+        assert plugin.is_active is False

--- a/tests/integration/test_translations.py
+++ b/tests/integration/test_translations.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+from django.utils import translation
+
+
+LOCALES = ["en", "de", "es", "fr"]
+LOCALE_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "escalated", "locale"
+)
+
+
+class TestTranslations:
+    def test_locale_directories_exist(self):
+        for locale in LOCALES:
+            po_path = os.path.join(LOCALE_DIR, locale, "LC_MESSAGES", "django.po")
+            assert os.path.isfile(po_path), f"Missing {po_path}"
+
+    @pytest.mark.parametrize("locale", LOCALES)
+    def test_enum_labels_resolve(self, locale):
+        with translation.override(locale):
+            from escalated.models import Ticket
+
+            for value, label in Ticket.Status.choices:
+                assert len(str(label)) > 0
+
+    @pytest.mark.parametrize("locale", LOCALES)
+    def test_no_empty_translations(self, locale):
+        """Non-English locales should have msgstr filled in for all msgid entries."""
+        if locale == "en":
+            return
+        po_path = os.path.join(LOCALE_DIR, locale, "LC_MESSAGES", "django.po")
+        with open(po_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        lines = content.split("\n")
+        in_header = True
+        for i, line in enumerate(lines):
+            if line.startswith("msgid ") and line != 'msgid ""':
+                in_header = False
+            if not in_header and line == 'msgstr ""':
+                if i + 1 < len(lines) and lines[i + 1].startswith('"'):
+                    continue
+                for j in range(i - 1, -1, -1):
+                    if lines[j].startswith("msgid"):
+                        pytest.fail(f"Empty translation in {locale}: {lines[j]}")
+                        break

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 DEBUG = True
+USE_TZ = True
 
 DATABASES = {
     "default": {

--- a/tests/unit/test_plugin_service.py
+++ b/tests/unit/test_plugin_service.py
@@ -1,0 +1,41 @@
+import pytest
+
+from escalated.plugin_models import EscalatedPlugin
+
+
+@pytest.mark.django_db
+class TestPluginService:
+    def test_get_activated_plugins(self):
+        from escalated.plugin_service import PluginService
+
+        EscalatedPlugin.objects.create(slug="active-plugin", is_active=True)
+        EscalatedPlugin.objects.create(slug="inactive-plugin", is_active=False)
+        service = PluginService()
+        active = service.get_activated_plugins()
+        assert "active-plugin" in active
+        assert "inactive-plugin" not in active
+
+    def test_activate_plugin(self):
+        from escalated.plugin_service import PluginService
+
+        EscalatedPlugin.objects.create(slug="test-plugin", is_active=False)
+        service = PluginService()
+        service.activate_plugin("test-plugin")
+        plugin = EscalatedPlugin.objects.get(slug="test-plugin")
+        assert plugin.is_active is True
+
+    def test_deactivate_plugin(self):
+        from escalated.plugin_service import PluginService
+
+        EscalatedPlugin.objects.create(slug="test-plugin", is_active=True)
+        service = PluginService()
+        service.deactivate_plugin("test-plugin")
+        plugin = EscalatedPlugin.objects.get(slug="test-plugin")
+        assert plugin.is_active is False
+
+    def test_get_all_plugins_returns_list(self):
+        from escalated.plugin_service import PluginService
+
+        service = PluginService()
+        result = service.get_all_plugins()
+        assert isinstance(result, list)

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1,0 +1,154 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+
+from escalated.policies import check_policy, PolicyDenied
+from escalated.policies.ticket_policy import TicketPolicy
+from escalated.policies.department_policy import DepartmentPolicy
+from escalated.policies.tag_policy import TagPolicy
+from escalated.policies.canned_response_policy import CannedResponsePolicy
+from escalated.policies.sla_policy_policy import SlaPolicyPolicy
+from escalated.policies.escalation_rule_policy import EscalationRulePolicy
+from escalated.policies.macro_policy import MacroPolicy
+from escalated.policies.article_policy import ArticlePolicy
+from tests.factories import UserFactory, DepartmentFactory, CannedResponseFactory, MacroFactory
+
+
+@pytest.mark.django_db
+class TestTicketPolicy:
+    def test_admin_can_view(self, admin_user, ticket):
+        assert TicketPolicy.view(admin_user, ticket) is True
+
+    def test_agent_can_view(self, agent_user, ticket):
+        assert TicketPolicy.view(agent_user, ticket) is True
+
+    def test_requester_can_view(self, user, ticket):
+        assert TicketPolicy.view(user, ticket) is True
+
+    def test_random_user_cannot_view(self, db, ticket):
+        stranger = UserFactory(username="stranger")
+        assert TicketPolicy.view(stranger, ticket) is False
+
+    def test_admin_can_delete(self, admin_user, ticket):
+        assert TicketPolicy.delete(admin_user, ticket) is True
+
+    def test_agent_cannot_delete(self, agent_user, ticket):
+        assert TicketPolicy.delete(agent_user, ticket) is False
+
+    def test_requester_cannot_delete(self, user, ticket):
+        assert TicketPolicy.delete(user, ticket) is False
+
+    def test_admin_can_create(self, admin_user):
+        assert TicketPolicy.create(admin_user) is True
+
+    def test_agent_can_create(self, agent_user):
+        assert TicketPolicy.create(agent_user) is True
+
+    def test_regular_user_can_create(self, user):
+        assert TicketPolicy.create(user) is True
+
+    def test_agent_can_add_note(self, agent_user, ticket):
+        assert TicketPolicy.add_note(agent_user, ticket) is True
+
+    def test_requester_cannot_add_note(self, user, ticket):
+        assert TicketPolicy.add_note(user, ticket) is False
+
+    def test_assigned_agent_can_update(self, db, ticket):
+        agent = UserFactory(username="assigned_agent")
+        dept = DepartmentFactory()
+        dept.agents.add(agent)
+        ticket.assigned_to = agent
+        ticket.save()
+        assert TicketPolicy.update(agent, ticket) is True
+
+    def test_unauthenticated_user_cannot_view(self, ticket):
+        assert TicketPolicy.view(AnonymousUser(), ticket) is False
+
+
+@pytest.mark.django_db
+class TestDepartmentPolicy:
+    def test_admin_can_create(self, admin_user):
+        assert DepartmentPolicy.create(admin_user) is True
+
+    def test_agent_cannot_create(self, agent_user):
+        assert DepartmentPolicy.create(agent_user) is False
+
+    def test_agent_can_view(self, agent_user, department):
+        assert DepartmentPolicy.view(agent_user, department) is True
+
+    def test_admin_can_delete(self, admin_user, department):
+        assert DepartmentPolicy.delete(admin_user, department) is True
+
+
+@pytest.mark.django_db
+class TestTagPolicy:
+    def test_admin_can_create(self, admin_user):
+        assert TagPolicy.create(admin_user) is True
+
+    def test_agent_cannot_create(self, agent_user):
+        assert TagPolicy.create(agent_user) is False
+
+    def test_agent_can_view(self, agent_user, tag):
+        assert TagPolicy.view(agent_user, tag) is True
+
+
+@pytest.mark.django_db
+class TestCannedResponsePolicy:
+    def test_admin_can_manage_any(self, admin_user, canned_response):
+        assert CannedResponsePolicy.update(admin_user, canned_response) is True
+
+    def test_creator_can_update_own_private(self, agent_user):
+        cr = CannedResponseFactory(created_by=agent_user, is_shared=False)
+        assert CannedResponsePolicy.update(agent_user, cr) is True
+
+    def test_creator_cannot_update_shared(self, agent_user, canned_response):
+        # Factory defaults is_shared=True, so creator needs admin to edit
+        assert CannedResponsePolicy.update(agent_user, canned_response) is False
+
+    def test_other_agent_cannot_update_private(self, db, canned_response):
+        other = UserFactory(username="other_agent")
+        dept = DepartmentFactory(slug="other-dept")
+        dept.agents.add(other)
+        assert CannedResponsePolicy.update(other, canned_response) is False
+
+
+@pytest.mark.django_db
+class TestSlaPolicyPolicy:
+    def test_admin_can_manage(self, admin_user):
+        assert SlaPolicyPolicy.create(admin_user) is True
+
+    def test_agent_cannot_manage(self, agent_user):
+        assert SlaPolicyPolicy.create(agent_user) is False
+
+
+@pytest.mark.django_db
+class TestEscalationRulePolicy:
+    def test_admin_can_manage(self, admin_user):
+        assert EscalationRulePolicy.create(admin_user) is True
+
+    def test_agent_cannot_manage(self, agent_user):
+        assert EscalationRulePolicy.create(agent_user) is False
+
+
+@pytest.mark.django_db
+class TestMacroPolicy:
+    def test_admin_can_manage_any(self, admin_user, macro):
+        assert MacroPolicy.update(admin_user, macro) is True
+
+    def test_creator_can_update_own_private(self, agent_user):
+        m = MacroFactory(created_by=agent_user, is_shared=False)
+        assert MacroPolicy.update(agent_user, m) is True
+
+    def test_creator_cannot_update_shared(self, agent_user, macro):
+        assert MacroPolicy.update(agent_user, macro) is False
+
+
+@pytest.mark.django_db
+class TestArticlePolicy:
+    def test_admin_can_create(self, admin_user):
+        assert ArticlePolicy.create(admin_user) is True
+
+    def test_agent_cannot_create(self, agent_user):
+        assert ArticlePolicy.create(agent_user) is False
+
+    def test_anyone_can_view(self, user, article):
+        assert ArticlePolicy.view(user, article) is True

--- a/tests/unit/test_two_factor_service.py
+++ b/tests/unit/test_two_factor_service.py
@@ -1,0 +1,44 @@
+import pytest
+
+from escalated.services.two_factor_service import TwoFactorService
+
+
+class TestTwoFactorService:
+    def test_generate_secret_returns_string(self):
+        service = TwoFactorService()
+        secret = service.generate_secret()
+        assert isinstance(secret, str)
+        assert len(secret) >= 10
+
+    def test_generate_qr_uri(self):
+        service = TwoFactorService()
+        secret = service.generate_secret()
+        uri = service.generate_qr_uri(secret, "user@example.com")
+        assert uri.startswith("otpauth://totp/")
+        assert secret in uri
+        assert "user@example.com" in uri
+
+    def test_verify_with_correct_code(self):
+        service = TwoFactorService()
+        secret = service.generate_secret()
+        # Generate a current code
+        import time
+        time_step = int(time.time()) // service.PERIOD
+        code = service._generate_totp(secret, time_step)
+        assert service.verify(secret, code) is True
+
+    def test_verify_with_wrong_code(self):
+        service = TwoFactorService()
+        secret = service.generate_secret()
+        assert service.verify(secret, "000000") is False
+
+    def test_generate_recovery_codes(self):
+        service = TwoFactorService()
+        codes = service.generate_recovery_codes()
+        assert len(codes) == 8
+        for code in codes:
+            assert "-" in code
+            parts = code.split("-")
+            assert len(parts) == 2
+            assert len(parts[0]) == 8
+            assert len(parts[1]) == 8

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -1,0 +1,322 @@
+import json
+import pytest
+from django.test import RequestFactory
+
+from escalated.validators import (
+    CreateTicketValidator,
+    UpdateTicketValidator,
+    ReplyToTicketValidator,
+    AssignTicketValidator,
+    ChangeStatusValidator,
+    ChangePriorityValidator,
+    UpdateTagsValidator,
+    BulkActionValidator,
+    StoreDepartmentValidator,
+    StoreTagValidator,
+    StoreCannedResponseValidator,
+    StoreMacroValidator,
+    StoreSlaPolicyValidator,
+    StoreEscalationRuleValidator,
+)
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+def _make_request(rf, data):
+    """Create a POST request with JSON body."""
+    request = rf.post("/", json.dumps(data), content_type="application/json")
+    return request
+
+
+class TestCreateTicketValidator:
+    def test_valid_input(self, rf):
+        request = _make_request(rf, {"subject": "Help", "description": "I need help"})
+        data, error = CreateTicketValidator.validate_request(request)
+        assert error is None
+        assert data["subject"] == "Help"
+        assert data["description"] == "I need help"
+
+    def test_missing_subject(self, rf):
+        request = _make_request(rf, {"description": "I need help"})
+        data, error = CreateTicketValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+    def test_missing_description(self, rf):
+        request = _make_request(rf, {"subject": "Help"})
+        data, error = CreateTicketValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+    def test_invalid_priority(self, rf):
+        request = _make_request(rf, {
+            "subject": "Help", "description": "I need help", "priority": "INVALID"
+        })
+        data, error = CreateTicketValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+    def test_valid_priority(self, rf):
+        request = _make_request(rf, {
+            "subject": "Help", "description": "I need help", "priority": "high"
+        })
+        data, error = CreateTicketValidator.validate_request(request)
+        assert error is None
+        assert data["priority"] == "high"
+
+    def test_default_priority(self, rf):
+        request = _make_request(rf, {"subject": "Help", "description": "I need help"})
+        data, error = CreateTicketValidator.validate_request(request)
+        assert error is None
+        assert data["priority"] == "medium"
+
+    def test_empty_body(self, rf):
+        request = rf.post("/", b"", content_type="application/json")
+        data, error = CreateTicketValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+    def test_invalid_json(self, rf):
+        request = rf.post("/", b"not json", content_type="application/json")
+        data, error = CreateTicketValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 400
+
+
+class TestReplyToTicketValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {"body": "Thanks for the help"})
+        data, error = ReplyToTicketValidator.validate_request(request)
+        assert error is None
+        assert data["body"] == "Thanks for the help"
+        assert data["is_internal_note"] is False
+
+    def test_internal_note(self, rf):
+        request = _make_request(rf, {"body": "Internal", "is_internal_note": True})
+        data, error = ReplyToTicketValidator.validate_request(request)
+        assert error is None
+        assert data["is_internal_note"] is True
+
+    def test_missing_body(self, rf):
+        request = _make_request(rf, {})
+        data, error = ReplyToTicketValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestChangeStatusValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {"status": "resolved"})
+        data, error = ChangeStatusValidator.validate_request(request)
+        assert error is None
+        assert data["status"] == "resolved"
+
+    def test_invalid(self, rf):
+        request = _make_request(rf, {"status": "nonexistent"})
+        data, error = ChangeStatusValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+    def test_missing(self, rf):
+        request = _make_request(rf, {})
+        data, error = ChangeStatusValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestChangePriorityValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {"priority": "urgent"})
+        data, error = ChangePriorityValidator.validate_request(request)
+        assert error is None
+        assert data["priority"] == "urgent"
+
+    def test_invalid(self, rf):
+        request = _make_request(rf, {"priority": "super_urgent"})
+        data, error = ChangePriorityValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestAssignTicketValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {"agent_id": 1})
+        data, error = AssignTicketValidator.validate_request(request)
+        assert error is None
+        assert data["agent_id"] == 1
+
+    def test_missing(self, rf):
+        request = _make_request(rf, {})
+        data, error = AssignTicketValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestUpdateTagsValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {"tag_ids": [1, 2, 3]})
+        data, error = UpdateTagsValidator.validate_request(request)
+        assert error is None
+        assert data["tag_ids"] == [1, 2, 3]
+
+    def test_not_a_list(self, rf):
+        request = _make_request(rf, {"tag_ids": "not a list"})
+        data, error = UpdateTagsValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+    def test_missing(self, rf):
+        request = _make_request(rf, {})
+        data, error = UpdateTagsValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestStoreTagValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {"name": "bug", "color": "#ef4444"})
+        data, error = StoreTagValidator.validate_request(request)
+        assert error is None
+        assert data["name"] == "bug"
+        assert data["color"] == "#ef4444"
+
+    def test_invalid_hex_color(self, rf):
+        request = _make_request(rf, {"name": "bug", "color": "not-a-color"})
+        data, error = StoreTagValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+    def test_missing_name(self, rf):
+        request = _make_request(rf, {"color": "#ef4444"})
+        data, error = StoreTagValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestStoreDepartmentValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {"name": "Support"})
+        data, error = StoreDepartmentValidator.validate_request(request)
+        assert error is None
+        assert data["name"] == "Support"
+
+    def test_missing_name(self, rf):
+        request = _make_request(rf, {})
+        data, error = StoreDepartmentValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestStoreCannedResponseValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {"title": "Greeting", "body": "Hello!"})
+        data, error = StoreCannedResponseValidator.validate_request(request)
+        assert error is None
+
+    def test_missing_body(self, rf):
+        request = _make_request(rf, {"title": "Greeting"})
+        data, error = StoreCannedResponseValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestStoreMacroValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {
+            "name": "Close and Tag",
+            "actions": [{"type": "change_status", "value": "closed"}],
+        })
+        data, error = StoreMacroValidator.validate_request(request)
+        assert error is None
+
+    def test_empty_actions(self, rf):
+        request = _make_request(rf, {"name": "Empty", "actions": []})
+        data, error = StoreMacroValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestStoreSlaPolicyValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {
+            "name": "Default SLA",
+            "first_response_hours": {"low": 24, "medium": 8, "high": 4, "urgent": 1, "critical": 0.5},
+            "resolution_hours": {"low": 72, "medium": 24, "high": 8, "urgent": 4, "critical": 2},
+        })
+        data, error = StoreSlaPolicyValidator.validate_request(request)
+        assert error is None
+
+    def test_missing_name(self, rf):
+        request = _make_request(rf, {
+            "first_response_hours": {"low": 24},
+            "resolution_hours": {"low": 72},
+        })
+        data, error = StoreSlaPolicyValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestStoreEscalationRuleValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {
+            "trigger_type": "time_based",
+            "conditions": [{"field": "priority", "operator": "eq", "value": "critical"}],
+            "actions": [{"type": "assign", "value": 1}],
+        })
+        data, error = StoreEscalationRuleValidator.validate_request(request)
+        assert error is None
+
+    def test_invalid_trigger_type(self, rf):
+        request = _make_request(rf, {
+            "trigger_type": "invalid",
+            "conditions": [],
+            "actions": [],
+        })
+        data, error = StoreEscalationRuleValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestBulkActionValidator:
+    def test_valid(self, rf):
+        request = _make_request(rf, {
+            "ticket_ids": [1, 2, 3],
+            "action": "change_status",
+            "value": "closed",
+        })
+        data, error = BulkActionValidator.validate_request(request)
+        assert error is None
+
+    def test_missing_ticket_ids(self, rf):
+        request = _make_request(rf, {"action": "change_status"})
+        data, error = BulkActionValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+    def test_invalid_action(self, rf):
+        request = _make_request(rf, {"ticket_ids": [1], "action": "destroy_everything"})
+        data, error = BulkActionValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422
+
+
+class TestUpdateTicketValidator:
+    def test_all_optional(self, rf):
+        request = _make_request(rf, {})
+        data, error = UpdateTicketValidator.validate_request(request)
+        assert error is None
+
+    def test_partial_update(self, rf):
+        request = _make_request(rf, {"subject": "Updated subject"})
+        data, error = UpdateTicketValidator.validate_request(request)
+        assert error is None
+        assert data["subject"] == "Updated subject"
+
+    def test_invalid_priority(self, rf):
+        request = _make_request(rf, {"priority": "INVALID"})
+        data, error = UpdateTicketValidator.validate_request(request)
+        assert data is None
+        assert error.status_code == 422

--- a/tests/unit/test_webhook_dispatcher.py
+++ b/tests/unit/test_webhook_dispatcher.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from escalated.models import Webhook, WebhookDelivery
+from escalated.services.webhook_dispatcher import WebhookDispatcher
+from tests.factories import WebhookFactory
+
+
+@pytest.mark.django_db
+class TestWebhookDispatcher:
+    def test_creates_delivery_record(self):
+        webhook = WebhookFactory(events=["ticket.created"], active=True)
+        dispatcher = WebhookDispatcher()
+
+        with patch("escalated.services.webhook_dispatcher.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="OK")
+            dispatcher.dispatch("ticket.created", {"ticket_id": 1})
+
+        assert WebhookDelivery.objects.filter(webhook=webhook).exists()
+
+    def test_skips_inactive_webhook(self):
+        WebhookFactory(events=["ticket.created"], active=False)
+        dispatcher = WebhookDispatcher()
+
+        with patch("escalated.services.webhook_dispatcher.requests.post") as mock_post:
+            dispatcher.dispatch("ticket.created", {"ticket_id": 1})
+            mock_post.assert_not_called()
+
+        assert WebhookDelivery.objects.count() == 0
+
+    def test_skips_unsubscribed_event(self):
+        WebhookFactory(events=["ticket.resolved"], active=True)
+        dispatcher = WebhookDispatcher()
+
+        with patch("escalated.services.webhook_dispatcher.requests.post") as mock_post:
+            dispatcher.dispatch("ticket.created", {"ticket_id": 1})
+            mock_post.assert_not_called()
+
+        assert WebhookDelivery.objects.count() == 0
+
+    def test_includes_signature_when_secret_set(self):
+        WebhookFactory(events=["ticket.created"], active=True, secret="my-secret")
+        dispatcher = WebhookDispatcher()
+
+        with patch("escalated.services.webhook_dispatcher.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="OK")
+            dispatcher.dispatch("ticket.created", {"ticket_id": 1})
+
+            call_kwargs = mock_post.call_args
+            assert "X-Escalated-Signature" in call_kwargs.kwargs.get("headers", call_kwargs[1].get("headers", {}))


### PR DESCRIPTION
## Summary
- Add 14 form-based request validators replacing inline validation
- Add 8 policy classes with `@check_policy` decorator for authorization
- Add 3 management commands: `install`, `plugin`, `purge_expired_data`
- Implement SAML and JWT validation in SSO service
- Add translation coverage tests for all 4 locales
- Add plugin service, webhook dispatcher, and 2FA service tests
- Refactor API views to use validators (net -38 lines)

## Test plan
- [x] All 495 tests pass
- [x] Existing API integration tests pass with zero regressions
- [x] New validator tests cover all 14 validators (40 test cases)
- [x] New policy tests cover all 8 policies (35 test cases)
- [x] Command tests verify install, plugin, and purge_expired_data