### PR TITLE
feat: add missing admin views for automations, articles, and side-conversations

### DIFF
--- a/escalated/serializers.py
+++ b/escalated/serializers.py
@@ -543,9 +543,11 @@ class SideConversationSerializer:
             "updated_at": _format_dt(conversation.updated_at),
         }
         if include_replies:
-            data["replies"] = SideConversationReplySerializer.serialize_list(
-                conversation.replies.all()
-            )
+            replies = conversation.replies.all()
+            data["replies"] = SideConversationReplySerializer.serialize_list(replies)
+            data["reply_count"] = len(data["replies"])
+        elif hasattr(conversation, "reply_count"):
+            data["reply_count"] = conversation.reply_count
         return data
 
     @staticmethod
@@ -718,13 +720,24 @@ class WebhookDeliverySerializer:
 class AutomationSerializer:
     @staticmethod
     def serialize(automation):
+        conditions = automation.conditions or []
+        actions = automation.actions or []
+        # Extract the trigger type from the first condition if available
+        trigger_type = None
+        if conditions and isinstance(conditions, list) and len(conditions) > 0:
+            first = conditions[0]
+            if isinstance(first, dict):
+                trigger_type = first.get("type") or first.get("field")
         return {
             "id": automation.pk,
             "name": automation.name,
-            "conditions": automation.conditions,
-            "actions": automation.actions,
+            "conditions": conditions,
+            "actions": actions,
             "active": automation.active,
             "position": automation.position,
+            "trigger_type": trigger_type,
+            "condition_count": len(conditions) if isinstance(conditions, list) else 0,
+            "action_count": len(actions) if isinstance(actions, list) else 0,
             "last_run_at": _format_dt(automation.last_run_at),
             "created_at": _format_dt(automation.created_at),
             "updated_at": _format_dt(automation.updated_at),

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -2268,7 +2268,7 @@ def ticket_merge(request, ticket_id):
 
 @login_required
 def side_conversations_index(request, ticket_id):
-    """List all side conversations for a ticket."""
+    """List all side conversations for a ticket with reply counts."""
     check = _require_admin(request)
     if check:
         return check
@@ -2282,7 +2282,8 @@ def side_conversations_index(request, ticket_id):
         ticket.side_conversations
         .select_related("created_by")
         .prefetch_related("replies__author")
-        .all()
+        .annotate(reply_count=Count("replies"))
+        .order_by("-created_at")
     )
 
     return JsonResponse({
@@ -2880,11 +2881,39 @@ def webhooks_retry(request, delivery_id):
 
 @login_required
 def automations_index(request):
+    """List all automation rules with status, trigger type, and action count."""
     check = _require_admin(request)
     if check:
         return check
+
     automations = Automation.objects.order_by("position")
-    return render_page(request, "Escalated/Admin/Automations/Index", props={"automations": AutomationSerializer.serialize_list(automations)})
+
+    # Filter by active status
+    active_filter = request.GET.get("active")
+    if active_filter is not None:
+        automations = automations.filter(active=active_filter == "true")
+
+    search = request.GET.get("search")
+    if search:
+        automations = automations.filter(name__icontains=search)
+
+    paginator = Paginator(automations, 20)
+    page = paginator.get_page(request.GET.get("page", 1))
+
+    return render_page(request, "Escalated/Admin/Automations/Index", props={
+        "automations": AutomationSerializer.serialize_list(page.object_list),
+        "pagination": {
+            "current_page": page.number,
+            "total_pages": paginator.num_pages,
+            "total_count": paginator.count,
+            "has_next": page.has_next(),
+            "has_previous": page.has_previous(),
+        },
+        "filters": {
+            "active": active_filter,
+            "search": search,
+        },
+    })
 
 
 @login_required


### PR DESCRIPTION
## Summary

- **Automations index**: Added pagination, search filtering, and active-status filtering to match the pattern used by other admin index views (articles, departments, etc.)
- **AutomationSerializer**: Added computed `trigger_type`, `condition_count`, and `action_count` fields so the frontend can display summary info without parsing raw JSON arrays
- **SideConversationSerializer**: Added `reply_count` field; side conversation listings now ordered by most recent first with annotated reply counts
- **Articles & KB categories**: Already fully implemented with proper Inertia rendering, pagination, filtering, and CRUD -- no changes needed

This brings the Django admin UI to full parity with the Laravel admin controllers for automations, articles, KB categories, and side conversations.

## Test plan

- [x] All 495 existing tests pass with no regressions
- [ ] Verify automations index renders with pagination and filters in browser
- [ ] Verify side conversations list shows reply counts and orders by newest first
- [ ] Verify automation serializer returns `trigger_type`, `condition_count`, and `action_count`