### PR TITLE
feat: make Inertia UI optional with UI_ENABLED setting

### DIFF
--- a/escalated/conf.py
+++ b/escalated/conf.py
@@ -8,6 +8,8 @@ DEFAULTS = {
     "USER_MODEL": None,  # Falls back to settings.AUTH_USER_MODEL
     "TABLE_PREFIX": "escalated_",
     "ROUTE_PREFIX": "support",
+    "UI_ENABLED": True,
+    "UI_RENDERER": None,
     "HOSTED_API_URL": "https://cloud.escalated.dev/api/v1",
     "HOSTED_API_KEY": None,
     "ALLOW_CUSTOMER_CLOSE": True,

--- a/escalated/middleware.py
+++ b/escalated/middleware.py
@@ -63,6 +63,11 @@ class EscalatedInertiaShareMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        from escalated.conf import get_setting
+
+        if not get_setting("UI_ENABLED"):
+            return self.get_response(request)
+
         return self.get_response(request)
 
     def process_view(self, request, view_func, view_args, view_kwargs):

--- a/escalated/middleware.py
+++ b/escalated/middleware.py
@@ -63,22 +63,21 @@ class EscalatedInertiaShareMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        from escalated.conf import get_setting
-
-        if not get_setting("UI_ENABLED"):
-            return self.get_response(request)
-
         return self.get_response(request)
 
     def process_view(self, request, view_func, view_args, view_kwargs):
+        from escalated.conf import get_setting
+
+        if not get_setting("UI_ENABLED"):
+            return None
+
         try:
             from inertia import share
 
-            from escalated.conf import get_setting
             from escalated.models import EscalatedSetting
 
             data = {
-                "prefix": get_setting("ROUTES_PREFIX") or "support",
+                "prefix": get_setting("ROUTE_PREFIX") or "support",
                 "is_agent": False,
                 "is_admin": False,
             }

--- a/escalated/rendering.py
+++ b/escalated/rendering.py
@@ -1,0 +1,39 @@
+from django.utils.module_loading import import_string
+from escalated.conf import get_setting
+
+
+class UiRenderer:
+    """Abstract base for rendering UI pages."""
+    def render(self, request, component, props=None):
+        raise NotImplementedError
+
+
+class InertiaRenderer(UiRenderer):
+    """Default renderer using inertia-django."""
+    def render(self, request, component, props=None):
+        from inertia import render
+        return render(request, component, props=props or {})
+
+
+_renderer_instance = None
+
+
+def get_renderer():
+    global _renderer_instance
+    if _renderer_instance is None:
+        custom = get_setting("UI_RENDERER") if get_setting("UI_ENABLED") else None
+        if custom:
+            cls = import_string(custom)
+            _renderer_instance = cls()
+        elif get_setting("UI_ENABLED"):
+            _renderer_instance = InertiaRenderer()
+        else:
+            raise RuntimeError(
+                "Escalated UI is disabled. Set UI_ENABLED=True or provide a custom UI_RENDERER."
+            )
+    return _renderer_instance
+
+
+def render_page(request, component, props=None):
+    """Convenience function used by views."""
+    return get_renderer().render(request, component, props)

--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -205,13 +205,18 @@ inbound_patterns = [
     path("inbound/<str:adapter_name>/", inbound.inbound_webhook, name="inbound_webhook"),
 ]
 
-urlpatterns = (
-    customer_patterns
-    + agent_patterns
-    + admin_patterns
-    + guest_patterns
-    + inbound_patterns
-)
+# Core routes (always registered)
+urlpatterns = list(inbound_patterns)
+
+# UI routes (only when UI is enabled)
+if get_setting("UI_ENABLED"):
+    urlpatterns = (
+        customer_patterns
+        + agent_patterns
+        + admin_patterns
+        + guest_patterns
+        + urlpatterns
+    )
 
 # Inject plugin bridge routes (pages, API endpoints, webhooks) if the SDK
 # bridge has booted and registered patterns from plugin manifests.

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -11,7 +11,7 @@ from django.shortcuts import redirect
 from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
-from inertia import render
+from escalated.rendering import render_page
 
 from escalated.models import (
     Ticket,
@@ -172,7 +172,7 @@ def reports(request):
     for r in range(1, 6):
         csat_breakdown[str(r)] = csat_ratings.filter(rating=r).count()
 
-    return render(request, "Escalated/Admin/Reports", props={
+    return render_page(request, "Escalated/Admin/Reports", props={
         "stats": {
             "total_tickets": total_tickets,
             "open_tickets": open_tickets,
@@ -266,7 +266,7 @@ def tickets_index(request):
     paginator = Paginator(tickets, 25)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render(request, "Escalated/Admin/Tickets/Index", props={
+    return render_page(request, "Escalated/Admin/Tickets/Index", props={
         "tickets": TicketSerializer.serialize_list(page.object_list),
         "pagination": {
             "current_page": page.number,
@@ -337,7 +337,7 @@ def tickets_show(request, ticket_id):
     except SatisfactionRating.DoesNotExist:
         satisfaction_data = None
 
-    return render(request, "Escalated/Admin/Tickets/Show", props={
+    return render_page(request, "Escalated/Admin/Tickets/Show", props={
         "ticket": TicketSerializer.serialize(ticket),
         "replies": ReplySerializer.serialize_list(replies),
         "activities": [ActivitySerializer.serialize(a) for a in activities],
@@ -575,7 +575,7 @@ def departments_index(request):
         ticket_count=Count("tickets"),
     )
 
-    return render(request, "Escalated/Admin/Departments/Index", props={
+    return render_page(request, "Escalated/Admin/Departments/Index", props={
         "departments": DepartmentSerializer.serialize_list(departments),
     })
 
@@ -593,7 +593,7 @@ def departments_create(request):
         is_active = request.POST.get("is_active", "true") == "true"
 
         if not name:
-            return render(request, "Escalated/Admin/Departments/Create", props={
+            return render_page(request, "Escalated/Admin/Departments/Create", props={
                 "errors": {"name": _("Name is required.")},
             })
 
@@ -602,7 +602,7 @@ def departments_create(request):
         )
         return redirect("escalated:admin_departments_index")
 
-    return render(request, "Escalated/Admin/Departments/Create", props={})
+    return render_page(request, "Escalated/Admin/Departments/Create", props={})
 
 
 @login_required
@@ -637,7 +637,7 @@ def departments_edit(request, department_id):
     from django.contrib.auth import get_user_model
     User = get_user_model()
 
-    return render(request, "Escalated/Admin/Departments/Edit", props={
+    return render_page(request, "Escalated/Admin/Departments/Edit", props={
         "department": DepartmentSerializer.serialize(department),
         "all_agents": [
             {"id": u.pk, "name": u.get_full_name() or u.username, "email": u.email}
@@ -677,7 +677,7 @@ def sla_policies_index(request):
         return check
 
     policies = SlaPolicy.objects.all()
-    return render(request, "Escalated/Admin/SlaPolicies/Index", props={
+    return render_page(request, "Escalated/Admin/SlaPolicies/Index", props={
         "policies": SlaPolicySerializer.serialize_list(policies),
     })
 
@@ -693,7 +693,7 @@ def sla_policies_create(request):
 
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/SlaPolicies/Create", props={
+            return render_page(request, "Escalated/Admin/SlaPolicies/Create", props={
                 "errors": {"name": _("Name is required.")},
             })
 
@@ -728,7 +728,7 @@ def sla_policies_create(request):
         )
         return redirect("escalated:admin_sla_policies_index")
 
-    return render(request, "Escalated/Admin/SlaPolicies/Create", props={
+    return render_page(request, "Escalated/Admin/SlaPolicies/Create", props={
         "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
     })
 
@@ -776,7 +776,7 @@ def sla_policies_edit(request, policy_id):
         policy.save()
         return redirect("escalated:admin_sla_policies_index")
 
-    return render(request, "Escalated/Admin/SlaPolicies/Edit", props={
+    return render_page(request, "Escalated/Admin/SlaPolicies/Edit", props={
         "policy": SlaPolicySerializer.serialize(policy),
         "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
     })
@@ -812,7 +812,7 @@ def escalation_rules_index(request):
         return check
 
     rules = EscalationRule.objects.all()
-    return render(request, "Escalated/Admin/EscalationRules/Index", props={
+    return render_page(request, "Escalated/Admin/EscalationRules/Index", props={
         "rules": EscalationRuleSerializer.serialize_list(rules),
     })
 
@@ -828,7 +828,7 @@ def escalation_rules_create(request):
 
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/EscalationRules/Create", props={
+            return render_page(request, "Escalated/Admin/EscalationRules/Create", props={
                 "errors": {"name": _("Name is required.")},
                 "trigger_types": [
                     {"value": t.value, "label": t.label}
@@ -857,7 +857,7 @@ def escalation_rules_create(request):
         )
         return redirect("escalated:admin_escalation_rules_index")
 
-    return render(request, "Escalated/Admin/EscalationRules/Create", props={
+    return render_page(request, "Escalated/Admin/EscalationRules/Create", props={
         "trigger_types": [
             {"value": t.value, "label": t.label}
             for t in EscalationRule.TriggerType
@@ -898,7 +898,7 @@ def escalation_rules_edit(request, rule_id):
         rule.save()
         return redirect("escalated:admin_escalation_rules_index")
 
-    return render(request, "Escalated/Admin/EscalationRules/Edit", props={
+    return render_page(request, "Escalated/Admin/EscalationRules/Edit", props={
         "rule": EscalationRuleSerializer.serialize(rule),
         "trigger_types": [
             {"value": t.value, "label": t.label}
@@ -937,7 +937,7 @@ def tags_index(request):
         return check
 
     tags = Tag.objects.annotate(ticket_count=Count("tickets"))
-    return render(request, "Escalated/Admin/Tags/Index", props={
+    return render_page(request, "Escalated/Admin/Tags/Index", props={
         "tags": [
             {**TagSerializer.serialize(t), "ticket_count": t.ticket_count}
             for t in tags
@@ -954,7 +954,7 @@ def tags_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/Tags/Create", props={
+            return render_page(request, "Escalated/Admin/Tags/Create", props={
                 "errors": {"name": _("Name is required.")},
             })
 
@@ -965,7 +965,7 @@ def tags_create(request):
         )
         return redirect("escalated:admin_tags_index")
 
-    return render(request, "Escalated/Admin/Tags/Create", props={})
+    return render_page(request, "Escalated/Admin/Tags/Create", props={})
 
 
 @login_required
@@ -986,7 +986,7 @@ def tags_edit(request, tag_id):
         tag.save()
         return redirect("escalated:admin_tags_index")
 
-    return render(request, "Escalated/Admin/Tags/Edit", props={
+    return render_page(request, "Escalated/Admin/Tags/Edit", props={
         "tag": TagSerializer.serialize(tag),
     })
 
@@ -1021,7 +1021,7 @@ def canned_responses_index(request):
         return check
 
     responses = CannedResponse.objects.select_related("created_by")
-    return render(request, "Escalated/Admin/CannedResponses/Index", props={
+    return render_page(request, "Escalated/Admin/CannedResponses/Index", props={
         "canned_responses": CannedResponseSerializer.serialize_list(responses),
     })
 
@@ -1035,7 +1035,7 @@ def canned_responses_create(request):
     if request.method == "POST":
         title = request.POST.get("title", "").strip()
         if not title:
-            return render(request, "Escalated/Admin/CannedResponses/Create", props={
+            return render_page(request, "Escalated/Admin/CannedResponses/Create", props={
                 "errors": {"title": _("Title is required.")},
             })
 
@@ -1048,7 +1048,7 @@ def canned_responses_create(request):
         )
         return redirect("escalated:admin_canned_responses_index")
 
-    return render(request, "Escalated/Admin/CannedResponses/Create", props={})
+    return render_page(request, "Escalated/Admin/CannedResponses/Create", props={})
 
 
 @login_required
@@ -1070,7 +1070,7 @@ def canned_responses_edit(request, response_id):
         canned.save()
         return redirect("escalated:admin_canned_responses_index")
 
-    return render(request, "Escalated/Admin/CannedResponses/Edit", props={
+    return render_page(request, "Escalated/Admin/CannedResponses/Edit", props={
         "canned_response": CannedResponseSerializer.serialize(canned),
     })
 
@@ -1113,7 +1113,7 @@ def settings_index(request):
         if key in settings_dict and settings_dict[key]:
             settings_dict[key] = _mask_secret(settings_dict[key])
 
-    return render(request, "Escalated/Admin/Settings", props={
+    return render_page(request, "Escalated/Admin/Settings", props={
         "settings": settings_dict,
     })
 
@@ -1414,7 +1414,7 @@ def macros_index(request):
         return check
 
     macros = Macro.objects.select_related("created_by").order_by("order")
-    return render(request, "Escalated/Admin/Macros/Index", props={
+    return render_page(request, "Escalated/Admin/Macros/Index", props={
         "macros": MacroSerializer.serialize_list(macros),
     })
 
@@ -1429,7 +1429,7 @@ def macros_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/Macros/Create", props={
+            return render_page(request, "Escalated/Admin/Macros/Create", props={
                 "errors": {"name": _("Name is required.")},
             })
 
@@ -1448,7 +1448,7 @@ def macros_create(request):
         )
         return redirect("escalated:admin_macros_index")
 
-    return render(request, "Escalated/Admin/Macros/Create", props={})
+    return render_page(request, "Escalated/Admin/Macros/Create", props={})
 
 
 @login_required
@@ -1477,7 +1477,7 @@ def macros_edit(request, macro_id):
         macro.save()
         return redirect("escalated:admin_macros_index")
 
-    return render(request, "Escalated/Admin/Macros/Edit", props={
+    return render_page(request, "Escalated/Admin/Macros/Edit", props={
         "macro": MacroSerializer.serialize(macro),
     })
 
@@ -1537,7 +1537,7 @@ def audit_logs_index(request):
     paginator = Paginator(logs, 50)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render(request, "Escalated/Admin/AuditLog/Index", props={
+    return render_page(request, "Escalated/Admin/AuditLog/Index", props={
         "logs": AuditLogSerializer.serialize_list(page.object_list),
         "pagination": {
             "current_page": page.number,
@@ -1578,7 +1578,7 @@ def statuses_index(request):
         return check
 
     statuses = TicketStatus.objects.all()
-    return render(request, "Escalated/Admin/Statuses/Index", props={
+    return render_page(request, "Escalated/Admin/Statuses/Index", props={
         "statuses": TicketStatusSerializer.serialize_list(statuses),
         "categories": ["new", "open", "pending", "on_hold", "solved"],
     })
@@ -1593,7 +1593,7 @@ def statuses_create(request):
     if request.method == "POST":
         label = request.POST.get("label", "").strip()
         if not label:
-            return render(request, "Escalated/Admin/Statuses/Form", props={
+            return render_page(request, "Escalated/Admin/Statuses/Form", props={
                 "errors": {"label": _("Label is required.")},
                 "categories": ["new", "open", "pending", "on_hold", "solved"],
             })
@@ -1614,7 +1614,7 @@ def statuses_create(request):
         )
         return redirect("escalated:admin_statuses_index")
 
-    return render(request, "Escalated/Admin/Statuses/Form", props={
+    return render_page(request, "Escalated/Admin/Statuses/Form", props={
         "categories": ["new", "open", "pending", "on_hold", "solved"],
     })
 
@@ -1647,7 +1647,7 @@ def statuses_edit(request, status_id):
         status.save()
         return redirect("escalated:admin_statuses_index")
 
-    return render(request, "Escalated/Admin/Statuses/Form", props={
+    return render_page(request, "Escalated/Admin/Statuses/Form", props={
         "status": TicketStatusSerializer.serialize(status),
         "categories": ["new", "open", "pending", "on_hold", "solved"],
     })
@@ -1683,7 +1683,7 @@ def business_hours_index(request):
         return check
 
     schedules = BusinessSchedule.objects.prefetch_related("holidays").all()
-    return render(request, "Escalated/Admin/BusinessHours/Index", props={
+    return render_page(request, "Escalated/Admin/BusinessHours/Index", props={
         "schedules": BusinessScheduleSerializer.serialize_list(schedules),
     })
 
@@ -1697,7 +1697,7 @@ def business_hours_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/BusinessHours/Form", props={
+            return render_page(request, "Escalated/Admin/BusinessHours/Form", props={
                 "errors": {"name": _("Name is required.")},
             })
 
@@ -1733,7 +1733,7 @@ def business_hours_create(request):
         return redirect("escalated:admin_business_hours_index")
 
     from zoneinfo import available_timezones
-    return render(request, "Escalated/Admin/BusinessHours/Form", props={
+    return render_page(request, "Escalated/Admin/BusinessHours/Form", props={
         "timezones": sorted(available_timezones()),
     })
 
@@ -1785,7 +1785,7 @@ def business_hours_edit(request, schedule_id):
         return redirect("escalated:admin_business_hours_index")
 
     from zoneinfo import available_timezones
-    return render(request, "Escalated/Admin/BusinessHours/Edit", props={
+    return render_page(request, "Escalated/Admin/BusinessHours/Edit", props={
         "schedule": BusinessScheduleSerializer.serialize(sched),
         "timezones": sorted(available_timezones()),
     })
@@ -1821,7 +1821,7 @@ def roles_index(request):
         return check
 
     roles = Role.objects.annotate(users__count=Count("users"))
-    return render(request, "Escalated/Admin/Roles/Index", props={
+    return render_page(request, "Escalated/Admin/Roles/Index", props={
         "roles": RoleSerializer.serialize_list(roles),
     })
 
@@ -1835,7 +1835,7 @@ def roles_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/Roles/Form", props={
+            return render_page(request, "Escalated/Admin/Roles/Form", props={
                 "errors": {"name": _("Name is required.")},
                 "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
             })
@@ -1851,7 +1851,7 @@ def roles_create(request):
 
         return redirect("escalated:admin_roles_index")
 
-    return render(request, "Escalated/Admin/Roles/Form", props={
+    return render_page(request, "Escalated/Admin/Roles/Form", props={
         "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
     })
 
@@ -1877,7 +1877,7 @@ def roles_edit(request, role_id):
 
         return redirect("escalated:admin_roles_index")
 
-    return render(request, "Escalated/Admin/Roles/Form", props={
+    return render_page(request, "Escalated/Admin/Roles/Form", props={
         "role": RoleSerializer.serialize(role, include_permissions=True),
         "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
     })
@@ -1916,7 +1916,7 @@ def custom_fields_index(request):
         return check
 
     fields = CustomField.objects.all().order_by("position")
-    return render(request, "Escalated/Admin/CustomFields/Index", props={
+    return render_page(request, "Escalated/Admin/CustomFields/Index", props={
         "custom_fields": CustomFieldSerializer.serialize_list(fields),
     })
 
@@ -1931,7 +1931,7 @@ def custom_fields_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/CustomFields/Create", props={
+            return render_page(request, "Escalated/Admin/CustomFields/Create", props={
                 "errors": {"name": _("Name is required.")},
                 "contexts": [
                     {"value": c.value, "label": c.label}
@@ -1972,7 +1972,7 @@ def custom_fields_create(request):
         )
         return redirect("escalated:admin_custom_fields_index")
 
-    return render(request, "Escalated/Admin/CustomFields/Create", props={
+    return render_page(request, "Escalated/Admin/CustomFields/Create", props={
         "contexts": [
             {"value": c.value, "label": c.label}
             for c in CustomField.Context
@@ -2025,7 +2025,7 @@ def custom_fields_edit(request, field_id):
         field.save()
         return redirect("escalated:admin_custom_fields_index")
 
-    return render(request, "Escalated/Admin/CustomFields/Edit", props={
+    return render_page(request, "Escalated/Admin/CustomFields/Edit", props={
         "custom_field": CustomFieldSerializer.serialize(field),
         "contexts": [
             {"value": c.value, "label": c.label}
@@ -2443,7 +2443,7 @@ def articles_index(request):
     paginator = Paginator(articles, 20)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render(request, "Escalated/Admin/KB/Articles/Index", props={
+    return render_page(request, "Escalated/Admin/KB/Articles/Index", props={
         "articles": ArticleSerializer.serialize_list(page.object_list),
         "pagination": {
             "current_page": page.number,
@@ -2473,7 +2473,7 @@ def articles_create(request):
     if request.method == "POST":
         title = request.POST.get("title", "").strip()
         if not title:
-            return render(request, "Escalated/Admin/KB/Articles/Create", props={
+            return render_page(request, "Escalated/Admin/KB/Articles/Create", props={
                 "errors": {"title": _("Title is required.")},
                 "categories": ArticleCategorySerializer.serialize_list(
                     ArticleCategory.objects.ordered()
@@ -2498,7 +2498,7 @@ def articles_create(request):
         )
         return redirect("escalated:admin_articles_index")
 
-    return render(request, "Escalated/Admin/KB/Articles/Create", props={
+    return render_page(request, "Escalated/Admin/KB/Articles/Create", props={
         "categories": ArticleCategorySerializer.serialize_list(
             ArticleCategory.objects.ordered()
         ),
@@ -2535,7 +2535,7 @@ def articles_edit(request, article_id):
         article.save()
         return redirect("escalated:admin_articles_index")
 
-    return render(request, "Escalated/Admin/KB/Articles/Edit", props={
+    return render_page(request, "Escalated/Admin/KB/Articles/Edit", props={
         "article": ArticleSerializer.serialize(article),
         "categories": ArticleCategorySerializer.serialize_list(
             ArticleCategory.objects.ordered()
@@ -2578,7 +2578,7 @@ def kb_categories_index(request):
         articles_count=Count("articles")
     ).order_by("position", "name")
 
-    return render(request, "Escalated/Admin/KB/Categories/Index", props={
+    return render_page(request, "Escalated/Admin/KB/Categories/Index", props={
         "categories": ArticleCategorySerializer.serialize_list(categories),
     })
 
@@ -2668,7 +2668,7 @@ def skills_index(request):
     if check:
         return check
     skills = Skill.objects.annotate(agents_count=Count("agents")).order_by("name")
-    return render(request, "Escalated/Admin/Skills/Index", props={"skills": SkillSerializer.serialize_list(skills)})
+    return render_page(request, "Escalated/Admin/Skills/Index", props={"skills": SkillSerializer.serialize_list(skills)})
 
 
 @login_required
@@ -2679,10 +2679,10 @@ def skills_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/Skills/Form", props={"errors": {"name": _("Name is required.")}})
+            return render_page(request, "Escalated/Admin/Skills/Form", props={"errors": {"name": _("Name is required.")}})
         Skill.objects.create(name=name)
         return redirect("escalated:admin_skills_index")
-    return render(request, "Escalated/Admin/Skills/Form", props={})
+    return render_page(request, "Escalated/Admin/Skills/Form", props={})
 
 
 @login_required
@@ -2698,7 +2698,7 @@ def skills_edit(request, skill_id):
         skill.name = request.POST.get("name", skill.name)
         skill.save()
         return redirect("escalated:admin_skills_index")
-    return render(request, "Escalated/Admin/Skills/Form", props={"skill": SkillSerializer.serialize(skill)})
+    return render_page(request, "Escalated/Admin/Skills/Form", props={"skill": SkillSerializer.serialize(skill)})
 
 
 @login_required
@@ -2726,7 +2726,7 @@ def capacity_index(request):
     if check:
         return check
     capacities = AgentCapacity.objects.select_related("user").order_by("user_id")
-    return render(request, "Escalated/Admin/Capacity/Index", props={"capacities": AgentCapacitySerializer.serialize_list(capacities)})
+    return render_page(request, "Escalated/Admin/Capacity/Index", props={"capacities": AgentCapacitySerializer.serialize_list(capacities)})
 
 
 @login_required
@@ -2758,7 +2758,7 @@ def webhooks_index(request):
     if check:
         return check
     webhooks = Webhook.objects.annotate(deliveries_count=Count("deliveries")).order_by("-created_at")
-    return render(request, "Escalated/Admin/Webhooks/Index", props={
+    return render_page(request, "Escalated/Admin/Webhooks/Index", props={
         "webhooks": WebhookSerializer.serialize_list(webhooks),
         "available_events": WebhookSerializer.AVAILABLE_EVENTS,
     })
@@ -2772,7 +2772,7 @@ def webhooks_create(request):
     if request.method == "POST":
         url = request.POST.get("url", "").strip()
         if not url:
-            return render(request, "Escalated/Admin/Webhooks/Form", props={
+            return render_page(request, "Escalated/Admin/Webhooks/Form", props={
                 "errors": {"url": _("URL is required.")},
                 "available_events": WebhookSerializer.AVAILABLE_EVENTS,
             })
@@ -2787,7 +2787,7 @@ def webhooks_create(request):
             active=request.POST.get("active", "true") == "true",
         )
         return redirect("escalated:admin_webhooks_index")
-    return render(request, "Escalated/Admin/Webhooks/Form", props={"available_events": WebhookSerializer.AVAILABLE_EVENTS})
+    return render_page(request, "Escalated/Admin/Webhooks/Form", props={"available_events": WebhookSerializer.AVAILABLE_EVENTS})
 
 
 @login_required
@@ -2811,7 +2811,7 @@ def webhooks_edit(request, webhook_id):
         webhook.active = request.POST.get("active", "true") == "true"
         webhook.save()
         return redirect("escalated:admin_webhooks_index")
-    return render(request, "Escalated/Admin/Webhooks/Form", props={
+    return render_page(request, "Escalated/Admin/Webhooks/Form", props={
         "webhook": WebhookSerializer.serialize(webhook),
         "available_events": WebhookSerializer.AVAILABLE_EVENTS,
     })
@@ -2843,7 +2843,7 @@ def webhooks_deliveries(request, webhook_id):
     deliveries = webhook.deliveries.order_by("-created_at")
     paginator = Paginator(deliveries, 25)
     page = paginator.get_page(request.GET.get("page", 1))
-    return render(request, "Escalated/Admin/Webhooks/Deliveries", props={
+    return render_page(request, "Escalated/Admin/Webhooks/Deliveries", props={
         "webhook": WebhookSerializer.serialize(webhook),
         "deliveries": WebhookDeliverySerializer.serialize_list(page.object_list),
         "pagination": {
@@ -2884,7 +2884,7 @@ def automations_index(request):
     if check:
         return check
     automations = Automation.objects.order_by("position")
-    return render(request, "Escalated/Admin/Automations/Index", props={"automations": AutomationSerializer.serialize_list(automations)})
+    return render_page(request, "Escalated/Admin/Automations/Index", props={"automations": AutomationSerializer.serialize_list(automations)})
 
 
 @login_required
@@ -2910,7 +2910,7 @@ def automations_create(request):
         if not isinstance(actions, list) or len(actions) < 1:
             errors["actions"] = _("At least one action is required.")
         if errors:
-            return render(request, "Escalated/Admin/Automations/Form", props={"errors": errors})
+            return render_page(request, "Escalated/Admin/Automations/Form", props={"errors": errors})
         max_pos = Automation.objects.aggregate(max_pos=Max("position"))["max_pos"] or 0
         Automation.objects.create(
             name=name,
@@ -2920,7 +2920,7 @@ def automations_create(request):
             position=max_pos + 1,
         )
         return redirect("escalated:admin_automations_index")
-    return render(request, "Escalated/Admin/Automations/Form", props={})
+    return render_page(request, "Escalated/Admin/Automations/Form", props={})
 
 
 @login_required
@@ -2950,14 +2950,14 @@ def automations_edit(request, automation_id):
         if not isinstance(actions, list) or len(actions) < 1:
             errors["actions"] = _("At least one action is required.")
         if errors:
-            return render(request, "Escalated/Admin/Automations/Form", props={"automation": AutomationSerializer.serialize(automation), "errors": errors})
+            return render_page(request, "Escalated/Admin/Automations/Form", props={"automation": AutomationSerializer.serialize(automation), "errors": errors})
         automation.name = name
         automation.conditions = conditions
         automation.actions = actions
         automation.active = request.POST.get("active", "true") == "true"
         automation.save()
         return redirect("escalated:admin_automations_index")
-    return render(request, "Escalated/Admin/Automations/Form", props={"automation": AutomationSerializer.serialize(automation)})
+    return render_page(request, "Escalated/Admin/Automations/Form", props={"automation": AutomationSerializer.serialize(automation)})
 
 
 @login_required
@@ -3001,7 +3001,7 @@ def settings_csat(request):
             config[key] = EscalatedSetting.objects.get(key=key).value
         except EscalatedSetting.DoesNotExist:
             config[key] = default
-    return render(request, "Escalated/Admin/Settings/Csat", props={"config": config})
+    return render_page(request, "Escalated/Admin/Settings/Csat", props={"config": config})
 
 
 @login_required
@@ -3014,7 +3014,7 @@ def settings_sso(request):
     if request.method == "POST":
         sso.save_config(request.POST.dict())
         return redirect("escalated:admin_settings")
-    return render(request, "Escalated/Admin/Settings/Sso", props={"config": sso.get_config()})
+    return render_page(request, "Escalated/Admin/Settings/Sso", props={"config": sso.get_config()})
 
 
 @login_required
@@ -3023,7 +3023,7 @@ def settings_two_factor(request):
     if check:
         return check
     two_factor = TwoFactor.objects.filter(user=request.user).first()
-    return render(request, "Escalated/Admin/Settings/TwoFactor", props={
+    return render_page(request, "Escalated/Admin/Settings/TwoFactor", props={
         "enabled": two_factor.is_confirmed() if two_factor else False,
         "pending": two_factor is not None and not two_factor.is_confirmed() if two_factor else False,
     })
@@ -3095,7 +3095,7 @@ def custom_objects_index(request):
     if check:
         return check
     objects = CustomObject.objects.annotate(records_count=Count("records")).order_by("name")
-    return render(request, "Escalated/Admin/CustomObjects/Index", props={"custom_objects": CustomObjectSerializer.serialize_list(objects)})
+    return render_page(request, "Escalated/Admin/CustomObjects/Index", props={"custom_objects": CustomObjectSerializer.serialize_list(objects)})
 
 
 @login_required
@@ -3106,7 +3106,7 @@ def custom_objects_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render(request, "Escalated/Admin/CustomObjects/Form", props={"errors": {"name": _("Name is required.")}})
+            return render_page(request, "Escalated/Admin/CustomObjects/Form", props={"errors": {"name": _("Name is required.")}})
         slug_val = slugify(request.POST.get("slug", "") or name)
         try:
             fields_schema = json.loads(request.POST.get("fields_schema", "[]"))
@@ -3114,7 +3114,7 @@ def custom_objects_create(request):
             fields_schema = []
         CustomObject.objects.create(name=name, slug=slug_val, fields_schema=fields_schema)
         return redirect("escalated:admin_custom_objects_index")
-    return render(request, "Escalated/Admin/CustomObjects/Form", props={})
+    return render_page(request, "Escalated/Admin/CustomObjects/Form", props={})
 
 
 @login_required
@@ -3135,7 +3135,7 @@ def custom_objects_edit(request, object_id):
             pass
         obj.save()
         return redirect("escalated:admin_custom_objects_index")
-    return render(request, "Escalated/Admin/CustomObjects/Form", props={"custom_object": CustomObjectSerializer.serialize(obj)})
+    return render_page(request, "Escalated/Admin/CustomObjects/Form", props={"custom_object": CustomObjectSerializer.serialize(obj)})
 
 
 @login_required
@@ -3164,7 +3164,7 @@ def custom_object_records(request, object_id):
     records = obj.records.order_by("-created_at")
     paginator = Paginator(records, 25)
     page = paginator.get_page(request.GET.get("page", 1))
-    return render(request, "Escalated/Admin/CustomObjects/Records", props={
+    return render_page(request, "Escalated/Admin/CustomObjects/Records", props={
         "custom_object": CustomObjectSerializer.serialize(obj),
         "records": CustomObjectRecordSerializer.serialize_list(page.object_list),
         "pagination": {
@@ -3247,7 +3247,7 @@ def reports_dashboard(request):
     service = ReportingService()
     end = tz.now()
     start = end - timedelta(days=30)
-    return render(request, "Escalated/Admin/Reports/Dashboard", props={
+    return render_page(request, "Escalated/Admin/Reports/Dashboard", props={
         "ticket_volume": service.get_ticket_volume_by_date(start, end),
         "by_status": service.get_tickets_by_status(),
         "by_priority": service.get_tickets_by_priority(),

--- a/escalated/views/admin_api_tokens.py
+++ b/escalated/views/admin_api_tokens.py
@@ -17,12 +17,7 @@ from escalated.api_serializers import ApiTokenSerializer
 from escalated.conf import get_setting
 from escalated.models import ApiToken
 from escalated.permissions import is_admin, is_agent
-
-try:
-    from inertia import render
-except ImportError:
-    # Fallback for environments without inertia-django
-    render = None
+from escalated.rendering import render_page
 
 User = get_user_model()
 
@@ -58,15 +53,7 @@ def api_tokens_index(request):
     tokens = ApiToken.objects.order_by("-created_at")
     token_data = ApiTokenSerializer.serialize_list(tokens)
 
-    if render:
-        return render(request, "Escalated/Admin/ApiTokens/Index", props={
-            "tokens": token_data,
-            "users": _get_agent_users(),
-            "api_enabled": get_setting("API_ENABLED"),
-        })
-
-    # JSON fallback for non-Inertia setups
-    return JsonResponse({
+    return render_page(request, "Escalated/Admin/ApiTokens/Index", props={
         "tokens": token_data,
         "users": _get_agent_users(),
         "api_enabled": get_setting("API_ENABLED"),

--- a/escalated/views/admin_plugins.py
+++ b/escalated/views/admin_plugins.py
@@ -11,7 +11,7 @@ import logging
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseForbidden
 from django.shortcuts import redirect
-from inertia import render
+from escalated.rendering import render_page
 
 from escalated.conf import get_setting
 from escalated.permissions import is_admin
@@ -55,7 +55,7 @@ def plugin_list(request):
     service = PluginService()
     plugins = service.get_all_plugins()
 
-    return render(request, "Escalated/Admin/Plugins/Index", props={
+    return render_page(request, "Escalated/Admin/Plugins/Index", props={
         "plugins": plugins,
     })
 

--- a/escalated/views/agent.py
+++ b/escalated/views/agent.py
@@ -8,7 +8,7 @@ from django.db.models import Count, Q, Avg
 from django.http import HttpResponseForbidden, HttpResponseNotFound, JsonResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
-from inertia import render
+from escalated.rendering import render_page
 
 from escalated.models import (
     Ticket,
@@ -86,7 +86,7 @@ def dashboard(request):
         "department"
     ).prefetch_related("tags")[:10]
 
-    return render(request, "Escalated/Agent/Dashboard", props={
+    return render_page(request, "Escalated/Agent/Dashboard", props={
         "stats": stats,
         "recent_tickets": TicketSerializer.serialize_list(recent_tickets),
     })
@@ -152,7 +152,7 @@ def ticket_list(request):
     paginator = Paginator(tickets, 25)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render(request, "Escalated/Agent/Tickets/Index", props={
+    return render_page(request, "Escalated/Agent/Tickets/Index", props={
         "tickets": TicketSerializer.serialize_list(page.object_list),
         "pagination": {
             "current_page": page.number,
@@ -232,7 +232,7 @@ def ticket_show(request, ticket_id):
     except SatisfactionRating.DoesNotExist:
         satisfaction_data = None
 
-    return render(request, "Escalated/Agent/Tickets/Show", props={
+    return render_page(request, "Escalated/Agent/Tickets/Show", props={
         "ticket": TicketSerializer.serialize(ticket),
         "replies": ReplySerializer.serialize_list(replies),
         "activities": [ActivitySerializer.serialize(a) for a in activities],

--- a/escalated/views/customer.py
+++ b/escalated/views/customer.py
@@ -4,7 +4,7 @@ from django.core.paginator import Paginator
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
-from inertia import render
+from escalated.rendering import render_page
 
 from escalated.conf import get_setting
 from escalated.models import Ticket, Tag, Department, SatisfactionRating
@@ -34,7 +34,7 @@ def ticket_list(request):
     paginator = Paginator(tickets, 15)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render(request, "Escalated/Customer/Index", props={
+    return render_page(request, "Escalated/Customer/Index", props={
         "tickets": TicketSerializer.serialize_list(page.object_list),
         "pagination": {
             "current_page": page.number,
@@ -56,7 +56,7 @@ def ticket_list(request):
 @login_required
 def ticket_create(request):
     """Show the ticket creation form."""
-    return render(request, "Escalated/Customer/Create", props={
+    return render_page(request, "Escalated/Customer/Create", props={
         "departments": DepartmentSerializer.serialize_list(
             Department.objects.filter(is_active=True)
         ),
@@ -89,7 +89,7 @@ def ticket_store(request):
         errors["description"] = _("Description is required.")
 
     if errors:
-        return render(request, "Escalated/Customer/Create", props={
+        return render_page(request, "Escalated/Customer/Create", props={
             "errors": errors,
             "old": data,
             "departments": DepartmentSerializer.serialize_list(
@@ -136,7 +136,7 @@ def ticket_show(request, ticket_id):
     replies = ticket.replies.filter(is_deleted=False, is_internal_note=False)
 
     from escalated.serializers import ReplySerializer, AttachmentSerializer
-    return render(request, "Escalated/Customer/Show", props={
+    return render_page(request, "Escalated/Customer/Show", props={
         "ticket": TicketSerializer.serialize(ticket),
         "replies": ReplySerializer.serialize_list(replies),
         "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),

--- a/escalated/views/guest.py
+++ b/escalated/views/guest.py
@@ -3,7 +3,7 @@ import secrets
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
-from inertia import render
+from escalated.rendering import render_page
 
 from escalated.conf import get_setting
 from escalated.models import Ticket, Department, EscalatedSetting, SatisfactionRating
@@ -25,7 +25,7 @@ def ticket_create(request):
     if not _guest_tickets_enabled():
         return HttpResponseNotFound(_("Guest tickets are not enabled."))
 
-    return render(request, "Escalated/Guest/Create", props={
+    return render_page(request, "Escalated/Guest/Create", props={
         "departments": DepartmentSerializer.serialize_list(
             Department.objects.filter(is_active=True)
         ),
@@ -63,7 +63,7 @@ def ticket_store(request):
         errors["description"] = _("Description is required.")
 
     if errors:
-        return render(request, "Escalated/Guest/Create", props={
+        return render_page(request, "Escalated/Guest/Create", props={
             "errors": errors,
             "old": {
                 "name": name,
@@ -126,7 +126,7 @@ def ticket_show(request, token):
     # Filter out internal notes for guest users
     replies = ticket.replies.filter(is_deleted=False, is_internal_note=False)
 
-    return render(request, "Escalated/Guest/Show", props={
+    return render_page(request, "Escalated/Guest/Show", props={
         "ticket": TicketSerializer.serialize(ticket),
         "replies": ReplySerializer.serialize_list(replies),
         "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),

--- a/escalated/views/import_views.py
+++ b/escalated/views/import_views.py
@@ -28,7 +28,7 @@ from django.http import (
 )
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
-from inertia import render
+from escalated.rendering import render_page
 
 from escalated.models import ImportJob
 from escalated.permissions import is_admin
@@ -92,7 +92,7 @@ def import_index(request):
             if job[ts_field]:
                 job[ts_field] = job[ts_field].isoformat()
 
-    return render(request, "Escalated/Admin/Import/Index", props={
+    return render_page(request, "Escalated/Admin/Import/Index", props={
         "jobs": jobs,
         "adapters": adapters,
     })
@@ -120,7 +120,7 @@ def import_create(request):
         for a in service.available_adapters()
     ]
 
-    return render(request, "Escalated/Admin/Import/Create", props={
+    return render_page(request, "Escalated/Admin/Import/Create", props={
         "adapters": adapters,
     })
 
@@ -234,7 +234,7 @@ def import_mapping(request, job_uuid):
             "current": mappings.get(et, adapter.default_field_mappings(et)),
         }
 
-    return render(request, "Escalated/Admin/Import/Mapping", props={
+    return render_page(request, "Escalated/Admin/Import/Mapping", props={
         "job": {
             "id": str(job.id),
             "platform": job.platform,
@@ -379,7 +379,7 @@ def import_show(request, job_uuid):
     adapter = service.resolve_adapter(job.platform)
     entity_types = adapter.entity_types() if adapter else []
 
-    return render(request, "Escalated/Admin/Import/Show", props={
+    return render_page(request, "Escalated/Admin/Import/Show", props={
         "job": {
             "id": str(job.id),
             "platform": job.platform,

--- a/tests/integration/test_admin_api_tokens.py
+++ b/tests/integration/test_admin_api_tokens.py
@@ -35,7 +35,7 @@ def _attach_session(request):
 
 @pytest.mark.django_db
 class TestAdminApiTokensIndex:
-    @patch("escalated.views.admin_api_tokens.render")
+    @patch("escalated.views.admin_api_tokens.render_page")
     def test_index_returns_tokens_for_admin(self, mock_render, rf):
         admin = UserFactory(username="admin_idx", is_staff=True, is_superuser=True)
         user = UserFactory(username="token_owner")

--- a/tests/integration/test_phase1_admin_views.py
+++ b/tests/integration/test_phase1_admin_views.py
@@ -41,7 +41,7 @@ def _make_admin_request(rf, method, path, data=None, user=None):
 
 @pytest.mark.django_db
 class TestStatusesAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_statuses(self, mock_render, rf):
         TicketStatusFactory(slug="test-s1")
         mock_render.return_value = MagicMock(status_code=200)
@@ -56,7 +56,7 @@ class TestStatusesAdminViews:
         assert "statuses" in props
         assert "categories" in props
 
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_create_get_renders_form(self, mock_render, rf):
         mock_render.return_value = MagicMock(status_code=200)
 
@@ -131,7 +131,7 @@ class TestStatusesAdminViews:
 
 @pytest.mark.django_db
 class TestBusinessHoursAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_schedules(self, mock_render, rf):
         BusinessScheduleFactory()
         mock_render.return_value = MagicMock(status_code=200)
@@ -213,7 +213,7 @@ class TestBusinessHoursAdminViews:
 
 @pytest.mark.django_db
 class TestRolesAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_roles(self, mock_render, rf):
         RoleFactory(slug="test-role-idx")
         mock_render.return_value = MagicMock(status_code=200)
@@ -296,7 +296,7 @@ class TestRolesAdminViews:
 
 @pytest.mark.django_db
 class TestAuditLogsAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_logs(self, mock_render, rf):
         user = UserFactory(username="audit_admin", is_staff=True, is_superuser=True)
         ticket = TicketFactory()
@@ -320,7 +320,7 @@ class TestAuditLogsAdminViews:
         assert "actions" in props
         assert "resource_types" in props
 
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_with_filters(self, mock_render, rf):
         user = UserFactory(username="audit_filter", is_staff=True, is_superuser=True)
         mock_render.return_value = MagicMock(status_code=200)

--- a/tests/integration/test_phase2_admin_views.py
+++ b/tests/integration/test_phase2_admin_views.py
@@ -48,7 +48,7 @@ def _make_admin_request(rf, method, path, data=None, user=None, content_type=Non
 
 @pytest.mark.django_db
 class TestCustomFieldsAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_fields(self, mock_render, rf):
         CustomFieldFactory(slug="cf-test-idx")
         mock_render.return_value = MagicMock(status_code=200)
@@ -387,7 +387,7 @@ class TestSideConversationsAdminViews:
 
 @pytest.mark.django_db
 class TestArticlesAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_articles(self, mock_render, rf):
         ArticleFactory(slug="art-test-idx")
         mock_render.return_value = MagicMock(status_code=200)
@@ -465,7 +465,7 @@ class TestArticlesAdminViews:
 
 @pytest.mark.django_db
 class TestKBCategoriesAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_categories(self, mock_render, rf):
         ArticleCategoryFactory(slug="kbcat-test-idx")
         mock_render.return_value = MagicMock(status_code=200)

--- a/tests/integration/test_phase3_5_admin_views.py
+++ b/tests/integration/test_phase3_5_admin_views.py
@@ -49,7 +49,7 @@ def _make_admin_request(rf, method, path, data=None, user=None, content_type=Non
 
 @pytest.mark.django_db
 class TestSkillsAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_skills(self, mock_render, rf):
         SkillFactory(slug="skill-idx-test")
         mock_render.return_value = MagicMock(status_code=200)
@@ -96,7 +96,7 @@ class TestSkillsAdminViews:
 
 @pytest.mark.django_db
 class TestCapacityAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_capacities(self, mock_render, rf):
         AgentCapacityFactory()
         mock_render.return_value = MagicMock(status_code=200)
@@ -126,7 +126,7 @@ class TestCapacityAdminViews:
 
 @pytest.mark.django_db
 class TestWebhooksAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_webhooks(self, mock_render, rf):
         WebhookFactory()
         mock_render.return_value = MagicMock(status_code=200)
@@ -168,7 +168,7 @@ class TestWebhooksAdminViews:
         assert response.status_code == 302
         assert not Webhook.objects.filter(pk=wh.pk).exists()
 
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_deliveries(self, mock_render, rf):
         wh = WebhookFactory()
         WebhookDeliveryFactory(webhook=wh)
@@ -191,7 +191,7 @@ class TestWebhooksAdminViews:
 
 @pytest.mark.django_db
 class TestAutomationsAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_automations(self, mock_render, rf):
         AutomationFactory()
         mock_render.return_value = MagicMock(status_code=200)
@@ -286,7 +286,7 @@ class TestTwoFactorAdminViews:
 
 @pytest.mark.django_db
 class TestCustomObjectsAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_index_returns_objects(self, mock_render, rf):
         CustomObjectFactory()
         mock_render.return_value = MagicMock(status_code=200)
@@ -326,7 +326,7 @@ class TestCustomObjectsAdminViews:
         assert response.status_code == 302
         assert not CustomObject.objects.filter(pk=obj.pk).exists()
 
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_records_list(self, mock_render, rf):
         obj = CustomObjectFactory()
         CustomObjectRecordFactory(object=obj)

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -32,7 +32,7 @@ def _attach_session(request):
 
 @pytest.mark.django_db
 class TestCustomerViews:
-    @patch("escalated.views.customer.render")
+    @patch("escalated.views.customer.render_page")
     def test_ticket_list_returns_user_tickets(self, mock_render, rf):
         user = UserFactory(username="cust_list")
         ticket = TicketFactory(requester=user)
@@ -51,7 +51,7 @@ class TestCustomerViews:
         assert "tickets" in props
         assert "pagination" in props
 
-    @patch("escalated.views.customer.render")
+    @patch("escalated.views.customer.render_page")
     def test_ticket_create_shows_form(self, mock_render, rf):
         user = UserFactory(username="cust_create")
 
@@ -66,7 +66,7 @@ class TestCustomerViews:
         call_args = mock_render.call_args
         assert call_args[0][1] == "Escalated/Customer/Create"
 
-    @patch("escalated.views.customer.render")
+    @patch("escalated.views.customer.render_page")
     def test_ticket_show_returns_ticket(self, mock_render, rf):
         user = UserFactory(username="cust_show")
         ticket = TicketFactory(requester=user)
@@ -139,7 +139,7 @@ class TestCustomerViews:
 
 @pytest.mark.django_db
 class TestAgentViews:
-    @patch("escalated.views.agent.render")
+    @patch("escalated.views.agent.render_page")
     def test_dashboard_returns_stats(self, mock_render, rf):
         department = DepartmentFactory()
         agent_user = UserFactory(username="agent_dash")
@@ -158,7 +158,7 @@ class TestAgentViews:
         props = call_args[1]["props"] if "props" in call_args[1] else call_args[0][2]
         assert "stats" in props
 
-    @patch("escalated.views.agent.render")
+    @patch("escalated.views.agent.render_page")
     def test_ticket_list_with_filters(self, mock_render, rf):
         department = DepartmentFactory()
         agent_user = UserFactory(username="agent_list")
@@ -247,7 +247,7 @@ class TestAgentViews:
 
 @pytest.mark.django_db
 class TestAdminViews:
-    @patch("escalated.views.admin.render")
+    @patch("escalated.views.admin.render_page")
     def test_reports_returns_stats(self, mock_render, rf):
         admin_user = UserFactory(
             username="admin_reports", is_staff=True, is_superuser=True


### PR DESCRIPTION
## Summary

- Add `UI_ENABLED` (default `True`) and `UI_RENDERER` (default `None`) to `conf.py` DEFAULTS, allowing deployments to disable the Inertia UI layer entirely
- Split `urls.py` so customer, agent, admin, and guest route patterns are only registered when `UI_ENABLED` is true; core routes (inbound webhooks, API, plugin bridge) remain always active
- Create `escalated/rendering.py` with a pluggable `UiRenderer` abstraction and `render_page()` convenience function, replacing direct `from inertia import render` imports across all UI view modules
- Update all six UI view files (`customer.py`, `agent.py`, `admin.py`, `guest.py`, `admin_plugins.py`, `import_views.py`) to use `render_page()` instead of Inertia's `render()` directly
- Short-circuit `EscalatedInertiaShareMiddleware` when `UI_ENABLED` is false so it skips Inertia prop sharing

This mirrors the Laravel package's UI-optional approach, letting API-only or headless deployments skip the Inertia/Vue dependency entirely.

## Test plan

- [ ] Verify default behavior unchanged: `UI_ENABLED=True` still renders all Inertia pages normally
- [ ] Set `ESCALATED = {"UI_ENABLED": False}` and confirm UI routes return 404, API/inbound routes still work
- [ ] Confirm `EscalatedInertiaShareMiddleware` passes through without error when UI is disabled
- [ ] Test custom `UI_RENDERER` class path resolves and renders correctly