### PR TITLE
ci: add linting to CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    name: Ruff
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: ruff check escalated/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "pytest-django>=4.5",
     "factory-boy>=3.2",
     "faker>=18.0",
+    "ruff>=0.4.0",
 ]
 
 [tool.pytest.ini_options]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 120
+target-version = "py310"
+
+[lint]
+select = ["E", "F", "I"]


### PR DESCRIPTION
## Summary
- Add `ruff` to dev dependencies in `pyproject.toml`
- Create `ruff.toml` with E/F/I rule sets, 120 char line length, Python 3.10 target
- Create `lint.yml` workflow that runs Ruff on PRs to main

## Test plan
- [ ] Verify the lint workflow runs on PRs to main
- [ ] Verify Ruff catches style/import violations
- [ ] Verify existing test workflow is unaffected