### PR TITLE
Add Ruff linting CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff check
+        run: ruff check .
+
+      - name: Run ruff format check
+        run: ruff format --check .

--- a/escalated/api_middleware.py
+++ b/escalated/api_middleware.py
@@ -1,7 +1,3 @@
-import hashlib
-import json
-import time
-
 from django.core.cache import cache
 from django.http import JsonResponse
 from django.utils import timezone
@@ -106,9 +102,7 @@ class ApiRateLimit:
 
     def process_response(self, request, response):
         # Only add rate-limit headers to API responses
-        if not hasattr(request, "api_token") and not request.path.startswith(
-            "/" + get_setting("API_PREFIX")
-        ):
+        if not hasattr(request, "api_token") and not request.path.startswith("/" + get_setting("API_PREFIX")):
             return response
 
         max_attempts = get_setting("API_RATE_LIMIT")

--- a/escalated/api_serializers.py
+++ b/escalated/api_serializers.py
@@ -3,7 +3,7 @@ Dict-based serializers for the REST API, producing JSON-compatible output that
 matches the Laravel API response format.
 """
 
-from escalated.serializers import _format_dt, _user_dict
+from escalated.serializers import _format_dt
 
 
 class ApiTicketCollectionSerializer:
@@ -34,15 +34,8 @@ class ApiTicketCollectionSerializer:
                 if assignee
                 else None
             ),
-            "department": (
-                {"id": department.pk, "name": department.name}
-                if department
-                else None
-            ),
-            "sla_breached": (
-                ticket.sla_first_response_breached
-                or ticket.sla_resolution_breached
-            ),
+            "department": ({"id": department.pk, "name": department.name} if department else None),
+            "sla_breached": (ticket.sla_first_response_breached or ticket.sla_resolution_breached),
             "created_at": _format_dt(ticket.created_at),
             "updated_at": _format_dt(ticket.updated_at),
         }
@@ -84,15 +77,8 @@ class ApiTicketDetailSerializer:
                 if assignee
                 else None
             ),
-            "department": (
-                {"id": department.pk, "name": department.name}
-                if department
-                else None
-            ),
-            "tags": [
-                {"id": tag.pk, "name": tag.name, "color": tag.color}
-                for tag in ticket.tags.all()
-            ],
+            "department": ({"id": department.pk, "name": department.name} if department else None),
+            "tags": [{"id": tag.pk, "name": tag.name, "color": tag.color} for tag in ticket.tags.all()],
             "sla": {
                 "first_response_due_at": _format_dt(ticket.first_response_due_at),
                 "first_response_at": _format_dt(ticket.first_response_at),
@@ -107,15 +93,11 @@ class ApiTicketDetailSerializer:
         }
 
         if include_replies:
-            data["replies"] = [
-                ApiReplySerializer.serialize(reply)
-                for reply in ticket.replies.filter(is_deleted=False)
-            ]
+            data["replies"] = [ApiReplySerializer.serialize(reply) for reply in ticket.replies.filter(is_deleted=False)]
 
         if include_activities:
             data["activities"] = [
-                ApiActivitySerializer.serialize(activity)
-                for activity in ticket.activities.all()[:20]
+                ApiActivitySerializer.serialize(activity) for activity in ticket.activities.all()[:20]
             ]
 
         return data
@@ -141,10 +123,7 @@ class ApiReplySerializer:
                 if author
                 else None
             ),
-            "attachments": [
-                ApiAttachmentSerializer.serialize(a)
-                for a in reply.attachments.all()
-            ],
+            "attachments": [ApiAttachmentSerializer.serialize(a) for a in reply.attachments.all()],
             "created_at": _format_dt(reply.created_at),
         }
         return data
@@ -165,9 +144,7 @@ class ApiActivitySerializer:
         try:
             causer = activity.causer
             data["causer"] = (
-                {"id": causer.pk, "name": getattr(causer, "get_full_name", lambda: str(causer))()}
-                if causer
-                else None
+                {"id": causer.pk, "name": getattr(causer, "get_full_name", lambda: str(causer))()} if causer else None
             )
         except Exception:
             data["causer"] = None
@@ -279,11 +256,7 @@ class ApiTokenSerializer:
         return {
             "id": token.pk,
             "name": token.name,
-            "user_name": (
-                getattr(tokenable, "get_full_name", lambda: str(tokenable))()
-                if tokenable
-                else None
-            ),
+            "user_name": (getattr(tokenable, "get_full_name", lambda: str(tokenable))() if tokenable else None),
             "user_email": getattr(tokenable, "email", None) if tokenable else None,
             "abilities": token.abilities,
             "last_used_at": _format_dt(token.last_used_at),

--- a/escalated/api_urls.py
+++ b/escalated/api_urls.py
@@ -7,7 +7,7 @@ Authentication and rate limiting are handled by middleware.
 
 from django.urls import path
 
-from escalated.views import api, admin_api_tokens
+from escalated.views import admin_api_tokens, api
 
 app_name = "escalated_api"
 
@@ -15,14 +15,11 @@ app_name = "escalated_api"
 api_patterns = [
     # Auth
     path("auth/validate/", api.auth_validate, name="auth_validate"),
-
     # Dashboard
     path("dashboard/", api.dashboard, name="dashboard"),
-
     # Tickets - list & create
     path("tickets/", api.ticket_list, name="ticket_list"),
     path("tickets/create/", api.ticket_create, name="ticket_create"),
-
     # Tickets - detail & actions (by reference or ID)
     path("tickets/<str:reference>/", api.ticket_show, name="ticket_show"),
     path("tickets/<str:reference>/reply/", api.ticket_reply, name="ticket_reply"),
@@ -33,7 +30,6 @@ api_patterns = [
     path("tickets/<str:reference>/macro/", api.ticket_apply_macro, name="ticket_macro"),
     path("tickets/<str:reference>/tags/", api.ticket_tags, name="ticket_tags"),
     path("tickets/<str:reference>/delete/", api.ticket_destroy, name="ticket_destroy"),
-
     # Resources
     path("agents/", api.resource_agents, name="agents"),
     path("departments/", api.resource_departments, name="departments"),

--- a/escalated/apps.py
+++ b/escalated/apps.py
@@ -34,6 +34,7 @@ class EscalatedConfig(AppConfig):
                 return
 
             from escalated.plugin_service import PluginService
+
             service = PluginService()
             service.load_active_plugins()
         except Exception as exc:
@@ -50,8 +51,9 @@ class EscalatedConfig(AppConfig):
         misconfigured runtime never prevents the Django app from starting.
         """
         try:
-            from escalated.conf import get_setting
             from django.conf import settings
+
+            from escalated.conf import get_setting
 
             escalated_settings = getattr(settings, "ESCALATED", {})
 
@@ -63,9 +65,8 @@ class EscalatedConfig(AppConfig):
                 return
 
             from escalated.bridge.plugin_bridge import get_bridge
+
             bridge = get_bridge()
             bridge.boot()
         except Exception as exc:
-            logger.debug(
-                "Could not boot SDK plugin bridge on startup: %s", exc
-            )
+            logger.debug("Could not boot SDK plugin bridge on startup: %s", exc)

--- a/escalated/bridge/context_handler.py
+++ b/escalated/bridge/context_handler.py
@@ -126,13 +126,11 @@ class ContextHandler:
     def _get_plugin_config(self, plugin: str) -> dict:
         from escalated.bridge.plugin_store_record import PluginStoreRecord
 
-        record = (
-            PluginStoreRecord.objects.filter(
-                plugin=plugin,
-                collection="__config__",
-                key="__config__",
-            ).first()
-        )
+        record = PluginStoreRecord.objects.filter(
+            plugin=plugin,
+            collection="__config__",
+            key="__config__",
+        ).first()
         if record is None:
             return {}
         return record.data if isinstance(record.data, dict) else {}
@@ -164,9 +162,7 @@ class ContextHandler:
         if not key:
             raise ValueError("ctx.store.get requires key")
 
-        record = PluginStoreRecord.objects.filter(
-            plugin=plugin, collection=collection, key=key
-        ).first()
+        record = PluginStoreRecord.objects.filter(plugin=plugin, collection=collection, key=key).first()
         return record.data if record else None
 
     def _store_set(self, params: dict) -> None:
@@ -182,7 +178,9 @@ class ContextHandler:
             raise ValueError("ctx.store.set requires key")
 
         PluginStoreRecord.objects.update_or_create(
-            plugin=plugin, collection=collection, key=key,
+            plugin=plugin,
+            collection=collection,
+            key=key,
             defaults={"data": value},
         )
         return None
@@ -229,10 +227,7 @@ class ContextHandler:
         if limit is not None:
             records = records[: int(limit)]
 
-        return [
-            {"_id": r.id, **(r.data if isinstance(r.data, dict) else {})}
-            for r in records
-        ]
+        return [{"_id": r.id, **(r.data if isinstance(r.data, dict) else {})} for r in records]
 
     def _apply_json_operator(self, qs, field: str, op: str, value):
         """
@@ -243,7 +238,6 @@ class ContextHandler:
         database-agnostic.  For large collections a database-level
         implementation would be more efficient.
         """
-        from escalated.bridge.plugin_store_record import PluginStoreRecord
 
         def _extract(record):
             if not isinstance(record.data, dict):
@@ -251,12 +245,12 @@ class ContextHandler:
             return record.data.get(field)
 
         op_funcs = {
-            "$gt":  lambda v, val: v is not None and v > val,
+            "$gt": lambda v, val: v is not None and v > val,
             "$gte": lambda v, val: v is not None and v >= val,
-            "$lt":  lambda v, val: v is not None and v < val,
+            "$lt": lambda v, val: v is not None and v < val,
             "$lte": lambda v, val: v is not None and v <= val,
-            "$ne":  lambda v, val: v != val,
-            "$in":  lambda v, val: v in (val if isinstance(val, list) else [val]),
+            "$ne": lambda v, val: v != val,
+            "$in": lambda v, val: v in (val if isinstance(val, list) else [val]),
             "$nin": lambda v, val: v not in (val if isinstance(val, list) else [val]),
         }
 
@@ -301,9 +295,7 @@ class ContextHandler:
         if data is None:
             raise ValueError("ctx.store.update requires data")
 
-        record = PluginStoreRecord.objects.get(
-            plugin=plugin, collection=collection, key=key
-        )
+        record = PluginStoreRecord.objects.get(plugin=plugin, collection=collection, key=key)
         existing = record.data if isinstance(record.data, dict) else {}
         record.data = {**existing, **data}
         record.save(update_fields=["data"])
@@ -320,9 +312,7 @@ class ContextHandler:
         if not key:
             raise ValueError("ctx.store.delete requires key")
 
-        PluginStoreRecord.objects.filter(
-            plugin=plugin, collection=collection, key=key
-        ).delete()
+        PluginStoreRecord.objects.filter(plugin=plugin, collection=collection, key=key).delete()
         return None
 
     # ------------------------------------------------------------------
@@ -406,11 +396,13 @@ class ContextHandler:
 
     def _get_user_model(self):
         from django.contrib.auth import get_user_model
+
         from escalated.conf import get_setting
 
         model_path = get_setting("USER_MODEL")
         if model_path:
             from django.apps import apps
+
             app_label, model_name = model_path.rsplit(".", 1) if "." in model_path else model_path.split(".")
             try:
                 return apps.get_model(app_label, model_name)
@@ -537,8 +529,8 @@ class ContextHandler:
         Gracefully no-ops when Channels is not installed.
         """
         try:
-            from channels.layers import get_channel_layer
             from asgiref.sync import async_to_sync
+            from channels.layers import get_channel_layer
 
             channel_layer = get_channel_layer()
             if channel_layer is None:
@@ -558,9 +550,7 @@ class ContextHandler:
                 channel,
             )
         except Exception as exc:
-            logger.warning(
-                "ctx.broadcast: failed to broadcast to '%s': %s", channel, exc
-            )
+            logger.warning("ctx.broadcast: failed to broadcast to '%s': %s", channel, exc)
 
     # ------------------------------------------------------------------
     # Misc
@@ -610,8 +600,6 @@ class ContextHandler:
         """Convert a Django model instance to a plain serialisable dict."""
         if instance is None:
             return None
-        from django.forms.models import model_to_dict
-        from django.db import models as django_models
 
         try:
             d = {}

--- a/escalated/bridge/json_rpc_client.py
+++ b/escalated/bridge/json_rpc_client.py
@@ -140,7 +140,7 @@ class JsonRpcClient:
             ready, _, _ = select.select([self._stdout], [], [], timeout_seconds)
             if not ready:
                 return None
-        except (select.error, ValueError):
+        except (OSError, ValueError):
             # select() is not available for this file object (e.g. Windows pipes).
             # Fall through to the blocking read below.
             pass
@@ -169,16 +169,12 @@ class JsonRpcClient:
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise RuntimeError(
-                    f"JSON-RPC timeout waiting for response to request #{expected_id}"
-                )
+                raise RuntimeError(f"JSON-RPC timeout waiting for response to request #{expected_id}")
 
             line = self.read_line(int(remaining) + 1)
 
             if line is None:
-                raise RuntimeError(
-                    f"JSON-RPC connection lost waiting for response to request #{expected_id}"
-                )
+                raise RuntimeError(f"JSON-RPC connection lost waiting for response to request #{expected_id}")
 
             if line == "":
                 continue
@@ -186,9 +182,7 @@ class JsonRpcClient:
             try:
                 decoded = json.loads(line)
             except json.JSONDecodeError:
-                logger.warning(
-                    "Escalated PluginBridge: received non-JSON line: %s", line[:200]
-                )
+                logger.warning("Escalated PluginBridge: received non-JSON line: %s", line[:200])
                 continue
 
             if not isinstance(decoded, dict) or "jsonrpc" not in decoded:

--- a/escalated/bridge/plugin_bridge.py
+++ b/escalated/bridge/plugin_bridge.py
@@ -24,12 +24,10 @@ that new action hooks are dropped with a warning.  Filter hooks return the
 unmodified value instead of being dropped.
 """
 
-import importlib.util
 import logging
 import os
 import shutil
 import subprocess
-import sys
 import time
 
 logger = logging.getLogger("escalated.bridge")
@@ -95,9 +93,7 @@ class PluginBridge:
             return
 
         if not self._is_runtime_available():
-            logger.info(
-                "Escalated PluginBridge: Node.js runtime not available — SDK plugins disabled"
-            )
+            logger.info("Escalated PluginBridge: Node.js runtime not available — SDK plugins disabled")
             return
 
         try:
@@ -106,9 +102,7 @@ class PluginBridge:
             self._register_routes()
             self._booted = True
         except Exception as exc:
-            logger.warning(
-                "Escalated PluginBridge: boot failed — SDK plugins disabled: %s", exc
-            )
+            logger.warning("Escalated PluginBridge: boot failed — SDK plugins disabled: %s", exc)
             self._teardown()
 
     def dispatch_action(self, hook: str, event: dict) -> None:
@@ -123,9 +117,7 @@ class PluginBridge:
             return
 
         if self._pending_action_count >= MAX_QUEUE_DEPTH:
-            logger.warning(
-                "Escalated PluginBridge: action queue full — dropping action '%s'", hook
-            )
+            logger.warning("Escalated PluginBridge: action queue full — dropping action '%s'", hook)
             return
 
         self._pending_action_count += 1
@@ -138,9 +130,7 @@ class PluginBridge:
                 self._context_handler.handle,
             )
         except Exception as exc:
-            logger.warning(
-                "Escalated PluginBridge: action '%s' failed: %s", hook, exc
-            )
+            logger.warning("Escalated PluginBridge: action '%s' failed: %s", hook, exc)
             self._handle_crash()
         finally:
             self._pending_action_count -= 1
@@ -256,12 +246,12 @@ class PluginBridge:
 
     def _is_runtime_available(self) -> bool:
         """Check that Node.js is available and SDK plugins are enabled."""
-        from escalated.conf import get_setting
 
         # Honour the SDK_ENABLED config key if present
         escalated_settings = {}
         try:
             from django.conf import settings
+
             escalated_settings = getattr(settings, "ESCALATED", {})
         except Exception:
             pass
@@ -286,7 +276,6 @@ class PluginBridge:
 
     def _spawn(self) -> None:
         """Spawn the Node.js plugin runtime subprocess."""
-        from escalated.conf import get_setting
         from django.conf import settings
 
         escalated_settings = getattr(settings, "ESCALATED", {})
@@ -313,9 +302,7 @@ class PluginBridge:
                 bufsize=1,  # line-buffered
             )
         except OSError as exc:
-            raise RuntimeError(
-                f"Failed to spawn plugin runtime '{command}': {exc}"
-            ) from exc
+            raise RuntimeError(f"Failed to spawn plugin runtime '{command}': {exc}") from exc
 
         from escalated.bridge.json_rpc_client import JsonRpcClient
 
@@ -398,8 +385,7 @@ class PluginBridge:
             elapsed = time.monotonic() - self._last_restart_at
             if elapsed < backoff:
                 logger.debug(
-                    "Escalated PluginBridge: waiting for backoff before restart "
-                    "(%.0f s remaining)",
+                    "Escalated PluginBridge: waiting for backoff before restart (%.0f s remaining)",
                     backoff - elapsed,
                 )
                 return False
@@ -417,8 +403,7 @@ class PluginBridge:
             self._restart_attempts += 1
             self._last_restart_at = time.monotonic()
             logger.error(
-                "Escalated PluginBridge: failed to start plugin runtime "
-                "(attempt %d): %s",
+                "Escalated PluginBridge: failed to start plugin runtime (attempt %d): %s",
                 self._restart_attempts,
                 exc,
             )
@@ -442,10 +427,7 @@ class PluginBridge:
     def _handle_crash(self) -> None:
         """Clean up after a crash so the next call triggers a restart."""
         if not self._is_process_alive():
-            logger.warning(
-                "Escalated PluginBridge: plugin runtime process has crashed — "
-                "will restart on next dispatch"
-            )
+            logger.warning("Escalated PluginBridge: plugin runtime process has crashed — will restart on next dispatch")
             self._teardown()
 
     def _teardown(self) -> None:
@@ -468,6 +450,7 @@ class PluginBridge:
         """Return the escalated-django package version."""
         try:
             from importlib.metadata import version
+
             return version("escalated-django")
         except Exception:
             pass
@@ -477,7 +460,8 @@ class PluginBridge:
             pyproject = os.path.join(pkg_root, "pyproject.toml")
             if os.path.isfile(pyproject):
                 import re
-                with open(pyproject, "r", encoding="utf-8") as fh:
+
+                with open(pyproject, encoding="utf-8") as fh:
                     content = fh.read()
                 match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
                 if match:

--- a/escalated/bridge/route_registrar.py
+++ b/escalated/bridge/route_registrar.py
@@ -15,7 +15,7 @@ boot) and injected into the main urlconf via include() in urls.py.
 import logging
 
 from django.http import JsonResponse
-from django.urls import path, re_path
+from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
 logger = logging.getLogger("escalated.bridge")
@@ -62,9 +62,7 @@ class RouteRegistrar:
     # Pages — rendered HTML views (Inertia or plain template)
     # ------------------------------------------------------------------
 
-    def _register_pages(
-        self, plugin_name: str, pages: list, prefix: str
-    ) -> None:
+    def _register_pages(self, plugin_name: str, pages: list, prefix: str) -> None:
         if not pages:
             return
 
@@ -76,8 +74,7 @@ class RouteRegistrar:
 
             if not route or not component:
                 logger.warning(
-                    "Escalated PluginBridge: skipping page with missing route or "
-                    "component for plugin '%s': %s",
+                    "Escalated PluginBridge: skipping page with missing route or component for plugin '%s': %s",
                     plugin_name,
                     page,
                 )
@@ -105,11 +102,11 @@ class RouteRegistrar:
         bridge = self._bridge
 
         def page_view(request):
-            from django.contrib.auth.decorators import login_required
             from django.http import HttpResponseForbidden
 
             if not request.user.is_authenticated:
                 from django.contrib.auth.views import redirect_to_login
+
                 return redirect_to_login(request.get_full_path())
 
             if not getattr(request.user, "is_staff", False):
@@ -128,6 +125,7 @@ class RouteRegistrar:
             # Try to use django-inertia if available; fall back to JsonResponse
             try:
                 from inertia import render as inertia_render
+
                 return inertia_render(
                     request,
                     "Escalated/Plugin/Page",
@@ -157,9 +155,7 @@ class RouteRegistrar:
     # Endpoints — authenticated JSON API
     # ------------------------------------------------------------------
 
-    def _register_endpoints(
-        self, plugin_name: str, endpoints: dict, prefix: str
-    ) -> None:
+    def _register_endpoints(self, plugin_name: str, endpoints: dict, prefix: str) -> None:
         if not endpoints:
             return
 
@@ -209,6 +205,7 @@ class RouteRegistrar:
 
             try:
                 import json as _json
+
                 try:
                     body = _json.loads(request.body) if request.body else {}
                 except ValueError:
@@ -243,9 +240,7 @@ class RouteRegistrar:
     # Webhooks — public (no auth)
     # ------------------------------------------------------------------
 
-    def _register_webhooks(
-        self, plugin_name: str, webhooks: dict, prefix: str
-    ) -> None:
+    def _register_webhooks(self, plugin_name: str, webhooks: dict, prefix: str) -> None:
         if not webhooks:
             return
 
@@ -267,15 +262,14 @@ class RouteRegistrar:
                 plugin_name,
             )
 
-    def _make_webhook_view(
-        self, plugin_name: str, http_method: str, wh_path: str
-    ):
+    def _make_webhook_view(self, plugin_name: str, http_method: str, wh_path: str):
         bridge = self._bridge
 
         @csrf_exempt
         def webhook_view(request, **kwargs):
-            from django.http import HttpResponseNotAllowed
             import json as _json
+
+            from django.http import HttpResponseNotAllowed
 
             if request.method.upper() != http_method:
                 return HttpResponseNotAllowed([http_method])

--- a/escalated/conf.py
+++ b/escalated/conf.py
@@ -2,7 +2,6 @@ import os
 
 from django.conf import settings
 
-
 DEFAULTS = {
     "MODE": "self_hosted",
     "USER_MODEL": None,  # Falls back to settings.AUTH_USER_MODEL

--- a/escalated/contracts/import_adapter.py
+++ b/escalated/contracts/import_adapter.py
@@ -21,7 +21,6 @@ via the ``import.adapters`` filter hook::
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from escalated.support.extract_result import ExtractResult
 
@@ -74,7 +73,7 @@ class ImportAdapter(ABC):
         """
 
     @abstractmethod
-    def extract(self, entity_type: str, credentials: dict, cursor: Optional[str]) -> ExtractResult:
+    def extract(self, entity_type: str, credentials: dict, cursor: str | None) -> ExtractResult:
         """
         Fetch one page of records for *entity_type*.
 
@@ -97,8 +96,8 @@ class ImportAdapter(ABC):
 
     def set_job_id(self, job_id: str) -> None:
         """Store the active ImportJob UUID for cross-referencing.  Optional."""
-        self._job_id: Optional[str] = job_id
+        self._job_id: str | None = job_id
 
-    def get_job_id(self) -> Optional[str]:
+    def get_job_id(self) -> str | None:
         """Return the stored job UUID, or ``None`` if not set."""
         return getattr(self, "_job_id", None)

--- a/escalated/drivers/__init__.py
+++ b/escalated/drivers/__init__.py
@@ -8,15 +8,15 @@ def get_driver():
     mode = get_setting("MODE")
     if mode == "self_hosted":
         from escalated.drivers.local import LocalDriver
+
         return LocalDriver()
     elif mode == "synced":
         from escalated.drivers.synced import SyncedDriver
+
         return SyncedDriver()
     elif mode == "cloud":
         from escalated.drivers.cloud import CloudDriver
+
         return CloudDriver()
     else:
-        raise ValueError(
-            f"Invalid ESCALATED MODE: '{mode}'. "
-            f"Must be one of: self_hosted, synced, cloud"
-        )
+        raise ValueError(f"Invalid ESCALATED MODE: '{mode}'. Must be one of: self_hosted, synced, cloud")

--- a/escalated/drivers/api_client.py
+++ b/escalated/drivers/api_client.py
@@ -64,8 +64,7 @@ class HostedApiClient:
             except (ValueError, AttributeError):
                 pass
             raise HostedApiError(
-                f"API returned {e.response.status_code}: "
-                f"{error_body.get('message', str(e))}",
+                f"API returned {e.response.status_code}: {error_body.get('message', str(e))}",
                 status_code=e.response.status_code,
                 response_body=error_body,
             )
@@ -85,9 +84,7 @@ class HostedApiClient:
         return self._request("GET", "/tickets", params=params)
 
     def transition_status(self, ticket_id, status):
-        return self._request(
-            "POST", f"/tickets/{ticket_id}/status", data={"status": status}
-        )
+        return self._request("POST", f"/tickets/{ticket_id}/status", data={"status": status})
 
     def assign_ticket(self, ticket_id, agent_id):
         return self._request(
@@ -107,14 +104,10 @@ class HostedApiClient:
     # ----- Tag endpoints -----
 
     def add_tags(self, ticket_id, tag_ids):
-        return self._request(
-            "POST", f"/tickets/{ticket_id}/tags", data={"tag_ids": tag_ids}
-        )
+        return self._request("POST", f"/tickets/{ticket_id}/tags", data={"tag_ids": tag_ids})
 
     def remove_tags(self, ticket_id, tag_ids):
-        return self._request(
-            "DELETE", f"/tickets/{ticket_id}/tags", data={"tag_ids": tag_ids}
-        )
+        return self._request("DELETE", f"/tickets/{ticket_id}/tags", data={"tag_ids": tag_ids})
 
     # ----- Department endpoints -----
 

--- a/escalated/drivers/cloud.py
+++ b/escalated/drivers/cloud.py
@@ -26,9 +26,7 @@ class CloudDriver:
             "metadata": data.get("metadata"),
             "requester_id": user.pk,
             "requester_email": getattr(user, "email", None),
-            "requester_name": getattr(
-                user, "get_full_name", lambda: str(user)
-            )(),
+            "requester_name": getattr(user, "get_full_name", lambda: str(user))(),
         }
         return self.api.create_ticket(payload)
 
@@ -55,9 +53,7 @@ class CloudDriver:
             "body": data["body"],
             "is_internal_note": data.get("is_internal_note", False),
             "author_id": user.pk if user else None,
-            "author_name": getattr(
-                user, "get_full_name", lambda: str(user)
-            )() if user else "Guest",
+            "author_name": getattr(user, "get_full_name", lambda: str(user))() if user else "Guest",
             "metadata": data.get("metadata"),
         }
         return self.api.add_reply(ticket_id, payload)

--- a/escalated/drivers/local.py
+++ b/escalated/drivers/local.py
@@ -1,32 +1,31 @@
 import logging
-from datetime import timedelta
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.utils import timezone
 
 from escalated.models import (
-    Ticket,
     Reply,
     Tag,
+    Ticket,
     TicketActivity,
 )
 from escalated.signals import (
-    ticket_created,
-    ticket_updated,
-    ticket_status_changed,
-    ticket_assigned,
-    ticket_unassigned,
-    ticket_priority_changed,
-    ticket_escalated,
-    ticket_resolved,
-    ticket_closed,
-    ticket_reopened,
-    reply_created,
+    department_changed,
     internal_note_added,
+    reply_created,
     tag_added,
     tag_removed,
-    department_changed,
+    ticket_assigned,
+    ticket_closed,
+    ticket_created,
+    ticket_escalated,
+    ticket_priority_changed,
+    ticket_reopened,
+    ticket_resolved,
+    ticket_status_changed,
+    ticket_unassigned,
+    ticket_updated,
 )
 
 logger = logging.getLogger("escalated")
@@ -84,9 +83,7 @@ class LocalDriver:
 
         if changes:
             ticket.save()
-            ticket_updated.send(
-                sender=Ticket, ticket=ticket, user=user, changes=changes
-            )
+            ticket_updated.send(sender=Ticket, ticket=ticket, user=user, changes=changes)
 
         return ticket
 
@@ -134,15 +131,12 @@ class LocalDriver:
         elif new_status == Ticket.Status.REOPENED:
             ticket_reopened.send(sender=Ticket, ticket=ticket, user=user)
         elif new_status == Ticket.Status.ESCALATED:
-            ticket_escalated.send(
-                sender=Ticket, ticket=ticket, user=user, reason="Manual escalation"
-            )
+            ticket_escalated.send(sender=Ticket, ticket=ticket, user=user, reason="Manual escalation")
 
         return ticket
 
     def assign_ticket(self, ticket, user, agent):
         """Assign a ticket to an agent."""
-        previous_agent = ticket.assigned_to
         ticket.assigned_to = agent
 
         if ticket.status == Ticket.Status.OPEN:
@@ -160,9 +154,7 @@ class LocalDriver:
             },
         )
 
-        ticket_assigned.send(
-            sender=Ticket, ticket=ticket, user=user, agent=agent
-        )
+        ticket_assigned.send(sender=Ticket, ticket=ticket, user=user, agent=agent)
 
         return ticket
 
@@ -207,16 +199,11 @@ class LocalDriver:
         # Update ticket status based on who is replying
         if not is_internal and user is not None:
             ct = ContentType.objects.get_for_model(user)
-            is_requester = (
-                ticket.requester_content_type == ct
-                and ticket.requester_object_id == user.pk
-            )
+            is_requester = ticket.requester_content_type == ct and ticket.requester_object_id == user.pk
 
             if is_requester:
                 if ticket.status == Ticket.Status.WAITING_ON_CUSTOMER:
-                    self.transition_status(
-                        ticket, user, Ticket.Status.WAITING_ON_AGENT
-                    )
+                    self.transition_status(ticket, user, Ticket.Status.WAITING_ON_AGENT)
             else:
                 if ticket.status in [
                     Ticket.Status.OPEN,
@@ -224,9 +211,7 @@ class LocalDriver:
                     Ticket.Status.WAITING_ON_AGENT,
                     Ticket.Status.REOPENED,
                 ]:
-                    self.transition_status(
-                        ticket, user, Ticket.Status.WAITING_ON_CUSTOMER
-                    )
+                    self.transition_status(ticket, user, Ticket.Status.WAITING_ON_CUSTOMER)
         elif not is_internal and user is None:
             # Guest reply — treat like a customer reply
             if ticket.status == Ticket.Status.WAITING_ON_CUSTOMER:
@@ -234,31 +219,23 @@ class LocalDriver:
 
         # Fire signals
         if is_internal:
-            internal_note_added.send(
-                sender=Reply, reply=reply, ticket=ticket, user=user
-            )
+            internal_note_added.send(sender=Reply, reply=reply, ticket=ticket, user=user)
         else:
-            reply_created.send(
-                sender=Reply, reply=reply, ticket=ticket, user=user
-            )
+            reply_created.send(sender=Reply, reply=reply, ticket=ticket, user=user)
 
         return reply
 
     def get_ticket(self, ticket_id):
         """Retrieve a single ticket by ID."""
         return (
-            Ticket.objects.select_related(
-                "assigned_to", "department", "sla_policy"
-            )
+            Ticket.objects.select_related("assigned_to", "department", "sla_policy")
             .prefetch_related("tags", "replies", "activities")
             .get(pk=ticket_id)
         )
 
     def list_tickets(self, filters=None):
         """List tickets with optional filters."""
-        qs = Ticket.objects.select_related(
-            "assigned_to", "department", "sla_policy"
-        ).prefetch_related("tags")
+        qs = Ticket.objects.select_related("assigned_to", "department", "sla_policy").prefetch_related("tags")
 
         if filters:
             if "status" in filters:

--- a/escalated/drivers/synced.py
+++ b/escalated/drivers/synced.py
@@ -1,8 +1,8 @@
 import logging
 
-from escalated.drivers.local import LocalDriver
 from escalated.drivers.api_client import HostedApiClient, HostedApiError
-from escalated.serializers import TicketSerializer, ReplySerializer
+from escalated.drivers.local import LocalDriver
+from escalated.serializers import ReplySerializer, TicketSerializer
 
 logger = logging.getLogger("escalated")
 
@@ -23,105 +23,132 @@ class SyncedDriver(LocalDriver):
         try:
             self.api.emit(event_type, payload)
         except HostedApiError as e:
-            logger.error(
-                f"Failed to sync event '{event_type}' to cloud: {e}. "
-                f"Local operation succeeded."
-            )
+            logger.error(f"Failed to sync event '{event_type}' to cloud: {e}. Local operation succeeded.")
         except Exception as e:
             logger.error(f"Unexpected error syncing '{event_type}': {e}")
 
     def create_ticket(self, user, data):
         ticket = super().create_ticket(user, data)
-        self._emit_safe("ticket.created", {
-            "ticket": TicketSerializer.serialize(ticket),
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "ticket.created",
+            {
+                "ticket": TicketSerializer.serialize(ticket),
+                "user_id": user.pk,
+            },
+        )
         return ticket
 
     def update_ticket(self, ticket, user, data):
         ticket = super().update_ticket(ticket, user, data)
-        self._emit_safe("ticket.updated", {
-            "ticket": TicketSerializer.serialize(ticket),
-            "user_id": user.pk,
-            "changes": data,
-        })
+        self._emit_safe(
+            "ticket.updated",
+            {
+                "ticket": TicketSerializer.serialize(ticket),
+                "user_id": user.pk,
+                "changes": data,
+            },
+        )
         return ticket
 
     def transition_status(self, ticket, user, new_status):
         old_status = ticket.status
         ticket = super().transition_status(ticket, user, new_status)
-        self._emit_safe("ticket.status_changed", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "old_status": old_status,
-            "new_status": new_status,
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "ticket.status_changed",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "old_status": old_status,
+                "new_status": new_status,
+                "user_id": user.pk,
+            },
+        )
         return ticket
 
     def assign_ticket(self, ticket, user, agent):
         ticket = super().assign_ticket(ticket, user, agent)
-        self._emit_safe("ticket.assigned", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "agent_id": agent.pk,
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "ticket.assigned",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "agent_id": agent.pk,
+                "user_id": user.pk,
+            },
+        )
         return ticket
 
     def unassign_ticket(self, ticket, user):
         ticket = super().unassign_ticket(ticket, user)
-        self._emit_safe("ticket.unassigned", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "ticket.unassigned",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "user_id": user.pk,
+            },
+        )
         return ticket
 
     def add_reply(self, ticket, user, data):
         reply = super().add_reply(ticket, user, data)
-        self._emit_safe("reply.created", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "reply": ReplySerializer.serialize(reply),
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "reply.created",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "reply": ReplySerializer.serialize(reply),
+                "user_id": user.pk,
+            },
+        )
         return reply
 
     def add_tags(self, ticket, user, tag_ids):
         super().add_tags(ticket, user, tag_ids)
-        self._emit_safe("ticket.tags_added", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "tag_ids": tag_ids,
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "ticket.tags_added",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "tag_ids": tag_ids,
+                "user_id": user.pk,
+            },
+        )
 
     def remove_tags(self, ticket, user, tag_ids):
         super().remove_tags(ticket, user, tag_ids)
-        self._emit_safe("ticket.tags_removed", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "tag_ids": tag_ids,
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "ticket.tags_removed",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "tag_ids": tag_ids,
+                "user_id": user.pk,
+            },
+        )
 
     def change_department(self, ticket, user, department):
         ticket = super().change_department(ticket, user, department)
-        self._emit_safe("ticket.department_changed", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "department_id": department.pk,
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "ticket.department_changed",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "department_id": department.pk,
+                "user_id": user.pk,
+            },
+        )
         return ticket
 
     def change_priority(self, ticket, user, new_priority):
         ticket = super().change_priority(ticket, user, new_priority)
-        self._emit_safe("ticket.priority_changed", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "priority": new_priority,
-            "user_id": user.pk,
-        })
+        self._emit_safe(
+            "ticket.priority_changed",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "priority": new_priority,
+                "user_id": user.pk,
+            },
+        )
         return ticket

--- a/escalated/handlers.py
+++ b/escalated/handlers.py
@@ -4,16 +4,16 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from escalated.signals import (
-    ticket_created,
-    ticket_updated,
-    ticket_status_changed,
-    ticket_assigned,
-    ticket_priority_changed,
     reply_created,
     sla_breached,
-    ticket_resolved,
+    ticket_assigned,
     ticket_closed,
+    ticket_created,
     ticket_escalated,
+    ticket_priority_changed,
+    ticket_resolved,
+    ticket_status_changed,
+    ticket_updated,
 )
 from escalated.support.import_context import ImportContext
 
@@ -29,6 +29,7 @@ def _bridge_dispatch(hook: str, event: dict) -> None:
     """
     try:
         from escalated.bridge.plugin_bridge import get_bridge
+
         bridge = get_bridge()
         if bridge.is_booted():
             bridge.dispatch_action(hook, event)
@@ -43,14 +44,12 @@ def on_ticket_created(sender, ticket, user, **kwargs):
         return
 
     from escalated.models import SlaPolicy, TicketActivity
-    from escalated.services.sla_service import SlaService
     from escalated.services.notification_service import NotificationService
+    from escalated.services.sla_service import SlaService
 
     # Attach default SLA policy if none set
     if not ticket.sla_policy:
-        default_policy = SlaPolicy.objects.filter(
-            is_default=True, is_active=True
-        ).first()
+        default_policy = SlaPolicy.objects.filter(is_default=True, is_active=True).first()
         if default_policy:
             ticket.sla_policy = default_policy
             SlaService.apply_sla_deadlines(ticket)
@@ -75,14 +74,17 @@ def on_ticket_created(sender, ticket, user, **kwargs):
     logger.info(f"Ticket {ticket.reference} created by user {user}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("ticket.created", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "subject": ticket.subject,
-        "status": ticket.status,
-        "priority": ticket.priority,
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "ticket.created",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "subject": ticket.subject,
+            "status": ticket.status,
+            "priority": ticket.priority,
+            "user_id": getattr(user, "pk", None),
+        },
+    )
 
 
 @receiver(reply_created)
@@ -95,11 +97,7 @@ def on_reply_created(sender, reply, ticket, user, **kwargs):
     from escalated.services.notification_service import NotificationService
 
     # Record first response if this is the first agent reply
-    if (
-        not ticket.first_response_at
-        and ticket.assigned_to
-        and user == ticket.assigned_to
-    ):
+    if not ticket.first_response_at and ticket.assigned_to and user == ticket.assigned_to:
         ticket.first_response_at = timezone.now()
         ticket.save(update_fields=["first_response_at", "updated_at"])
 
@@ -117,13 +115,16 @@ def on_reply_created(sender, reply, ticket, user, **kwargs):
     logger.info(f"Reply added to ticket {ticket.reference} by user {user}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("reply.created", {
-        "reply_id": reply.pk,
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "is_internal": reply.is_internal_note,
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "reply.created",
+        {
+            "reply_id": reply.pk,
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "is_internal": reply.is_internal_note,
+            "user_id": getattr(user, "pk", None),
+        },
+    )
 
 
 @receiver(ticket_status_changed)
@@ -142,18 +143,19 @@ def on_status_changed(sender, ticket, user, old_status, new_status, **kwargs):
     )
 
     NotificationService.notify_status_changed(ticket, old_status, new_status)
-    logger.info(
-        f"Ticket {ticket.reference} status changed: {old_status} -> {new_status}"
-    )
+    logger.info(f"Ticket {ticket.reference} status changed: {old_status} -> {new_status}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("ticket.status_changed", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "old_status": old_status,
-        "new_status": new_status,
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "ticket.status_changed",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "old_status": old_status,
+            "new_status": new_status,
+            "user_id": getattr(user, "pk", None),
+        },
+    )
 
 
 @receiver(ticket_assigned)
@@ -178,12 +180,15 @@ def on_ticket_assigned(sender, ticket, user, agent, **kwargs):
     logger.info(f"Ticket {ticket.reference} assigned to {agent}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("ticket.assigned", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "agent_id": agent.pk,
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "ticket.assigned",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "agent_id": agent.pk,
+            "user_id": getattr(user, "pk", None),
+        },
+    )
 
 
 @receiver(sla_breached)
@@ -205,11 +210,14 @@ def on_sla_breached(sender, ticket, breach_type, **kwargs):
     logger.warning(f"SLA breached on ticket {ticket.reference}: {breach_type}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("sla.breached", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "breach_type": breach_type,
-    })
+    _bridge_dispatch(
+        "sla.breached",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "breach_type": breach_type,
+        },
+    )
 
 
 @receiver(ticket_resolved)
@@ -224,11 +232,14 @@ def on_ticket_resolved(sender, ticket, user, **kwargs):
     logger.info(f"Ticket {ticket.reference} resolved by {user}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("ticket.resolved", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "ticket.resolved",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "user_id": getattr(user, "pk", None),
+        },
+    )
 
 
 @receiver(ticket_closed)
@@ -240,11 +251,14 @@ def on_ticket_closed(sender, ticket, user, **kwargs):
     logger.info(f"Ticket {ticket.reference} closed by {user}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("ticket.closed", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "ticket.closed",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "user_id": getattr(user, "pk", None),
+        },
+    )
 
 
 @receiver(ticket_escalated)
@@ -266,12 +280,15 @@ def on_ticket_escalated(sender, ticket, user, reason, **kwargs):
     logger.warning(f"Ticket {ticket.reference} escalated: {reason}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("ticket.escalated", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "reason": reason,
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "ticket.escalated",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "reason": reason,
+            "user_id": getattr(user, "pk", None),
+        },
+    )
 
 
 @receiver(ticket_updated)
@@ -282,20 +299,26 @@ def on_ticket_updated(sender, ticket, user, changes, **kwargs):
 
     from escalated.services.notification_service import NotificationService
 
-    NotificationService._fire_webhook("ticket.updated", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "changes": {k: v["new"] for k, v in changes.items()},
-    })
+    NotificationService._fire_webhook(
+        "ticket.updated",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "changes": {k: v["new"] for k, v in changes.items()},
+        },
+    )
     logger.info(f"Ticket {ticket.reference} updated: {list(changes.keys())}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("ticket.updated", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "changes": {k: v["new"] for k, v in changes.items()},
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "ticket.updated",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "changes": {k: v["new"] for k, v in changes.items()},
+            "user_id": getattr(user, "pk", None),
+        },
+    )
 
 
 @receiver(ticket_priority_changed)
@@ -306,21 +329,25 @@ def on_ticket_priority_changed(sender, ticket, user, old_priority, new_priority,
 
     from escalated.services.notification_service import NotificationService
 
-    NotificationService._fire_webhook("ticket.priority_changed", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "old_priority": old_priority,
-        "new_priority": new_priority,
-    })
-    logger.info(
-        f"Ticket {ticket.reference} priority changed: {old_priority} -> {new_priority}"
+    NotificationService._fire_webhook(
+        "ticket.priority_changed",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "old_priority": old_priority,
+            "new_priority": new_priority,
+        },
     )
+    logger.info(f"Ticket {ticket.reference} priority changed: {old_priority} -> {new_priority}")
 
     # Dual dispatch to SDK plugin bridge
-    _bridge_dispatch("ticket.priority_changed", {
-        "ticket_id": ticket.pk,
-        "reference": ticket.reference,
-        "old_priority": old_priority,
-        "new_priority": new_priority,
-        "user_id": getattr(user, "pk", None),
-    })
+    _bridge_dispatch(
+        "ticket.priority_changed",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "old_priority": old_priority,
+            "new_priority": new_priority,
+            "user_id": getattr(user, "pk", None),
+        },
+    )

--- a/escalated/hook_registry.py
+++ b/escalated/hook_registry.py
@@ -41,69 +41,40 @@ class HookRegistry:
             "plugin_loaded": {
                 "description": "Fired when a plugin file has been loaded.",
                 "parameters": ["slug", "manifest"],
-                "example": (
-                    "add_action('plugin_loaded', "
-                    "lambda slug, manifest: print(f'Loaded {slug}'))"
-                ),
+                "example": ("add_action('plugin_loaded', lambda slug, manifest: print(f'Loaded {slug}'))"),
             },
             "plugin_activated": {
                 "description": "Fired when any plugin is activated.",
                 "parameters": ["slug"],
-                "example": (
-                    "add_action('plugin_activated', "
-                    "lambda slug: print(f'Activated {slug}'))"
-                ),
+                "example": ("add_action('plugin_activated', lambda slug: print(f'Activated {slug}'))"),
             },
             "plugin_activated_{slug}": {
-                "description": (
-                    "Fired when a specific plugin is activated. "
-                    "Replace {slug} with the plugin's slug."
-                ),
+                "description": ("Fired when a specific plugin is activated. Replace {slug} with the plugin's slug."),
                 "parameters": [],
-                "example": (
-                    "add_action('plugin_activated_hello-world', "
-                    "lambda: print('Hello World activated!'))"
-                ),
+                "example": ("add_action('plugin_activated_hello-world', lambda: print('Hello World activated!'))"),
             },
             "plugin_deactivated": {
                 "description": "Fired when any plugin is deactivated.",
                 "parameters": ["slug"],
-                "example": (
-                    "add_action('plugin_deactivated', "
-                    "lambda slug: print(f'Deactivated {slug}'))"
-                ),
+                "example": ("add_action('plugin_deactivated', lambda slug: print(f'Deactivated {slug}'))"),
             },
             "plugin_deactivated_{slug}": {
-                "description": (
-                    "Fired when a specific plugin is deactivated. "
-                    "Replace {slug} with the plugin's slug."
-                ),
+                "description": ("Fired when a specific plugin is deactivated. Replace {slug} with the plugin's slug."),
                 "parameters": [],
-                "example": (
-                    "add_action('plugin_deactivated_hello-world', "
-                    "lambda: print('Hello World deactivated!'))"
-                ),
+                "example": ("add_action('plugin_deactivated_hello-world', lambda: print('Hello World deactivated!'))"),
             },
             "plugin_uninstalling": {
                 "description": "Fired before any plugin is deleted.",
                 "parameters": ["slug"],
-                "example": (
-                    "add_action('plugin_uninstalling', "
-                    "lambda slug: print(f'Uninstalling {slug}'))"
-                ),
+                "example": ("add_action('plugin_uninstalling', lambda slug: print(f'Uninstalling {slug}'))"),
             },
             "plugin_uninstalling_{slug}": {
-                "description": (
-                    "Fired before a specific plugin is deleted. "
-                    "Replace {slug} with the plugin's slug."
-                ),
+                "description": ("Fired before a specific plugin is deleted. Replace {slug} with the plugin's slug."),
                 "parameters": [],
                 "example": (
-                    "add_action('plugin_uninstalling_hello-world', "
-                    "lambda: print('Hello World is being removed!'))"
+                    "add_action('plugin_uninstalling_hello-world', lambda: print('Hello World is being removed!'))"
                 ),
             },
-
             # ===========================================================
             # TICKET LIFECYCLE
             # ===========================================================
@@ -111,189 +82,123 @@ class HookRegistry:
                 "description": "Fired before a ticket is persisted.",
                 "parameters": ["validated_data", "request"],
                 "example": (
-                    "add_action('ticket_before_create', "
-                    "lambda data, request: data.update({'channel': 'api'}))"
+                    "add_action('ticket_before_create', lambda data, request: data.update({'channel': 'api'}))"
                 ),
             },
             "ticket_created": {
                 "description": "Fired after a ticket is created.",
                 "parameters": ["ticket", "user"],
-                "example": (
-                    "add_action('ticket_created', "
-                    "lambda ticket, user: print(ticket.reference))"
-                ),
+                "example": ("add_action('ticket_created', lambda ticket, user: print(ticket.reference))"),
             },
             "ticket_before_update": {
                 "description": "Fired before a ticket is updated.",
                 "parameters": ["ticket", "validated_data", "request"],
-                "example": (
-                    "add_action('ticket_before_update', "
-                    "lambda t, data, req: None)"
-                ),
+                "example": ("add_action('ticket_before_update', lambda t, data, req: None)"),
             },
             "ticket_updated": {
                 "description": "Fired after a ticket is updated.",
                 "parameters": ["ticket", "user", "changes"],
-                "example": (
-                    "add_action('ticket_updated', "
-                    "lambda ticket, user, changes: None)"
-                ),
+                "example": ("add_action('ticket_updated', lambda ticket, user, changes: None)"),
             },
             "ticket_status_changed": {
                 "description": "Fired when a ticket's status changes.",
                 "parameters": ["ticket", "user", "old_status", "new_status"],
-                "example": (
-                    "add_action('ticket_status_changed', "
-                    "lambda t, u, old, new: print(f'{old} -> {new}'))"
-                ),
+                "example": ("add_action('ticket_status_changed', lambda t, u, old, new: print(f'{old} -> {new}'))"),
             },
             "ticket_assigned": {
                 "description": "Fired when a ticket is assigned to an agent.",
                 "parameters": ["ticket", "user", "agent"],
-                "example": (
-                    "add_action('ticket_assigned', "
-                    "lambda t, u, a: print(f'Assigned to {a}'))"
-                ),
+                "example": ("add_action('ticket_assigned', lambda t, u, a: print(f'Assigned to {a}'))"),
             },
             "ticket_unassigned": {
                 "description": "Fired when a ticket's assignment is removed.",
                 "parameters": ["ticket", "user", "previous_agent"],
-                "example": (
-                    "add_action('ticket_unassigned', "
-                    "lambda t, u, prev: None)"
-                ),
+                "example": ("add_action('ticket_unassigned', lambda t, u, prev: None)"),
             },
             "ticket_priority_changed": {
                 "description": "Fired when a ticket's priority changes.",
                 "parameters": ["ticket", "user", "old_priority", "new_priority"],
-                "example": (
-                    "add_action('ticket_priority_changed', "
-                    "lambda t, u, old, new: None)"
-                ),
+                "example": ("add_action('ticket_priority_changed', lambda t, u, old, new: None)"),
             },
             "ticket_escalated": {
                 "description": "Fired when a ticket is escalated.",
                 "parameters": ["ticket", "user", "reason"],
-                "example": (
-                    "add_action('ticket_escalated', "
-                    "lambda t, u, reason: None)"
-                ),
+                "example": ("add_action('ticket_escalated', lambda t, u, reason: None)"),
             },
             "ticket_resolved": {
                 "description": "Fired when a ticket is resolved.",
                 "parameters": ["ticket", "user"],
-                "example": (
-                    "add_action('ticket_resolved', "
-                    "lambda ticket, user: None)"
-                ),
+                "example": ("add_action('ticket_resolved', lambda ticket, user: None)"),
             },
             "ticket_closed": {
                 "description": "Fired when a ticket is closed.",
                 "parameters": ["ticket", "user"],
-                "example": (
-                    "add_action('ticket_closed', "
-                    "lambda ticket, user: None)"
-                ),
+                "example": ("add_action('ticket_closed', lambda ticket, user: None)"),
             },
             "ticket_reopened": {
                 "description": "Fired when a ticket is reopened.",
                 "parameters": ["ticket", "user"],
-                "example": (
-                    "add_action('ticket_reopened', "
-                    "lambda ticket, user: None)"
-                ),
+                "example": ("add_action('ticket_reopened', lambda ticket, user: None)"),
             },
             "ticket_deleted": {
                 "description": "Fired after a ticket is deleted.",
                 "parameters": ["ticket", "user"],
-                "example": (
-                    "add_action('ticket_deleted', "
-                    "lambda ticket, user: None)"
-                ),
+                "example": ("add_action('ticket_deleted', lambda ticket, user: None)"),
             },
-
             # ===========================================================
             # REPLY HOOKS
             # ===========================================================
             "reply_created": {
                 "description": "Fired after a reply is added to a ticket.",
                 "parameters": ["reply", "ticket", "user"],
-                "example": (
-                    "add_action('reply_created', "
-                    "lambda reply, ticket, user: None)"
-                ),
+                "example": ("add_action('reply_created', lambda reply, ticket, user: None)"),
             },
             "internal_note_added": {
                 "description": "Fired after an internal note is added.",
                 "parameters": ["reply", "ticket", "user"],
-                "example": (
-                    "add_action('internal_note_added', "
-                    "lambda reply, ticket, user: None)"
-                ),
+                "example": ("add_action('internal_note_added', lambda reply, ticket, user: None)"),
             },
-
             # ===========================================================
             # SLA HOOKS
             # ===========================================================
             "sla_breached": {
                 "description": "Fired when an SLA deadline is breached.",
                 "parameters": ["ticket", "breach_type"],
-                "example": (
-                    "add_action('sla_breached', "
-                    "lambda ticket, breach_type: None)"
-                ),
+                "example": ("add_action('sla_breached', lambda ticket, breach_type: None)"),
             },
             "sla_warning": {
                 "description": "Fired when an SLA deadline is approaching.",
                 "parameters": ["ticket", "warning_type", "remaining"],
-                "example": (
-                    "add_action('sla_warning', "
-                    "lambda ticket, wtype, remaining: None)"
-                ),
+                "example": ("add_action('sla_warning', lambda ticket, wtype, remaining: None)"),
             },
-
             # ===========================================================
             # TAG HOOKS
             # ===========================================================
             "tag_added": {
                 "description": "Fired when a tag is added to a ticket.",
                 "parameters": ["tag", "ticket", "user"],
-                "example": (
-                    "add_action('tag_added', "
-                    "lambda tag, ticket, user: None)"
-                ),
+                "example": ("add_action('tag_added', lambda tag, ticket, user: None)"),
             },
             "tag_removed": {
                 "description": "Fired when a tag is removed from a ticket.",
                 "parameters": ["tag", "ticket", "user"],
-                "example": (
-                    "add_action('tag_removed', "
-                    "lambda tag, ticket, user: None)"
-                ),
+                "example": ("add_action('tag_removed', lambda tag, ticket, user: None)"),
             },
-
             # ===========================================================
             # DEPARTMENT HOOKS
             # ===========================================================
             "department_changed": {
                 "description": "Fired when a ticket is moved to a different department.",
                 "parameters": ["ticket", "user", "old_department", "new_department"],
-                "example": (
-                    "add_action('department_changed', "
-                    "lambda t, u, old, new: None)"
-                ),
+                "example": ("add_action('department_changed', lambda t, u, old, new: None)"),
             },
-
             # ===========================================================
             # DASHBOARD HOOKS
             # ===========================================================
             "dashboard_viewed": {
                 "description": "Fired when the agent dashboard is viewed.",
                 "parameters": ["user"],
-                "example": (
-                    "add_action('dashboard_viewed', "
-                    "lambda user: None)"
-                ),
+                "example": ("add_action('dashboard_viewed', lambda user: None)"),
             },
         }
 
@@ -310,146 +215,96 @@ class HookRegistry:
             "ticket_subject": {
                 "description": "Modify a ticket's subject before display.",
                 "parameters": ["subject", "ticket"],
-                "example": (
-                    "add_filter('ticket_subject', "
-                    "lambda subj, ticket: subj.upper())"
-                ),
+                "example": ("add_filter('ticket_subject', lambda subj, ticket: subj.upper())"),
             },
             "ticket_description": {
                 "description": "Modify a ticket's description before display.",
                 "parameters": ["description", "ticket"],
-                "example": (
-                    "add_filter('ticket_description', "
-                    "lambda desc, ticket: desc)"
-                ),
+                "example": ("add_filter('ticket_description', lambda desc, ticket: desc)"),
             },
             "ticket_list_query": {
                 "description": "Modify the ticket list queryset.",
                 "parameters": ["queryset", "request"],
-                "example": (
-                    "add_filter('ticket_list_query', "
-                    "lambda qs, req: qs.filter(priority='high'))"
-                ),
+                "example": ("add_filter('ticket_list_query', lambda qs, req: qs.filter(priority='high'))"),
             },
             "ticket_list_data": {
                 "description": "Modify serialized ticket list before rendering.",
                 "parameters": ["tickets", "request"],
-                "example": (
-                    "add_filter('ticket_list_data', "
-                    "lambda tickets, req: tickets)"
-                ),
+                "example": ("add_filter('ticket_list_data', lambda tickets, req: tickets)"),
             },
             "ticket_show_data": {
                 "description": "Modify ticket data before displaying detail page.",
                 "parameters": ["ticket_data", "ticket"],
-                "example": (
-                    "add_filter('ticket_show_data', "
-                    "lambda data, t: data)"
-                ),
+                "example": ("add_filter('ticket_show_data', lambda data, t: data)"),
             },
             "ticket_store_validation": {
                 "description": "Modify validation rules for creating tickets.",
                 "parameters": ["rules", "request"],
                 "example": (
-                    "add_filter('ticket_store_validation', "
-                    "lambda rules, req: {**rules, 'custom_field': 'required'})"
+                    "add_filter('ticket_store_validation', lambda rules, req: {**rules, 'custom_field': 'required'})"
                 ),
             },
             "ticket_store_data": {
                 "description": "Modify validated data before creating a ticket.",
                 "parameters": ["validated_data", "request"],
-                "example": (
-                    "add_filter('ticket_store_data', "
-                    "lambda data, req: data)"
-                ),
+                "example": ("add_filter('ticket_store_data', lambda data, req: data)"),
             },
             "ticket_update_data": {
                 "description": "Modify validated data before updating a ticket.",
                 "parameters": ["validated_data", "ticket", "request"],
-                "example": (
-                    "add_filter('ticket_update_data', "
-                    "lambda data, ticket, req: data)"
-                ),
+                "example": ("add_filter('ticket_update_data', lambda data, ticket, req: data)"),
             },
-
             # ===========================================================
             # DASHBOARD FILTERS
             # ===========================================================
             "dashboard_stats_data": {
                 "description": "Modify dashboard statistics before rendering.",
                 "parameters": ["stats", "user"],
-                "example": (
-                    "add_filter('dashboard_stats_data', "
-                    "lambda stats, user: {**stats, 'custom': 42})"
-                ),
+                "example": ("add_filter('dashboard_stats_data', lambda stats, user: {**stats, 'custom': 42})"),
             },
             "dashboard_page_data": {
                 "description": "Modify all data passed to the dashboard page.",
                 "parameters": ["data", "user"],
-                "example": (
-                    "add_filter('dashboard_page_data', "
-                    "lambda data, user: data)"
-                ),
+                "example": ("add_filter('dashboard_page_data', lambda data, user: data)"),
             },
-
             # ===========================================================
             # UI FILTERS
             # ===========================================================
             "navigation_menu": {
                 "description": "Add or modify navigation menu items.",
                 "parameters": ["menu_items", "user"],
-                "example": (
-                    "add_filter('navigation_menu', "
-                    "lambda items, user: items + [{'label': 'Custom'}])"
-                ),
+                "example": ("add_filter('navigation_menu', lambda items, user: items + [{'label': 'Custom'}])"),
             },
             "sidebar_menu": {
                 "description": "Add or modify sidebar menu items.",
                 "parameters": ["menu_items", "user"],
-                "example": (
-                    "add_filter('sidebar_menu', "
-                    "lambda items, user: items)"
-                ),
+                "example": ("add_filter('sidebar_menu', lambda items, user: items)"),
             },
             "user_permissions": {
                 "description": "Modify user permissions.",
                 "parameters": ["permissions", "user"],
-                "example": (
-                    "add_filter('user_permissions', "
-                    "lambda perms, user: perms + ['custom_perm'])"
-                ),
+                "example": ("add_filter('user_permissions', lambda perms, user: perms + ['custom_perm'])"),
             },
-
             # ===========================================================
             # REPLY FILTERS
             # ===========================================================
             "reply_body": {
                 "description": "Modify a reply body before display.",
                 "parameters": ["body", "reply"],
-                "example": (
-                    "add_filter('reply_body', "
-                    "lambda body, reply: body)"
-                ),
+                "example": ("add_filter('reply_body', lambda body, reply: body)"),
             },
-
             # ===========================================================
             # NOTIFICATION FILTERS
             # ===========================================================
             "notification_channels": {
                 "description": "Modify which channels a notification is sent through.",
                 "parameters": ["channels", "event_type", "ticket"],
-                "example": (
-                    "add_filter('notification_channels', "
-                    "lambda ch, evt, t: ch + ['slack'])"
-                ),
+                "example": ("add_filter('notification_channels', lambda ch, evt, t: ch + ['slack'])"),
             },
             "notification_recipients": {
                 "description": "Modify the list of recipients for a notification.",
                 "parameters": ["recipients", "event_type", "ticket"],
-                "example": (
-                    "add_filter('notification_recipients', "
-                    "lambda recips, evt, t: recips)"
-                ),
+                "example": ("add_filter('notification_recipients', lambda recips, evt, t: recips)"),
             },
         }
 

--- a/escalated/hooks.py
+++ b/escalated/hooks.py
@@ -90,10 +90,7 @@ class HookManager:
         """Return True if any callbacks are registered for *tag*."""
         if tag not in self._actions:
             return False
-        return any(
-            len(callbacks) > 0
-            for callbacks in self._actions[tag].values()
-        )
+        return any(len(callbacks) > 0 for callbacks in self._actions[tag].values())
 
     def remove_action(self, tag, callback=None):
         """
@@ -110,9 +107,7 @@ class HookManager:
             return
 
         for priority in list(self._actions[tag].keys()):
-            self._actions[tag][priority] = [
-                cb for cb in self._actions[tag][priority] if cb is not callback
-            ]
+            self._actions[tag][priority] = [cb for cb in self._actions[tag][priority] if cb is not callback]
             if not self._actions[tag][priority]:
                 del self._actions[tag][priority]
 
@@ -171,10 +166,7 @@ class HookManager:
         """Return True if any callbacks are registered for *tag*."""
         if tag not in self._filters:
             return False
-        return any(
-            len(callbacks) > 0
-            for callbacks in self._filters[tag].values()
-        )
+        return any(len(callbacks) > 0 for callbacks in self._filters[tag].values())
 
     def remove_filter(self, tag, callback=None):
         """
@@ -191,9 +183,7 @@ class HookManager:
             return
 
         for priority in list(self._filters[tag].keys()):
-            self._filters[tag][priority] = [
-                cb for cb in self._filters[tag][priority] if cb is not callback
-            ]
+            self._filters[tag][priority] = [cb for cb in self._filters[tag][priority] if cb is not callback]
             if not self._filters[tag][priority]:
                 del self._filters[tag][priority]
 
@@ -278,13 +268,16 @@ def on_action(tag, priority=10):
         def handle(ticket, user):
             ...
     """
+
     def decorator(func):
         add_action(tag, func, priority)
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
+
         return wrapper
+
     return decorator
 
 
@@ -296,11 +289,14 @@ def on_filter(tag, priority=10):
         def uppercase(value, ticket):
             return value.upper()
     """
+
     def decorator(func):
         add_filter(tag, func, priority)
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
+
         return wrapper
+
     return decorator

--- a/escalated/mail/adapters/__init__.py
+++ b/escalated/mail/adapters/__init__.py
@@ -1,8 +1,8 @@
 from escalated.mail.adapters.base import BaseAdapter
+from escalated.mail.adapters.imap import IMAPAdapter
 from escalated.mail.adapters.mailgun import MailgunAdapter
 from escalated.mail.adapters.postmark import PostmarkAdapter
 from escalated.mail.adapters.ses import SESAdapter
-from escalated.mail.adapters.imap import IMAPAdapter
 
 ADAPTERS = {
     "mailgun": MailgunAdapter,
@@ -20,10 +20,7 @@ def get_adapter(name: str) -> BaseAdapter:
     """
     adapter_class = ADAPTERS.get(name)
     if adapter_class is None:
-        raise ValueError(
-            f"Unknown inbound email adapter: '{name}'. "
-            f"Must be one of: {', '.join(ADAPTERS.keys())}"
-        )
+        raise ValueError(f"Unknown inbound email adapter: '{name}'. Must be one of: {', '.join(ADAPTERS.keys())}")
     return adapter_class()
 
 

--- a/escalated/mail/adapters/imap.py
+++ b/escalated/mail/adapters/imap.py
@@ -33,10 +33,7 @@ class IMAPAdapter(BaseAdapter):
 
     def parse_request(self, request) -> InboundMessage:
         """IMAP adapter does not parse webhook requests."""
-        raise NotImplementedError(
-            "IMAPAdapter does not handle webhook requests. "
-            "Use fetch_messages() instead."
-        )
+        raise NotImplementedError("IMAPAdapter does not handle webhook requests. Use fetch_messages() instead.")
 
     def connect(self) -> imaplib.IMAP4_SSL | imaplib.IMAP4:
         """
@@ -72,9 +69,7 @@ class IMAPAdapter(BaseAdapter):
             logger.info(f"Connected to IMAP server {host}:{port}")
             return conn
         except (imaplib.IMAP4.error, OSError) as exc:
-            raise ConnectionError(
-                f"Failed to connect to IMAP server {host}:{port}: {exc}"
-            ) from exc
+            raise ConnectionError(f"Failed to connect to IMAP server {host}:{port}: {exc}") from exc
 
     def fetch_messages(self) -> list[InboundMessage]:
         """
@@ -166,12 +161,14 @@ class IMAPAdapter(BaseAdapter):
                 if "attachment" in content_disposition:
                     filename = part.get_filename() or "unnamed"
                     payload = part.get_payload(decode=True)
-                    attachments.append({
-                        "filename": filename,
-                        "content_type": content_type,
-                        "size": len(payload) if payload else 0,
-                        "data": payload,
-                    })
+                    attachments.append(
+                        {
+                            "filename": filename,
+                            "content_type": content_type,
+                            "size": len(payload) if payload else 0,
+                            "data": payload,
+                        }
+                    )
                     continue
 
                 if content_type == "text/plain" and text_body is None:

--- a/escalated/mail/adapters/mailgun.py
+++ b/escalated/mail/adapters/mailgun.py
@@ -49,10 +49,7 @@ class MailgunAdapter(BaseAdapter):
         """
         signing_key = get_setting("MAILGUN_SIGNING_KEY")
         if not signing_key:
-            logger.warning(
-                "Mailgun signing key not configured. "
-                "Set ESCALATED['MAILGUN_SIGNING_KEY'] in settings."
-            )
+            logger.warning("Mailgun signing key not configured. Set ESCALATED['MAILGUN_SIGNING_KEY'] in settings.")
             return False
 
         timestamp = request.POST.get("timestamp", "")
@@ -73,14 +70,12 @@ class MailgunAdapter(BaseAdapter):
             return False
 
         if abs(int(time.time()) - ts) > 300:
-            logger.warning(
-                "Mailgun webhook timestamp too old — possible replay attack."
-            )
+            logger.warning("Mailgun webhook timestamp too old — possible replay attack.")
             return False
 
         expected = hmac.new(
             signing_key.encode("utf-8"),
-            f"{timestamp}{token}".encode("utf-8"),
+            f"{timestamp}{token}".encode(),
             hashlib.sha256,
         ).hexdigest()
 
@@ -111,12 +106,14 @@ class MailgunAdapter(BaseAdapter):
         for i in range(1, attachment_count + 1):
             uploaded_file = request.FILES.get(f"attachment-{i}")
             if uploaded_file:
-                attachments.append({
-                    "filename": uploaded_file.name,
-                    "content_type": uploaded_file.content_type,
-                    "size": uploaded_file.size,
-                    "file": uploaded_file,
-                })
+                attachments.append(
+                    {
+                        "filename": uploaded_file.name,
+                        "content_type": uploaded_file.content_type,
+                        "size": uploaded_file.size,
+                        "file": uploaded_file,
+                    }
+                )
 
         return InboundMessage(
             from_email=from_email,

--- a/escalated/mail/adapters/postmark.py
+++ b/escalated/mail/adapters/postmark.py
@@ -42,10 +42,7 @@ class PostmarkAdapter(BaseAdapter):
         expected_token = get_setting("POSTMARK_INBOUND_TOKEN")
         if not expected_token:
             # No token configured — reject request for security
-            logger.warning(
-                "Escalated: Postmark inbound token not configured — "
-                "rejecting request."
-            )
+            logger.warning("Escalated: Postmark inbound token not configured — rejecting request.")
             return False
 
         # Postmark can include the token as a query param or header
@@ -86,18 +83,17 @@ class PostmarkAdapter(BaseAdapter):
         # Collect attachments (Postmark sends base64-encoded content)
         attachments = []
         for att in data.get("Attachments", []):
-            attachments.append({
-                "filename": att.get("Name", "unnamed"),
-                "content_type": att.get("ContentType", "application/octet-stream"),
-                "size": att.get("ContentLength", 0),
-                "content_base64": att.get("Content"),
-            })
+            attachments.append(
+                {
+                    "filename": att.get("Name", "unnamed"),
+                    "content_type": att.get("ContentType", "application/octet-stream"),
+                    "size": att.get("ContentLength", 0),
+                    "content_base64": att.get("Content"),
+                }
+            )
 
         # Build raw headers string for storage
-        raw_headers = "\n".join(
-            f"{h.get('Name', '')}: {h.get('Value', '')}"
-            for h in data.get("Headers", [])
-        )
+        "\n".join(f"{h.get('Name', '')}: {h.get('Value', '')}" for h in data.get("Headers", []))
 
         return InboundMessage(
             from_email=from_email,

--- a/escalated/mail/adapters/ses.py
+++ b/escalated/mail/adapters/ses.py
@@ -1,5 +1,3 @@
-import base64
-import hashlib
 import json
 import logging
 import re
@@ -52,17 +50,12 @@ class SESAdapter(BaseAdapter):
         # Verify Topic ARN — reject if not configured
         expected_arn = get_setting("SES_TOPIC_ARN")
         if not expected_arn:
-            logger.warning(
-                "Escalated: SES Topic ARN not configured — rejecting request."
-            )
+            logger.warning("Escalated: SES Topic ARN not configured — rejecting request.")
             return False
 
         topic_arn = data.get("TopicArn", "")
         if topic_arn != expected_arn:
-            logger.warning(
-                f"SES adapter: Topic ARN mismatch. "
-                f"Expected '{expected_arn}', got '{topic_arn}'"
-            )
+            logger.warning(f"SES adapter: Topic ARN mismatch. Expected '{expected_arn}', got '{topic_arn}'")
             return False
 
         # Validate SNS message type
@@ -72,24 +65,18 @@ class SESAdapter(BaseAdapter):
             "Notification",
             "UnsubscribeConfirmation",
         ):
-            logger.warning(
-                f"SES adapter: unexpected SNS message type: {message_type}"
-            )
+            logger.warning(f"SES adapter: unexpected SNS message type: {message_type}")
             return False
 
         # Validate SigningCertURL is from a legitimate AWS SNS endpoint
-        signing_cert_url = data.get("SigningCertURL") or data.get(
-            "SigningCertUrl"
-        )
+        signing_cert_url = data.get("SigningCertURL") or data.get("SigningCertUrl")
         if signing_cert_url:
             parsed_cert_url = urlparse(signing_cert_url)
             if parsed_cert_url.scheme != "https" or not re.match(
                 r"^sns\.[a-z0-9-]+\.amazonaws\.com$",
                 parsed_cert_url.hostname or "",
             ):
-                logger.warning(
-                    f"SES adapter: invalid SigningCertURL: {signing_cert_url}"
-                )
+                logger.warning(f"SES adapter: invalid SigningCertURL: {signing_cert_url}")
                 return False
 
         return True
@@ -115,9 +102,7 @@ class SESAdapter(BaseAdapter):
         try:
             ses_message = json.loads(sns_data.get("Message", "{}"))
         except (json.JSONDecodeError, TypeError) as exc:
-            raise ValueError(
-                f"Invalid SES message in SNS notification: {exc}"
-            ) from exc
+            raise ValueError(f"Invalid SES message in SNS notification: {exc}") from exc
 
         mail_data = ses_message.get("mail", {})
         common_headers = mail_data.get("commonHeaders", {})
@@ -171,10 +156,7 @@ class SESAdapter(BaseAdapter):
         """
         subscribe_url = data.get("SubscribeURL")
         if not subscribe_url or not self._is_valid_sns_url(subscribe_url):
-            logger.warning(
-                "SNS SubscriptionConfirmation has missing or invalid "
-                f"SubscribeURL: {subscribe_url!r}"
-            )
+            logger.warning(f"SNS SubscriptionConfirmation has missing or invalid SubscribeURL: {subscribe_url!r}")
             return
 
         try:
@@ -191,10 +173,7 @@ class SESAdapter(BaseAdapter):
         try:
             parsed = urlparse(url)
             return bool(
-                parsed.scheme == 'https'
-                and re.match(
-                    r'^sns\.[a-z0-9-]+\.amazonaws\.com$', parsed.hostname or ''
-                )
+                parsed.scheme == "https" and re.match(r"^sns\.[a-z0-9-]+\.amazonaws\.com$", parsed.hostname or "")
             )
         except Exception:
             return False

--- a/escalated/mail/inbound_message.py
+++ b/escalated/mail/inbound_message.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 @dataclass
@@ -10,14 +9,14 @@ class InboundMessage:
     """
 
     from_email: str
-    from_name: Optional[str]
+    from_name: str | None
     to_email: str
     subject: str
-    body_text: Optional[str]
-    body_html: Optional[str]
-    message_id: Optional[str] = None
-    in_reply_to: Optional[str] = None
-    references: Optional[str] = None
+    body_text: str | None
+    body_html: str | None
+    message_id: str | None = None
+    in_reply_to: str | None = None
+    references: str | None = None
     headers: dict = field(default_factory=dict)
     attachments: list = field(default_factory=list)
 

--- a/escalated/management/commands/escalated_import.py
+++ b/escalated/management/commands/escalated_import.py
@@ -22,10 +22,8 @@ Usage examples::
 """
 
 import json
-import sys
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from escalated.models import ImportJob
@@ -100,18 +98,13 @@ class Command(BaseCommand):
         # ------------------------------------------------------------------
         platform = options.get("platform")
         if not platform:
-            raise CommandError(
-                _("Please provide a platform slug, e.g.: escalated_import zendesk")
-            )
+            raise CommandError(_("Please provide a platform slug, e.g.: escalated_import zendesk"))
 
         adapter = service.resolve_adapter(platform)
         if not adapter:
             available = [a.name() for a in service.available_adapters()]
             raise CommandError(
-                _(
-                    "No adapter found for platform '%(platform)s'. "
-                    "Available: %(available)s"
-                )
+                _("No adapter found for platform '%(platform)s'. Available: %(available)s")
                 % {"platform": platform, "available": ", ".join(available) or "(none)"}
             )
 
@@ -122,9 +115,7 @@ class Command(BaseCommand):
             status="pending",
             credentials=credentials,
         )
-        self.stdout.write(
-            self.style.SUCCESS(_("Created import job %(id)s.") % {"id": job.id})
-        )
+        self.stdout.write(self.style.SUCCESS(_("Created import job %(id)s.") % {"id": job.id}))
 
         # Test connection
         job.transition_to("authenticating")
@@ -158,8 +149,7 @@ class Command(BaseCommand):
             failed = progress_data.get("failed", 0)
             pct = f"{processed / total * 100:.1f}%" if total else "?"
             self.stdout.write(
-                f"  {entity_type}: {processed}/{total} ({pct}) "
-                f"skipped={skipped} failed={failed}",
+                f"  {entity_type}: {processed}/{total} ({pct}) skipped={skipped} failed={failed}",
                 ending="\r",
             )
             self.stdout.flush()
@@ -173,18 +163,9 @@ class Command(BaseCommand):
         job.refresh_from_db()
 
         if job.status == "paused":
-            self.stdout.write(
-                self.style.WARNING(
-                    _("\nImport paused. Resume with: "
-                      "--resume=%(id)s") % {"id": job.id}
-                )
-            )
+            self.stdout.write(self.style.WARNING(_("\nImport paused. Resume with: --resume=%(id)s") % {"id": job.id}))
         else:
-            self.stdout.write(
-                self.style.SUCCESS(
-                    _("\nImport completed successfully (job %(id)s).") % {"id": job.id}
-                )
-            )
+            self.stdout.write(self.style.SUCCESS(_("\nImport completed successfully (job %(id)s).") % {"id": job.id}))
             for entity_type, progress_data in (job.progress or {}).items():
                 self.stdout.write(
                     f"  {entity_type}: "
@@ -201,10 +182,7 @@ class Command(BaseCommand):
 
         if not job.is_resumable():
             raise CommandError(
-                _(
-                    "Job %(id)s is not resumable (status: %(status)s). "
-                    "Only 'paused' or 'failed' jobs can be resumed."
-                )
+                _("Job %(id)s is not resumable (status: %(status)s). Only 'paused' or 'failed' jobs can be resumed.")
                 % {"id": job_uuid, "status": job.status}
             )
 
@@ -220,9 +198,7 @@ class Command(BaseCommand):
             self.stdout.write(_("No import jobs found."))
             return
 
-        self.stdout.write(
-            f"{'ID':<38}  {'Platform':<15}  {'Status':<15}  {'Created'}"
-        )
+        self.stdout.write(f"{'ID':<38}  {'Platform':<15}  {'Status':<15}  {'Created'}")
         self.stdout.write("-" * 90)
         for job in jobs:
             self.stdout.write(
@@ -236,9 +212,7 @@ class Command(BaseCommand):
         except ImportJob.DoesNotExist:
             raise CommandError(_("ImportJob '%(id)s' not found.") % {"id": job_uuid})
 
-        self.stdout.write(
-            json.dumps(job.field_mappings or {}, indent=2, default=str)
-        )
+        self.stdout.write(json.dumps(job.field_mappings or {}, indent=2, default=str))
 
     def _parse_credentials(self, options: dict, adapter) -> dict:
         """
@@ -249,9 +223,7 @@ class Command(BaseCommand):
             try:
                 return json.loads(options["credentials"])
             except json.JSONDecodeError as exc:
-                raise CommandError(
-                    _("Invalid JSON for --credentials: %(err)s") % {"err": exc}
-                )
+                raise CommandError(_("Invalid JSON for --credentials: %(err)s") % {"err": exc})
 
         # Fall back: prompt interactively for each declared credential field
         creds = {}
@@ -262,6 +234,7 @@ class Command(BaseCommand):
 
             if is_secret:
                 import getpass
+
                 value = getpass.getpass(f"{label}: ")
             else:
                 value = input(f"{label}: ")

--- a/escalated/management/commands/evaluate_escalations.py
+++ b/escalated/management/commands/evaluate_escalations.py
@@ -13,8 +13,5 @@ class Command(BaseCommand):
         actions_taken = EscalationService.evaluate_all()
 
         self.stdout.write(
-            self.style.SUCCESS(
-                _("Escalation evaluation complete: %(count)d actions taken.")
-                % {"count": actions_taken}
-            )
+            self.style.SUCCESS(_("Escalation evaluation complete: %(count)d actions taken.") % {"count": actions_taken})
         )

--- a/escalated/management/commands/install.py
+++ b/escalated/management/commands/install.py
@@ -47,10 +47,18 @@ class Command(BaseCommand):
                 description="Default SLA policy",
                 is_default=True,
                 first_response_hours={
-                    "low": 24, "medium": 8, "high": 4, "urgent": 1, "critical": 0.5,
+                    "low": 24,
+                    "medium": 8,
+                    "high": 4,
+                    "urgent": 1,
+                    "critical": 0.5,
                 },
                 resolution_hours={
-                    "low": 72, "medium": 24, "high": 8, "urgent": 4, "critical": 2,
+                    "low": 72,
+                    "medium": 24,
+                    "high": 8,
+                    "urgent": 4,
+                    "critical": 2,
                 },
             )
             self.stdout.write(self.style.SUCCESS(_("Created default SLA policy.")))

--- a/escalated/management/commands/poll_imap.py
+++ b/escalated/management/commands/poll_imap.py
@@ -9,10 +9,7 @@ logger = logging.getLogger("escalated")
 
 
 class Command(BaseCommand):
-    help = (
-        "Poll an IMAP mailbox for new inbound emails and process them as "
-        "tickets or replies."
-    )
+    help = "Poll an IMAP mailbox for new inbound emails and process them as tickets or replies."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -32,29 +29,21 @@ class Command(BaseCommand):
         if not get_setting("INBOUND_EMAIL_ENABLED"):
             self.stderr.write(
                 self.style.ERROR(
-                    "Inbound email processing is disabled. "
-                    "Set ESCALATED['INBOUND_EMAIL_ENABLED'] = True in settings."
+                    "Inbound email processing is disabled. Set ESCALATED['INBOUND_EMAIL_ENABLED'] = True in settings."
                 )
             )
             return
 
         host = get_setting("IMAP_HOST")
         if not host:
-            self.stderr.write(
-                self.style.ERROR(
-                    "IMAP host not configured. "
-                    "Set ESCALATED['IMAP_HOST'] in settings."
-                )
-            )
+            self.stderr.write(self.style.ERROR("IMAP host not configured. Set ESCALATED['IMAP_HOST'] in settings."))
             return
 
         continuous = options["continuous"]
         interval = options["interval"]
 
         if continuous:
-            self.stdout.write(
-                f"Starting continuous IMAP polling (interval: {interval}s)..."
-            )
+            self.stdout.write(f"Starting continuous IMAP polling (interval: {interval}s)...")
             while True:
                 try:
                     self._poll_once()
@@ -62,9 +51,7 @@ class Command(BaseCommand):
                     self.stdout.write("\nStopping IMAP polling.")
                     break
                 except Exception as exc:
-                    self.stderr.write(
-                        self.style.ERROR(f"Error during IMAP poll: {exc}")
-                    )
+                    self.stderr.write(self.style.ERROR(f"Error during IMAP poll: {exc}"))
                     logger.exception("Error during IMAP poll")
 
                 time.sleep(interval)
@@ -99,22 +86,11 @@ class Command(BaseCommand):
             inbound = InboundEmailService.process(message, adapter_name="imap")
             if inbound.status == "processed":
                 processed += 1
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        f"  Processed: {message.from_email} - {message.subject}"
-                    )
-                )
+                self.stdout.write(self.style.SUCCESS(f"  Processed: {message.from_email} - {message.subject}"))
             else:
                 failed += 1
                 self.stdout.write(
-                    self.style.ERROR(
-                        f"  Failed: {message.from_email} - {message.subject}"
-                        f" ({inbound.error_message})"
-                    )
+                    self.style.ERROR(f"  Failed: {message.from_email} - {message.subject} ({inbound.error_message})")
                 )
 
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"IMAP poll complete: {processed} processed, {failed} failed."
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(f"IMAP poll complete: {processed} processed, {failed} failed."))

--- a/escalated/management/commands/purge_activities.py
+++ b/escalated/management/commands/purge_activities.py
@@ -31,9 +31,7 @@ class Command(BaseCommand):
         count = old_activities.count()
 
         if dry_run:
-            self.stdout.write(
-                f"[DRY RUN] Would purge {count} activities older than {days} days."
-            )
+            self.stdout.write(f"[DRY RUN] Would purge {count} activities older than {days} days.")
             return
 
         if count == 0:
@@ -42,8 +40,4 @@ class Command(BaseCommand):
 
         deleted, _ = old_activities.delete()
 
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"Purged {deleted} activity records older than {days} days."
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(f"Purged {deleted} activity records older than {days} days."))

--- a/escalated/management/commands/purge_expired_data.py
+++ b/escalated/management/commands/purge_expired_data.py
@@ -72,6 +72,4 @@ class Command(BaseCommand):
         if total_purged == 0:
             self.stdout.write("No expired data to purge.")
         else:
-            self.stdout.write(
-                self.style.SUCCESS(f"Purge complete: {total_purged} total records removed.")
-            )
+            self.stdout.write(self.style.SUCCESS(f"Purge complete: {total_purged} total records removed."))

--- a/escalated/management/commands/run_automations.py
+++ b/escalated/management/commands/run_automations.py
@@ -14,7 +14,5 @@ class Command(BaseCommand):
         count = runner.run()
 
         self.stdout.write(
-            self.style.SUCCESS(
-                _("Automations complete: %(count)d ticket(s) affected") % {"count": count}
-            )
+            self.style.SUCCESS(_("Automations complete: %(count)d ticket(s) affected") % {"count": count})
         )

--- a/escalated/management/commands/seed_permissions.py
+++ b/escalated/management/commands/seed_permissions.py
@@ -18,7 +18,12 @@ PERMISSIONS = [
     # Tickets
     {"slug": "ticket.view", "name": "View tickets", "group": "Tickets", "description": "View tickets"},
     {"slug": "ticket.create", "name": "Create tickets", "group": "Tickets", "description": "Create tickets"},
-    {"slug": "ticket.edit", "name": "Edit ticket properties", "group": "Tickets", "description": "Edit ticket properties"},
+    {
+        "slug": "ticket.edit",
+        "name": "Edit ticket properties",
+        "group": "Tickets",
+        "description": "Edit ticket properties",
+    },
     {"slug": "ticket.delete", "name": "Delete tickets", "group": "Tickets", "description": "Delete tickets"},
     {"slug": "ticket.assign", "name": "Assign tickets", "group": "Tickets", "description": "Assign tickets to agents"},
     {"slug": "ticket.merge", "name": "Merge tickets", "group": "Tickets", "description": "Merge tickets together"},
@@ -26,7 +31,12 @@ PERMISSIONS = [
     {"slug": "ticket.export", "name": "Export tickets", "group": "Tickets", "description": "Export ticket data"},
     # Replies
     {"slug": "reply.create", "name": "Reply to tickets", "group": "Replies", "description": "Reply to tickets"},
-    {"slug": "reply.create_internal", "name": "Add internal notes", "group": "Replies", "description": "Add internal notes"},
+    {
+        "slug": "reply.create_internal",
+        "name": "Add internal notes",
+        "group": "Replies",
+        "description": "Add internal notes",
+    },
     {"slug": "reply.edit", "name": "Edit replies", "group": "Replies", "description": "Edit replies"},
     {"slug": "reply.delete", "name": "Delete replies", "group": "Replies", "description": "Delete replies"},
     # Knowledge Base
@@ -34,58 +44,153 @@ PERMISSIONS = [
     {"slug": "kb.create", "name": "Create articles", "group": "Knowledge Base", "description": "Create articles"},
     {"slug": "kb.edit", "name": "Edit articles", "group": "Knowledge Base", "description": "Edit articles"},
     {"slug": "kb.delete", "name": "Delete articles", "group": "Knowledge Base", "description": "Delete articles"},
-    {"slug": "kb.publish", "name": "Publish articles", "group": "Knowledge Base", "description": "Publish/unpublish articles"},
+    {
+        "slug": "kb.publish",
+        "name": "Publish articles",
+        "group": "Knowledge Base",
+        "description": "Publish/unpublish articles",
+    },
     # Departments
     {"slug": "department.view", "name": "View departments", "group": "Departments", "description": "View departments"},
-    {"slug": "department.create", "name": "Create departments", "group": "Departments", "description": "Create departments"},
+    {
+        "slug": "department.create",
+        "name": "Create departments",
+        "group": "Departments",
+        "description": "Create departments",
+    },
     {"slug": "department.edit", "name": "Edit departments", "group": "Departments", "description": "Edit departments"},
-    {"slug": "department.delete", "name": "Delete departments", "group": "Departments", "description": "Delete departments"},
+    {
+        "slug": "department.delete",
+        "name": "Delete departments",
+        "group": "Departments",
+        "description": "Delete departments",
+    },
     # Reports
     {"slug": "report.view", "name": "View reports", "group": "Reports", "description": "View reports and analytics"},
     {"slug": "report.export", "name": "Export reports", "group": "Reports", "description": "Export report data"},
     # SLA
     {"slug": "sla.view", "name": "View SLA policies", "group": "SLA", "description": "View SLA policies"},
-    {"slug": "sla.manage", "name": "Manage SLA policies", "group": "SLA", "description": "Create, edit, delete SLA policies"},
+    {
+        "slug": "sla.manage",
+        "name": "Manage SLA policies",
+        "group": "SLA",
+        "description": "Create, edit, delete SLA policies",
+    },
     # Automations
     {"slug": "automation.view", "name": "View automations", "group": "Automations", "description": "View automations"},
-    {"slug": "automation.manage", "name": "Manage automations", "group": "Automations", "description": "Create, edit, delete automations"},
+    {
+        "slug": "automation.manage",
+        "name": "Manage automations",
+        "group": "Automations",
+        "description": "Create, edit, delete automations",
+    },
     # Escalation Rules
-    {"slug": "escalation.view", "name": "View escalation rules", "group": "Escalation Rules", "description": "View escalation rules"},
-    {"slug": "escalation.manage", "name": "Manage escalation rules", "group": "Escalation Rules", "description": "Create, edit, delete escalation rules"},
+    {
+        "slug": "escalation.view",
+        "name": "View escalation rules",
+        "group": "Escalation Rules",
+        "description": "View escalation rules",
+    },
+    {
+        "slug": "escalation.manage",
+        "name": "Manage escalation rules",
+        "group": "Escalation Rules",
+        "description": "Create, edit, delete escalation rules",
+    },
     # Macros
     {"slug": "macro.view", "name": "View macros", "group": "Macros", "description": "View macros"},
     {"slug": "macro.create", "name": "Create macros", "group": "Macros", "description": "Create personal macros"},
-    {"slug": "macro.manage", "name": "Manage macros", "group": "Macros", "description": "Create, edit, delete shared macros"},
+    {
+        "slug": "macro.manage",
+        "name": "Manage macros",
+        "group": "Macros",
+        "description": "Create, edit, delete shared macros",
+    },
     # Tags
     {"slug": "tag.view", "name": "View tags", "group": "Tags", "description": "View tags"},
     {"slug": "tag.manage", "name": "Manage tags", "group": "Tags", "description": "Create, edit, delete tags"},
     # Custom Fields
-    {"slug": "custom_field.view", "name": "View custom fields", "group": "Custom Fields", "description": "View custom fields"},
-    {"slug": "custom_field.manage", "name": "Manage custom fields", "group": "Custom Fields", "description": "Create, edit, delete custom fields"},
+    {
+        "slug": "custom_field.view",
+        "name": "View custom fields",
+        "group": "Custom Fields",
+        "description": "View custom fields",
+    },
+    {
+        "slug": "custom_field.manage",
+        "name": "Manage custom fields",
+        "group": "Custom Fields",
+        "description": "Create, edit, delete custom fields",
+    },
     # Roles
     {"slug": "role.view", "name": "View roles", "group": "Roles", "description": "View roles"},
-    {"slug": "role.manage", "name": "Manage roles", "group": "Roles", "description": "Create, edit, delete roles and assign permissions"},
+    {
+        "slug": "role.manage",
+        "name": "Manage roles",
+        "group": "Roles",
+        "description": "Create, edit, delete roles and assign permissions",
+    },
     # Users
     {"slug": "user.view", "name": "View users", "group": "Users", "description": "View user profiles"},
-    {"slug": "user.manage", "name": "Manage users", "group": "Users", "description": "Manage user accounts and agent profiles"},
+    {
+        "slug": "user.manage",
+        "name": "Manage users",
+        "group": "Users",
+        "description": "Manage user accounts and agent profiles",
+    },
     # Settings
     {"slug": "settings.view", "name": "View settings", "group": "Settings", "description": "View settings"},
-    {"slug": "settings.manage", "name": "Manage settings", "group": "Settings", "description": "Manage system settings"},
+    {
+        "slug": "settings.manage",
+        "name": "Manage settings",
+        "group": "Settings",
+        "description": "Manage system settings",
+    },
     # Webhooks
     {"slug": "webhook.view", "name": "View webhooks", "group": "Webhooks", "description": "View webhooks"},
-    {"slug": "webhook.manage", "name": "Manage webhooks", "group": "Webhooks", "description": "Create, edit, delete webhooks"},
+    {
+        "slug": "webhook.manage",
+        "name": "Manage webhooks",
+        "group": "Webhooks",
+        "description": "Create, edit, delete webhooks",
+    },
     # API Tokens
     {"slug": "api_token.view", "name": "View API tokens", "group": "API Tokens", "description": "View API tokens"},
-    {"slug": "api_token.manage", "name": "Manage API tokens", "group": "API Tokens", "description": "Create, revoke API tokens"},
+    {
+        "slug": "api_token.manage",
+        "name": "Manage API tokens",
+        "group": "API Tokens",
+        "description": "Create, revoke API tokens",
+    },
     # Audit Log
     {"slug": "audit.view", "name": "View audit log", "group": "Audit Log", "description": "View audit log"},
     # Plugins
     {"slug": "plugin.view", "name": "View plugins", "group": "Plugins", "description": "View plugins"},
-    {"slug": "plugin.manage", "name": "Manage plugins", "group": "Plugins", "description": "Install, configure, remove plugins"},
+    {
+        "slug": "plugin.manage",
+        "name": "Manage plugins",
+        "group": "Plugins",
+        "description": "Install, configure, remove plugins",
+    },
     # Custom Objects
-    {"slug": "custom_object.view", "name": "View custom objects", "group": "Custom Objects", "description": "View custom objects"},
-    {"slug": "custom_object.manage", "name": "Manage custom objects", "group": "Custom Objects", "description": "Create, edit, delete custom object schemas"},
-    {"slug": "custom_object.data", "name": "Manage custom object data", "group": "Custom Objects", "description": "Manage custom object records"},
+    {
+        "slug": "custom_object.view",
+        "name": "View custom objects",
+        "group": "Custom Objects",
+        "description": "View custom objects",
+    },
+    {
+        "slug": "custom_object.manage",
+        "name": "Manage custom objects",
+        "group": "Custom Objects",
+        "description": "Create, edit, delete custom object schemas",
+    },
+    {
+        "slug": "custom_object.data",
+        "name": "Manage custom object data",
+        "group": "Custom Objects",
+        "description": "Manage custom object records",
+    },
 ]
 
 ROLES = [
@@ -194,9 +299,7 @@ class Command(BaseCommand):
                 if updated:
                     permission.save()
 
-        self.stdout.write(
-            self.style.SUCCESS(f"Seeded {len(PERMISSIONS)} permissions.")
-        )
+        self.stdout.write(self.style.SUCCESS(f"Seeded {len(PERMISSIONS)} permissions."))
 
     def _seed_roles(self):
         slug_to_permission = {p.slug: p for p in Permission.objects.all()}
@@ -216,13 +319,7 @@ class Command(BaseCommand):
             role.is_system = True
             role.save()
 
-            resolved = resolve_permissions(
-                definition["permissions"], slug_to_permission
-            )
+            resolved = resolve_permissions(definition["permissions"], slug_to_permission)
             role.permissions.set(resolved)
 
-            self.stdout.write(
-                self.style.SUCCESS(
-                    f'Role "{role.name}" synced with {len(resolved)} permissions.'
-                )
-            )
+            self.stdout.write(self.style.SUCCESS(f'Role "{role.name}" synced with {len(resolved)} permissions.'))

--- a/escalated/middleware.py
+++ b/escalated/middleware.py
@@ -2,7 +2,7 @@ from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
-from escalated.permissions import is_agent, is_admin
+from escalated.permissions import is_admin, is_agent
 
 
 class EnsureAgentMiddleware:
@@ -22,9 +22,7 @@ class EnsureAgentMiddleware:
             return HttpResponseRedirect(reverse("login"))
 
         if not is_agent(request.user) and not is_admin(request.user):
-            return HttpResponseForbidden(
-                _("You do not have permission to access the agent dashboard.")
-            )
+            return HttpResponseForbidden(_("You do not have permission to access the agent dashboard."))
 
         return None
 
@@ -46,9 +44,7 @@ class EnsureAdminMiddleware:
             return HttpResponseRedirect(reverse("login"))
 
         if not is_admin(request.user):
-            return HttpResponseForbidden(
-                _("You do not have permission to access the admin area.")
-            )
+            return HttpResponseForbidden(_("You do not have permission to access the admin area."))
 
         return None
 

--- a/escalated/migrations/0001_initial.py
+++ b/escalated/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [
@@ -68,14 +67,16 @@ class Migration(migrations.Migration):
                     "first_response_hours",
                     models.JSONField(
                         default=dict,
-                        help_text='Map of priority to hours, e.g. {"low": 24, "medium": 8, "high": 4, "urgent": 1, "critical": 0.5}',
+                        help_text="Map of priority to hours, e.g."
+                        ' {"low": 24, "medium": 8, "high": 4, "urgent": 1, "critical": 0.5}',
                     ),
                 ),
                 (
                     "resolution_hours",
                     models.JSONField(
                         default=dict,
-                        help_text='Map of priority to hours, e.g. {"low": 72, "medium": 24, "high": 8, "urgent": 4, "critical": 2}',
+                        help_text="Map of priority to hours, e.g."
+                        ' {"low": 72, "medium": 24, "high": 8, "urgent": 4, "critical": 2}',
                     ),
                 ),
                 ("business_hours_only", models.BooleanField(default=False)),
@@ -235,9 +236,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "tags",
-                    models.ManyToManyField(
-                        blank=True, related_name="tickets", to="escalated.tag"
-                    ),
+                    models.ManyToManyField(blank=True, related_name="tickets", to="escalated.tag"),
                 ),
             ],
             options={
@@ -247,33 +246,23 @@ class Migration(migrations.Migration):
         ),
         migrations.AddIndex(
             model_name="ticket",
-            index=models.Index(
-                fields=["status"], name="escalated_t_status_idx"
-            ),
+            index=models.Index(fields=["status"], name="escalated_t_status_idx"),
         ),
         migrations.AddIndex(
             model_name="ticket",
-            index=models.Index(
-                fields=["priority"], name="escalated_t_priority_idx"
-            ),
+            index=models.Index(fields=["priority"], name="escalated_t_priority_idx"),
         ),
         migrations.AddIndex(
             model_name="ticket",
-            index=models.Index(
-                fields=["reference"], name="escalated_t_reference_idx"
-            ),
+            index=models.Index(fields=["reference"], name="escalated_t_reference_idx"),
         ),
         migrations.AddIndex(
             model_name="ticket",
-            index=models.Index(
-                fields=["assigned_to"], name="escalated_t_assigned_idx"
-            ),
+            index=models.Index(fields=["assigned_to"], name="escalated_t_assigned_idx"),
         ),
         migrations.AddIndex(
             model_name="ticket",
-            index=models.Index(
-                fields=["created_at"], name="escalated_t_created_idx"
-            ),
+            index=models.Index(fields=["created_at"], name="escalated_t_created_idx"),
         ),
         # Reply
         migrations.CreateModel(
@@ -355,9 +344,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "size",
-                    models.PositiveIntegerField(
-                        default=0, help_text="File size in bytes"
-                    ),
+                    models.PositiveIntegerField(default=0, help_text="File size in bytes"),
                 ),
                 ("created_at", models.DateTimeField(auto_now_add=True)),
                 ("updated_at", models.DateTimeField(auto_now=True)),

--- a/escalated/migrations/0002_settings_and_guest_tickets.py
+++ b/escalated/migrations/0002_settings_and_guest_tickets.py
@@ -18,7 +18,6 @@ def seed_default_settings(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("escalated", "0001_initial"),
     ]

--- a/escalated/migrations/0003_inboundemail.py
+++ b/escalated/migrations/0003_inboundemail.py
@@ -5,7 +5,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("escalated", "0002_settings_and_guest_tickets"),
     ]
@@ -25,9 +24,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "message_id",
-                    models.CharField(
-                        blank=True, max_length=500, null=True, unique=True
-                    ),
+                    models.CharField(blank=True, max_length=500, null=True, unique=True),
                 ),
                 ("from_email", models.CharField(max_length=500)),
                 (
@@ -88,20 +85,14 @@ class Migration(migrations.Migration):
         ),
         migrations.AddIndex(
             model_name="inboundemail",
-            index=models.Index(
-                fields=["status"], name="escalated_ie_status_idx"
-            ),
+            index=models.Index(fields=["status"], name="escalated_ie_status_idx"),
         ),
         migrations.AddIndex(
             model_name="inboundemail",
-            index=models.Index(
-                fields=["from_email"], name="escalated_ie_from_idx"
-            ),
+            index=models.Index(fields=["from_email"], name="escalated_ie_from_idx"),
         ),
         migrations.AddIndex(
             model_name="inboundemail",
-            index=models.Index(
-                fields=["message_id"], name="escalated_ie_msgid_idx"
-            ),
+            index=models.Index(fields=["message_id"], name="escalated_ie_msgid_idx"),
         ),
     ]

--- a/escalated/migrations/0004_v040_advanced_features.py
+++ b/escalated/migrations/0004_v040_advanced_features.py
@@ -6,7 +6,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("contenttypes", "0002_remove_content_type_name"),

--- a/escalated/migrations/0005_api_tokens.py
+++ b/escalated/migrations/0005_api_tokens.py
@@ -6,7 +6,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("contenttypes", "0002_remove_content_type_name"),

--- a/escalated/migrations/0005_escalatedplugin.py
+++ b/escalated/migrations/0005_escalatedplugin.py
@@ -8,7 +8,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("escalated", "0004_v040_advanced_features"),
     ]

--- a/escalated/migrations/0006_merge_api_tokens_and_plugins.py
+++ b/escalated/migrations/0006_merge_api_tokens_and_plugins.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("escalated", "0005_api_tokens"),
         ("escalated", "0005_escalatedplugin"),

--- a/escalated/migrations/0007_platform_parity_phase1.py
+++ b/escalated/migrations/0007_platform_parity_phase1.py
@@ -6,7 +6,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("escalated", "0006_merge_api_tokens_and_plugins"),

--- a/escalated/migrations/0008_platform_parity_phase2.py
+++ b/escalated/migrations/0008_platform_parity_phase2.py
@@ -6,7 +6,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("escalated", "0007_platform_parity_phase1"),

--- a/escalated/migrations/0009_platform_parity_phase3_5.py
+++ b/escalated/migrations/0009_platform_parity_phase3_5.py
@@ -6,7 +6,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("escalated", "0008_platform_parity_phase2"),

--- a/escalated/migrations/0010_import_framework.py
+++ b/escalated/migrations/0010_import_framework.py
@@ -14,7 +14,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("escalated", "0009_platform_parity_phase3_5"),
     ]

--- a/escalated/migrations/0011_plugin_bridge_store.py
+++ b/escalated/migrations/0011_plugin_bridge_store.py
@@ -11,7 +11,6 @@ from escalated.conf import get_table_name
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("escalated", "0010_import_framework"),
     ]

--- a/escalated/migrations/0012_ticket_type_field.py
+++ b/escalated/migrations/0012_ticket_type_field.py
@@ -1,8 +1,7 @@
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("escalated", "0011_plugin_bridge_store"),
     ]

--- a/escalated/migrations/0013_plugin_metadata_fields.py
+++ b/escalated/migrations/0013_plugin_metadata_fields.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("escalated", "0012_ticket_type_field"),
     ]

--- a/escalated/mixins.py
+++ b/escalated/mixins.py
@@ -93,9 +93,11 @@ class AuditableMixin:
     @staticmethod
     def _get_current_request():
         try:
-            from django.middleware.common import CommonMiddleware  # noqa: F401
             import threading
+
+            from django.middleware.common import CommonMiddleware  # noqa: F401
+
             # Fall back to None if no request middleware is available
-            return getattr(threading.current_thread(), '_escalated_request', None)
+            return getattr(threading.current_thread(), "_escalated_request", None)
         except Exception:
             return None

--- a/escalated/models.py
+++ b/escalated/models.py
@@ -1,7 +1,6 @@
 import hashlib
 import secrets
 import uuid
-from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
@@ -12,7 +11,6 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from escalated.conf import get_table_name
-
 
 # ---------------------------------------------------------------------------
 # Managers / QuerySets
@@ -42,16 +40,10 @@ class TicketQuerySet(models.QuerySet):
         return self.filter(assigned_to_id=user_id)
 
     def breached_sla(self):
-        return self.filter(
-            Q(sla_first_response_breached=True) | Q(sla_resolution_breached=True)
-        )
+        return self.filter(Q(sla_first_response_breached=True) | Q(sla_resolution_breached=True))
 
     def search(self, term):
-        return self.filter(
-            Q(subject__icontains=term)
-            | Q(description__icontains=term)
-            | Q(reference__icontains=term)
-        )
+        return self.filter(Q(subject__icontains=term) | Q(description__icontains=term) | Q(reference__icontains=term))
 
     def by_department(self, department_id):
         return self.filter(department_id=department_id)
@@ -227,23 +219,20 @@ class Ticket(models.Model):
     guest_name = models.CharField(max_length=255, null=True, blank=True)
     guest_email = models.EmailField(null=True, blank=True)
     guest_token = models.CharField(
-        max_length=64, null=True, blank=True, unique=True,
+        max_length=64,
+        null=True,
+        blank=True,
+        unique=True,
         help_text=_("Unique token for guest ticket access"),
     )
 
     subject = models.CharField(max_length=500)
     description = models.TextField()
-    status = models.CharField(
-        max_length=30, choices=Status.choices, default=Status.OPEN
-    )
-    priority = models.CharField(
-        max_length=20, choices=Priority.choices, default=Priority.MEDIUM
-    )
+    status = models.CharField(max_length=30, choices=Status.choices, default=Status.OPEN)
+    priority = models.CharField(max_length=20, choices=Priority.choices, default=Priority.MEDIUM)
     channel = models.CharField(max_length=50, default="web")
     reference = models.CharField(max_length=20, unique=True, editable=False)
-    ticket_type = models.CharField(
-        max_length=50, choices=TicketType.choices, default=TicketType.QUESTION
-    )
+    ticket_type = models.CharField(max_length=50, choices=TicketType.choices, default=TicketType.QUESTION)
     merged_into = models.ForeignKey(
         "self",
         on_delete=models.SET_NULL,
@@ -402,9 +391,7 @@ class Reply(models.Model):
         NOTE = "note", _("Internal Note")
         SYSTEM = "system", _("System")
 
-    ticket = models.ForeignKey(
-        Ticket, on_delete=models.CASCADE, related_name="replies"
-    )
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, related_name="replies")
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -452,9 +439,7 @@ class Attachment(models.Model):
     file = models.FileField(upload_to="escalated/attachments/%Y/%m/")
     original_filename = models.CharField(max_length=500)
     mime_type = models.CharField(max_length=255, blank=True, default="")
-    size = models.PositiveIntegerField(
-        default=0, help_text=_("File size in bytes")
-    )
+    size = models.PositiveIntegerField(default=0, help_text=_("File size in bytes"))
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -542,9 +527,7 @@ class TicketActivity(models.Model):
         ATTACHMENT_ADDED = "attachment_added", _("Attachment Added")
         MERGED = "merged", _("Merged")
 
-    ticket = models.ForeignKey(
-        Ticket, on_delete=models.CASCADE, related_name="activities"
-    )
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, related_name="activities")
 
     # Causer via GenericForeignKey
     causer_content_type = models.ForeignKey(
@@ -595,9 +578,7 @@ class EscalatedSetting(models.Model):
     @classmethod
     def set(cls, key, value):
         """Set a setting value by key."""
-        obj, _ = cls.objects.update_or_create(
-            key=key, defaults={"value": str(value) if value is not None else None}
-        )
+        obj, _ = cls.objects.update_or_create(key=key, defaults={"value": str(value) if value is not None else None})
         return obj
 
     @classmethod
@@ -750,9 +731,7 @@ class InboundEmail(models.Model):
         related_name="inbound_emails",
     )
 
-    status = models.CharField(
-        max_length=20, choices=Status.choices, default=Status.PENDING
-    )
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.PENDING)
     adapter = models.CharField(max_length=50)
     error_message = models.TextField(null=True, blank=True)
     processed_at = models.DateTimeField(null=True, blank=True)
@@ -778,9 +757,15 @@ class InboundEmail(models.Model):
         self.ticket = ticket
         self.reply = reply
         self.processed_at = timezone.now()
-        self.save(update_fields=[
-            "status", "ticket", "reply", "processed_at", "updated_at",
-        ])
+        self.save(
+            update_fields=[
+                "status",
+                "ticket",
+                "reply",
+                "processed_at",
+                "updated_at",
+            ]
+        )
 
     def mark_failed(self, error_message):
         """Mark this inbound email as failed."""
@@ -802,9 +787,7 @@ class InboundEmail(models.Model):
 class ApiTokenQuerySet(models.QuerySet):
     def active(self):
         """Return tokens that are not expired."""
-        return self.filter(
-            Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now())
-        )
+        return self.filter(Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now()))
 
     def expired(self):
         """Return tokens that have expired."""
@@ -914,12 +897,14 @@ class AuditLog(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
-        null=True, blank=True,
+        null=True,
+        blank=True,
         related_name="escalated_audit_logs",
     )
     action = models.CharField(max_length=50)
     auditable_content_type = models.ForeignKey(
-        ContentType, on_delete=models.CASCADE,
+        ContentType,
+        on_delete=models.CASCADE,
         related_name="escalated_audit_logs",
     )
     auditable_object_id = models.PositiveIntegerField()
@@ -978,6 +963,7 @@ class TicketStatus(models.Model):
     def save(self, *args, **kwargs):
         if not self.slug:
             from django.utils.text import slugify
+
             self.slug = slugify(self.label).replace("-", "_")
         super().save(*args, **kwargs)
 
@@ -1007,7 +993,9 @@ class BusinessSchedule(models.Model):
 
 class Holiday(models.Model):
     schedule = models.ForeignKey(
-        BusinessSchedule, on_delete=models.CASCADE, related_name="holidays",
+        BusinessSchedule,
+        on_delete=models.CASCADE,
+        related_name="holidays",
     )
     name = models.CharField(max_length=255)
     date = models.DateField()
@@ -1047,11 +1035,15 @@ class Role(models.Model):
     description = models.TextField(blank=True, default="")
     is_system = models.BooleanField(default=False)
     permissions = models.ManyToManyField(
-        "Permission", related_name="roles", blank=True,
+        "Permission",
+        related_name="roles",
+        blank=True,
         db_table=get_table_name("role_permission"),
     )
     users = models.ManyToManyField(
-        settings.AUTH_USER_MODEL, related_name="escalated_roles", blank=True,
+        settings.AUTH_USER_MODEL,
+        related_name="escalated_roles",
+        blank=True,
         db_table=get_table_name("role_user"),
     )
     created_at = models.DateTimeField(auto_now_add=True)
@@ -1066,6 +1058,7 @@ class Role(models.Model):
     def save(self, *args, **kwargs):
         if not self.slug:
             from django.utils.text import slugify
+
             self.slug = slugify(self.name).replace("-", "_")
         super().save(*args, **kwargs)
 
@@ -1096,9 +1089,7 @@ class CustomField(models.Model):
     name = models.CharField(max_length=255)
     slug = models.SlugField(max_length=255, unique=True)
     type = models.CharField(max_length=50, choices=FieldType.choices)
-    context = models.CharField(
-        max_length=50, choices=Context.choices, default=Context.TICKET
-    )
+    context = models.CharField(max_length=50, choices=Context.choices, default=Context.TICKET)
     options = models.JSONField(null=True, blank=True)
     required = models.BooleanField(default=False)
     placeholder = models.CharField(max_length=255, null=True, blank=True)
@@ -1120,6 +1111,7 @@ class CustomField(models.Model):
     def save(self, *args, **kwargs):
         if not self.slug:
             from django.utils.text import slugify
+
             self.slug = slugify(self.name).replace("-", "_")
         super().save(*args, **kwargs)
 
@@ -1213,12 +1205,8 @@ class SideConversation(models.Model):
         related_name="side_conversations",
     )
     subject = models.CharField(max_length=255)
-    channel = models.CharField(
-        max_length=50, choices=Channel.choices, default=Channel.INTERNAL
-    )
-    status = models.CharField(
-        max_length=20, choices=Status.choices, default=Status.OPEN
-    )
+    channel = models.CharField(max_length=50, choices=Channel.choices, default=Channel.INTERNAL)
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.OPEN)
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -1319,10 +1307,7 @@ class ArticleQuerySet(models.QuerySet):
         return self.filter(status="draft")
 
     def search(self, term):
-        return self.filter(
-            Q(title__icontains=term)
-            | Q(body__icontains=term)
-        )
+        return self.filter(Q(title__icontains=term) | Q(body__icontains=term))
 
 
 class ArticleManager(models.Manager):
@@ -1354,9 +1339,7 @@ class Article(models.Model):
     title = models.CharField(max_length=255)
     slug = models.SlugField(max_length=255, unique=True)
     body = models.TextField(blank=True, default="")
-    status = models.CharField(
-        max_length=20, choices=Status.choices, default=Status.DRAFT
-    )
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.DRAFT)
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -1475,6 +1458,7 @@ class Skill(models.Model):
     def save(self, *args, **kwargs):
         if not self.slug:
             from django.utils.text import slugify
+
             self.slug = slugify(self.name)
         super().save(*args, **kwargs)
 
@@ -1682,6 +1666,7 @@ class EncryptedJSONField(models.TextField):
     def _get_fernet(self):
         import base64
         import hashlib
+
         from cryptography.fernet import Fernet
         from django.conf import settings as django_settings
 
@@ -1695,11 +1680,13 @@ class EncryptedJSONField(models.TextField):
             return None
         if isinstance(value, str) and value.startswith(self.PREFIX):
             import json
+
             fernet = self._get_fernet()
-            decrypted = fernet.decrypt(value[len(self.PREFIX):].encode()).decode()
+            decrypted = fernet.decrypt(value[len(self.PREFIX) :].encode()).decode()
             return json.loads(decrypted)
         # Legacy plain JSON (shouldn't happen in prod, but handles dev fixtures)
         import json
+
         try:
             return json.loads(value)
         except Exception:
@@ -1714,6 +1701,7 @@ class EncryptedJSONField(models.TextField):
         if value is None:
             return None
         import json
+
         fernet = self._get_fernet()
         plaintext = json.dumps(value).encode()
         token = fernet.encrypt(plaintext).decode()
@@ -1791,9 +1779,7 @@ class ImportJob(models.Model):
         allowed = self.VALID_TRANSITIONS.get(current, [])
 
         if new_status not in allowed:
-            raise ValueError(
-                f"Cannot transition ImportJob from '{current}' to '{new_status}'."
-            )
+            raise ValueError(f"Cannot transition ImportJob from '{current}' to '{new_status}'.")
 
         self.status = new_status
         self.save(update_fields=["status", "updated_at"])
@@ -1814,9 +1800,16 @@ class ImportJob(models.Model):
     ) -> None:
         """Merge partial progress for a single entity type and save."""
         progress = dict(self.progress or {})
-        current = progress.get(entity_type, {
-            "total": 0, "processed": 0, "skipped": 0, "failed": 0, "cursor": None,
-        })
+        current = progress.get(
+            entity_type,
+            {
+                "total": 0,
+                "processed": 0,
+                "skipped": 0,
+                "failed": 0,
+                "cursor": None,
+            },
+        )
 
         if processed is not None:
             current["processed"] = processed
@@ -1841,12 +1834,14 @@ class ImportJob(models.Model):
         """Append an error entry to the log (capped at 10 000 entries)."""
         log = list(self.error_log or [])
         if len(log) < 10_000:
-            log.append({
-                "entity_type": entity_type,
-                "source_id": source_id,
-                "error": error,
-                "timestamp": timezone.now().isoformat(),
-            })
+            log.append(
+                {
+                    "entity_type": entity_type,
+                    "source_id": source_id,
+                    "error": error,
+                    "timestamp": timezone.now().isoformat(),
+                }
+            )
             self.error_log = log
             self.save(update_fields=["error_log", "updated_at"])
 
@@ -1897,10 +1892,7 @@ class ImportSourceMap(models.Model):
         ]
 
     def __str__(self):
-        return (
-            f"ImportSourceMap({self.entity_type} "
-            f"{self.source_id} → {self.escalated_id})"
-        )
+        return f"ImportSourceMap({self.entity_type} {self.source_id} → {self.escalated_id})"
 
     # ------------------------------------------------------------------
     # Class-level helpers
@@ -1912,11 +1904,15 @@ class ImportSourceMap(models.Model):
         Return the Escalated ID for a given source ID, or ``None`` if not yet
         imported.
         """
-        return cls.objects.filter(
-            import_job_id=job_id,
-            entity_type=entity_type,
-            source_id=source_id,
-        ).values_list("escalated_id", flat=True).first()
+        return (
+            cls.objects.filter(
+                import_job_id=job_id,
+                entity_type=entity_type,
+                source_id=source_id,
+            )
+            .values_list("escalated_id", flat=True)
+            .first()
+        )
 
     @classmethod
     def has_been_imported(cls, job_id, entity_type: str, source_id: str) -> bool:

--- a/escalated/permissions.py
+++ b/escalated/permissions.py
@@ -10,9 +10,7 @@ def is_agent(user):
     """
     if not user or not user.is_authenticated:
         return False
-    return Department.objects.filter(
-        agents=user, is_active=True
-    ).exists()
+    return Department.objects.filter(agents=user, is_active=True).exists()
 
 
 def is_admin(user):
@@ -41,10 +39,7 @@ def can_view_ticket(user, ticket):
 
     # Check if user is the requester
     ct = ContentType.objects.get_for_model(user)
-    if (
-        ticket.requester_content_type == ct
-        and ticket.requester_object_id == user.pk
-    ):
+    if ticket.requester_content_type == ct and ticket.requester_object_id == user.pk:
         return True
 
     # Check if user is the assigned agent
@@ -95,10 +90,7 @@ def can_reply_ticket(user, ticket):
 
     # Requester can reply
     ct = ContentType.objects.get_for_model(user)
-    if (
-        ticket.requester_content_type == ct
-        and ticket.requester_object_id == user.pk
-    ):
+    if ticket.requester_content_type == ct and ticket.requester_object_id == user.pk:
         return True
 
     if is_agent(user):
@@ -132,10 +124,7 @@ def can_close_ticket(user, ticket):
 
     if get_setting("ALLOW_CUSTOMER_CLOSE"):
         ct = ContentType.objects.get_for_model(user)
-        if (
-            ticket.requester_content_type == ct
-            and ticket.requester_object_id == user.pk
-        ):
+        if ticket.requester_content_type == ct and ticket.requester_object_id == user.pk:
             return True
 
     return False

--- a/escalated/plugin_models.py
+++ b/escalated/plugin_models.py
@@ -6,7 +6,6 @@ from django.db import models
 
 from escalated.conf import get_table_name
 
-
 # ---------------------------------------------------------------------------
 # Manager / QuerySet
 # ---------------------------------------------------------------------------

--- a/escalated/plugin_service.py
+++ b/escalated/plugin_service.py
@@ -42,9 +42,7 @@ class PluginService:
             try:
                 os.makedirs(self._plugins_path, exist_ok=True)
             except OSError:
-                logger.warning(
-                    "Could not create plugins directory: %s", self._plugins_path
-                )
+                logger.warning("Could not create plugins directory: %s", self._plugins_path)
 
     def _get_manifest(self, slug):
         """
@@ -54,7 +52,7 @@ class PluginService:
         if not os.path.isfile(manifest_path):
             return None
         try:
-            with open(manifest_path, "r", encoding="utf-8") as fh:
+            with open(manifest_path, encoding="utf-8") as fh:
                 return json.load(fh)
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Failed to read manifest for plugin '%s': %s", slug, exc)
@@ -79,7 +77,7 @@ class PluginService:
         if not os.path.isfile(manifest_path):
             return None
         try:
-            with open(manifest_path, "r", encoding="utf-8") as fh:
+            with open(manifest_path, encoding="utf-8") as fh:
                 return json.load(fh)
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Failed to read manifest for plugin '%s': %s", slug, exc)
@@ -124,40 +122,39 @@ class PluginService:
             except Exception:
                 db_plugin = None
 
-            plugins.append({
-                "slug": entry,
-                "name": manifest.get("name", entry),
-                "description": manifest.get("description", ""),
-                "version": manifest.get("version", "1.0.0"),
-                "author": manifest.get("author", "Unknown"),
-                "author_url": manifest.get("author_url", ""),
-                "requires": manifest.get("requires", "1.0.0"),
-                "main_file": manifest.get("main_file", "plugin.py"),
-                "is_active": db_plugin.is_active if db_plugin else False,
-                "activated_at": (
-                    db_plugin.activated_at.isoformat()
-                    if db_plugin and db_plugin.activated_at
-                    else None
-                ),
-                "path": plugin_dir,
-                "source": "local",
-            })
+            plugins.append(
+                {
+                    "slug": entry,
+                    "name": manifest.get("name", entry),
+                    "description": manifest.get("description", ""),
+                    "version": manifest.get("version", "1.0.0"),
+                    "author": manifest.get("author", "Unknown"),
+                    "author_url": manifest.get("author_url", ""),
+                    "requires": manifest.get("requires", "1.0.0"),
+                    "main_file": manifest.get("main_file", "plugin.py"),
+                    "is_active": db_plugin.is_active if db_plugin else False,
+                    "activated_at": (
+                        db_plugin.activated_at.isoformat() if db_plugin and db_plugin.activated_at else None
+                    ),
+                    "path": plugin_dir,
+                    "source": "local",
+                }
+            )
 
         return plugins
 
     def _get_pip_plugins(self):
         """Discover plugins installed via pip (packages with plugin.json)."""
-        from escalated.plugin_models import EscalatedPlugin
         import importlib.metadata
+
+        from escalated.plugin_models import EscalatedPlugin
 
         plugins = []
         try:
             for dist in importlib.metadata.distributions():
                 # Check if the distribution has a plugin.json at its root
                 dist_files = dist.files or []
-                has_manifest = any(
-                    str(f) == "plugin.json" for f in dist_files
-                )
+                has_manifest = any(str(f) == "plugin.json" for f in dist_files)
                 if not has_manifest:
                     continue
 
@@ -173,7 +170,7 @@ class PluginService:
 
                 directory = os.path.dirname(dist_path)
                 try:
-                    with open(dist_path, "r", encoding="utf-8") as fh:
+                    with open(dist_path, encoding="utf-8") as fh:
                         manifest = json.load(fh)
                 except (json.JSONDecodeError, OSError):
                     continue
@@ -188,24 +185,24 @@ class PluginService:
                 except Exception:
                     db_plugin = None
 
-                plugins.append({
-                    "slug": slug,
-                    "name": manifest.get("name", slug),
-                    "description": manifest.get("description", ""),
-                    "version": manifest.get("version", "1.0.0"),
-                    "author": manifest.get("author", "Unknown"),
-                    "author_url": manifest.get("author_url", ""),
-                    "requires": manifest.get("requires", "1.0.0"),
-                    "main_file": manifest.get("main_file", "plugin.py"),
-                    "is_active": db_plugin.is_active if db_plugin else False,
-                    "activated_at": (
-                        db_plugin.activated_at.isoformat()
-                        if db_plugin and db_plugin.activated_at
-                        else None
-                    ),
-                    "path": directory,
-                    "source": "composer",  # Use "composer" for consistency with frontend
-                })
+                plugins.append(
+                    {
+                        "slug": slug,
+                        "name": manifest.get("name", slug),
+                        "description": manifest.get("description", ""),
+                        "version": manifest.get("version", "1.0.0"),
+                        "author": manifest.get("author", "Unknown"),
+                        "author_url": manifest.get("author_url", ""),
+                        "requires": manifest.get("requires", "1.0.0"),
+                        "main_file": manifest.get("main_file", "plugin.py"),
+                        "is_active": db_plugin.is_active if db_plugin else False,
+                        "activated_at": (
+                            db_plugin.activated_at.isoformat() if db_plugin and db_plugin.activated_at else None
+                        ),
+                        "path": directory,
+                        "source": "composer",  # Use "composer" for consistency with frontend
+                    }
+                )
         except Exception as exc:
             logger.debug("Could not scan pip packages: %s", exc)
 
@@ -257,11 +254,19 @@ class PluginService:
             plugin.is_active = True
             plugin.activated_at = timezone.now()
             plugin.deactivated_at = None
-            plugin.save(update_fields=[
-                "name", "version", "description", "author",
-                "is_active", "activated_at", "deactivated_at",
-                "installed_at", "updated_at",
-            ])
+            plugin.save(
+                update_fields=[
+                    "name",
+                    "version",
+                    "description",
+                    "author",
+                    "is_active",
+                    "activated_at",
+                    "deactivated_at",
+                    "installed_at",
+                    "updated_at",
+                ]
+            )
 
             # Load the plugin so its hooks get registered
             self.load_plugin(slug)
@@ -355,6 +360,7 @@ class PluginService:
 
         # Save to a temp path
         import tempfile
+
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
         try:
             for chunk in uploaded_file.chunks():
@@ -375,10 +381,7 @@ class PluginService:
 
                 extract_path = os.path.join(self._plugins_path, root_folder)
                 if os.path.exists(extract_path):
-                    raise Exception(
-                        f"Plugin '{root_folder}' already exists. "
-                        "Delete it first before uploading again."
-                    )
+                    raise Exception(f"Plugin '{root_folder}' already exists. Delete it first before uploading again.")
 
                 zf.extractall(self._plugins_path)
 
@@ -386,15 +389,13 @@ class PluginService:
             manifest_path = os.path.join(extract_path, "plugin.json")
             if not os.path.isfile(manifest_path):
                 shutil.rmtree(extract_path, ignore_errors=True)
-                raise Exception(
-                    "Invalid plugin: missing plugin.json in root directory."
-                )
+                raise Exception("Invalid plugin: missing plugin.json in root directory.")
 
             # Create a DB record so the plugin appears immediately
             from escalated.plugin_models import EscalatedPlugin
 
             try:
-                with open(manifest_path, "r", encoding="utf-8") as fh:
+                with open(manifest_path, encoding="utf-8") as fh:
                     manifest = json.load(fh)
             except (json.JSONDecodeError, OSError):
                 manifest = {}
@@ -426,9 +427,10 @@ class PluginService:
         # Check pip-installed plugins
         try:
             import importlib.metadata
+
             for dist in importlib.metadata.distributions():
                 if dist.metadata["Name"] == slug:
-                    for f in (dist.files or []):
+                    for f in dist.files or []:
                         if str(f) == "plugin.json":
                             return os.path.dirname(str(f.locate()))
         except Exception:
@@ -462,7 +464,7 @@ class PluginService:
 
         manifest_path = os.path.join(plugin_dir, "plugin.json")
         try:
-            with open(manifest_path, "r", encoding="utf-8") as fh:
+            with open(manifest_path, encoding="utf-8") as fh:
                 manifest = json.load(fh)
         except (json.JSONDecodeError, OSError):
             logger.warning("Cannot load plugin '%s': no manifest found.", slug)
@@ -495,7 +497,7 @@ class PluginService:
                 logger.info("Plugin '%s' loaded via importlib.", slug)
             else:
                 # Fallback: exec the file directly
-                with open(plugin_file, "r", encoding="utf-8") as fh:
+                with open(plugin_file, encoding="utf-8") as fh:
                     code = fh.read()
                 exec(compile(code, plugin_file, "exec"), {"__name__": module_name})
                 logger.info("Plugin '%s' loaded via exec.", slug)

--- a/escalated/policies/__init__.py
+++ b/escalated/policies/__init__.py
@@ -28,6 +28,7 @@ def check_policy(policy_class, action, obj_arg=None, lookup_model=None, lookup_f
     If obj_arg is None, calls the policy method with just (user,).
     Otherwise resolves the object and calls with (user, obj).
     """
+
     def decorator(view_func):
         @functools.wraps(view_func)
         def wrapper(request, *args, **kwargs):
@@ -49,5 +50,7 @@ def check_policy(policy_class, action, obj_arg=None, lookup_model=None, lookup_f
             if obj is not None:
                 request.policy_object = obj
             return view_func(request, *args, **kwargs)
+
         return wrapper
+
     return decorator

--- a/escalated/policies/ticket_policy.py
+++ b/escalated/policies/ticket_policy.py
@@ -1,11 +1,11 @@
 from escalated.permissions import (
-    is_admin,
-    is_agent,
-    can_view_ticket,
-    can_update_ticket,
-    can_reply_ticket,
     can_add_note,
     can_close_ticket,
+    can_reply_ticket,
+    can_update_ticket,
+    can_view_ticket,
+    is_admin,
+    is_agent,
 )
 
 

--- a/escalated/rendering.py
+++ b/escalated/rendering.py
@@ -1,17 +1,21 @@
 from django.utils.module_loading import import_string
+
 from escalated.conf import get_setting
 
 
 class UiRenderer:
     """Abstract base for rendering UI pages."""
+
     def render(self, request, component, props=None):
         raise NotImplementedError
 
 
 class InertiaRenderer(UiRenderer):
     """Default renderer using inertia-django."""
+
     def render(self, request, component, props=None):
         from inertia import render
+
         return render(request, component, props=props or {})
 
 
@@ -28,9 +32,7 @@ def get_renderer():
         elif get_setting("UI_ENABLED"):
             _renderer_instance = InertiaRenderer()
         else:
-            raise RuntimeError(
-                "Escalated UI is disabled. Set UI_ENABLED=True or provide a custom UI_RENDERER."
-            )
+            raise RuntimeError("Escalated UI is disabled. Set UI_ENABLED=True or provide a custom UI_RENDERER.")
     return _renderer_instance
 
 

--- a/escalated/serializers.py
+++ b/escalated/serializers.py
@@ -3,8 +3,6 @@ Dict-based serializers for converting Django model instances to plain dicts
 suitable for Inertia.js props. No DRF dependency required.
 """
 
-from django.utils.formats import date_format
-
 
 def _format_dt(dt):
     """Format a datetime for JSON output, or return None."""
@@ -38,19 +36,9 @@ class TicketSerializer:
             "priority_display": ticket.get_priority_display(),
             "channel": ticket.channel,
             "assigned_to": _user_dict(ticket.assigned_to),
-            "department": (
-                DepartmentSerializer.serialize(ticket.department)
-                if ticket.department
-                else None
-            ),
-            "sla_policy": (
-                SlaPolicySerializer.serialize_brief(ticket.sla_policy)
-                if ticket.sla_policy
-                else None
-            ),
-            "tags": [
-                TagSerializer.serialize(tag) for tag in ticket.tags.all()
-            ],
+            "department": (DepartmentSerializer.serialize(ticket.department) if ticket.department else None),
+            "sla_policy": (SlaPolicySerializer.serialize_brief(ticket.sla_policy) if ticket.sla_policy else None),
+            "tags": [TagSerializer.serialize(tag) for tag in ticket.tags.all()],
             "is_open": ticket.is_open,
             "first_response_at": _format_dt(ticket.first_response_at),
             "first_response_due_at": _format_dt(ticket.first_response_due_at),
@@ -79,16 +67,10 @@ class TicketSerializer:
             data["requester"] = None
 
         if include_replies:
-            data["replies"] = [
-                ReplySerializer.serialize(reply)
-                for reply in ticket.replies.filter(is_deleted=False)
-            ]
+            data["replies"] = [ReplySerializer.serialize(reply) for reply in ticket.replies.filter(is_deleted=False)]
 
         if include_activities:
-            data["activities"] = [
-                ActivitySerializer.serialize(activity)
-                for activity in ticket.activities.all()[:50]
-            ]
+            data["activities"] = [ActivitySerializer.serialize(activity) for activity in ticket.activities.all()[:50]]
 
         return data
 
@@ -110,10 +92,7 @@ class ReplySerializer:
             "type": reply.type,
             "type_display": reply.get_type_display(),
             "metadata": reply.metadata,
-            "attachments": [
-                AttachmentSerializer.serialize(a)
-                for a in reply.attachments.all()
-            ],
+            "attachments": [AttachmentSerializer.serialize(a) for a in reply.attachments.all()],
             "created_at": _format_dt(reply.created_at),
             "updated_at": _format_dt(reply.updated_at),
         }
@@ -342,7 +321,7 @@ class AuditLogSerializer:
 
     @staticmethod
     def serialize_list(logs):
-        return [AuditLogSerializer.serialize(l) for l in logs]
+        return [AuditLogSerializer.serialize(log) for log in logs]
 
 
 class TicketStatusSerializer:
@@ -390,10 +369,7 @@ class BusinessScheduleSerializer:
             "updated_at": _format_dt(schedule.updated_at),
         }
         if include_holidays:
-            data["holidays"] = [
-                HolidaySerializer.serialize(h)
-                for h in schedule.holidays.all()
-            ]
+            data["holidays"] = [HolidaySerializer.serialize(h) for h in schedule.holidays.all()]
         return data
 
     @staticmethod
@@ -437,14 +413,14 @@ class RoleSerializer:
             "slug": role.slug,
             "description": role.description,
             "is_system": role.is_system,
-            "users_count": role.users.count() if hasattr(role, '_prefetched_objects_cache') else getattr(role, 'users__count', role.users.count()),
+            "users_count": role.users.count()
+            if hasattr(role, "_prefetched_objects_cache")
+            else getattr(role, "users__count", role.users.count()),
             "created_at": _format_dt(role.created_at),
             "updated_at": _format_dt(role.updated_at),
         }
         if include_permissions:
-            data["permissions"] = PermissionSerializer.serialize_list(
-                role.permissions.all()
-            )
+            data["permissions"] = PermissionSerializer.serialize_list(role.permissions.all())
         return data
 
     @staticmethod
@@ -496,8 +472,8 @@ class CustomFieldValueSerializer:
 
 class TicketLinkSerializer:
     @staticmethod
-    def serialize(link, direction='parent'):
-        ticket = link.child_ticket if direction == 'parent' else link.parent_ticket
+    def serialize(link, direction="parent"):
+        ticket = link.child_ticket if direction == "parent" else link.parent_ticket
         return {
             "id": link.pk,
             "link_type": link.link_type,
@@ -507,7 +483,7 @@ class TicketLinkSerializer:
                 "reference": ticket.reference,
                 "subject": ticket.subject,
                 "status": ticket.status,
-                "type": getattr(ticket, 'type', 'question'),
+                "type": getattr(ticket, "type", "question"),
             },
         }
 
@@ -568,9 +544,9 @@ class ArticleCategorySerializer:
             "created_at": _format_dt(category.created_at),
             "updated_at": _format_dt(category.updated_at),
         }
-        if hasattr(category, 'articles__count'):
+        if hasattr(category, "articles__count"):
             data["articles_count"] = category.articles__count
-        elif hasattr(category, 'articles_count'):
+        elif hasattr(category, "articles_count"):
             data["articles_count"] = category.articles_count
         return data
 
@@ -584,11 +560,7 @@ class ArticleSerializer:
     def serialize(article):
         return {
             "id": article.pk,
-            "category": (
-                ArticleCategorySerializer.serialize(article.category)
-                if article.category
-                else None
-            ),
+            "category": (ArticleCategorySerializer.serialize(article.category) if article.category else None),
             "title": article.title,
             "slug": article.slug,
             "body": article.body,
@@ -613,7 +585,7 @@ class AgentProfileSerializer:
         return {
             "id": profile.pk,
             "user_id": profile.user_id,
-            "user": _user_dict(profile.user) if hasattr(profile, 'user') else None,
+            "user": _user_dict(profile.user) if hasattr(profile, "user") else None,
             "agent_type": profile.agent_type,
             "max_tickets": profile.max_tickets,
             "created_at": _format_dt(profile.created_at),
@@ -635,9 +607,9 @@ class SkillSerializer:
             "created_at": _format_dt(skill.created_at),
             "updated_at": _format_dt(skill.updated_at),
         }
-        if hasattr(skill, 'agents_count'):
+        if hasattr(skill, "agents_count"):
             data["agents_count"] = skill.agents_count
-        elif hasattr(skill, 'agents__count'):
+        elif hasattr(skill, "agents__count"):
             data["agents_count"] = skill.agents__count
         return data
 
@@ -666,12 +638,23 @@ class AgentCapacitySerializer:
 
 class WebhookSerializer:
     AVAILABLE_EVENTS = [
-        "ticket.created", "ticket.updated", "ticket.status_changed",
-        "ticket.resolved", "ticket.closed", "ticket.reopened",
-        "ticket.assigned", "ticket.unassigned", "ticket.escalated",
-        "ticket.priority_changed", "ticket.department_changed",
-        "reply.created", "internal_note.added",
-        "sla.breached", "sla.warning", "tag.added", "tag.removed",
+        "ticket.created",
+        "ticket.updated",
+        "ticket.status_changed",
+        "ticket.resolved",
+        "ticket.closed",
+        "ticket.reopened",
+        "ticket.assigned",
+        "ticket.unassigned",
+        "ticket.escalated",
+        "ticket.priority_changed",
+        "ticket.department_changed",
+        "reply.created",
+        "internal_note.added",
+        "sla.breached",
+        "sla.warning",
+        "tag.added",
+        "tag.removed",
     ]
 
     @staticmethod
@@ -685,9 +668,9 @@ class WebhookSerializer:
             "created_at": _format_dt(webhook.created_at),
             "updated_at": _format_dt(webhook.updated_at),
         }
-        if hasattr(webhook, 'deliveries_count'):
+        if hasattr(webhook, "deliveries_count"):
             data["deliveries_count"] = webhook.deliveries_count
-        elif hasattr(webhook, 'deliveries__count'):
+        elif hasattr(webhook, "deliveries__count"):
             data["deliveries_count"] = webhook.deliveries__count
         return data
 
@@ -759,9 +742,9 @@ class CustomObjectSerializer:
             "created_at": _format_dt(obj.created_at),
             "updated_at": _format_dt(obj.updated_at),
         }
-        if hasattr(obj, 'records_count'):
+        if hasattr(obj, "records_count"):
             data["records_count"] = obj.records_count
-        elif hasattr(obj, 'records__count'):
+        elif hasattr(obj, "records__count"):
             data["records_count"] = obj.records__count
         return data
 

--- a/escalated/services/assignment_service.py
+++ b/escalated/services/assignment_service.py
@@ -2,7 +2,7 @@ import logging
 
 from django.db.models import Count, Q
 
-from escalated.models import Ticket, Department
+from escalated.models import Department, Ticket
 
 logger = logging.getLogger("escalated")
 
@@ -24,10 +24,7 @@ class AssignmentService:
 
         agents = department.agents.all()
         if not agents.exists():
-            logger.info(
-                f"No agents in department '{department.name}' for auto-assign "
-                f"on ticket {ticket.reference}"
-            )
+            logger.info(f"No agents in department '{department.name}' for auto-assign on ticket {ticket.reference}")
             return None
 
         # Find agent with fewest open tickets
@@ -56,10 +53,7 @@ class AssignmentService:
             if ticket.status == Ticket.Status.OPEN:
                 ticket.status = Ticket.Status.IN_PROGRESS
             ticket.save(update_fields=["assigned_to", "status", "updated_at"])
-            logger.info(
-                f"Auto-assigned ticket {ticket.reference} to {agent} "
-                f"in department '{department.name}'"
-            )
+            logger.info(f"Auto-assigned ticket {ticket.reference} to {agent} in department '{department.name}'")
 
         return agent
 
@@ -81,10 +75,9 @@ class AssignmentService:
         if department:
             agents = department.agents.filter(is_active=True)
         else:
-            agents = Department.objects.filter(is_active=True).values_list(
-                "agents", flat=True
-            )
+            agents = Department.objects.filter(is_active=True).values_list("agents", flat=True)
             from django.contrib.auth import get_user_model
+
             User = get_user_model()
             agents = User.objects.filter(pk__in=agents, is_active=True)
 

--- a/escalated/services/attachment_service.py
+++ b/escalated/services/attachment_service.py
@@ -41,20 +41,15 @@ class AttachmentService:
         file_size = getattr(file, "size", 0)
         if file_size > max_size_kb * 1024:
             raise ValidationError(
-                f"File '{filename}' exceeds maximum size of {max_size_kb}KB. "
-                f"Got {file_size / 1024:.1f}KB."
+                f"File '{filename}' exceeds maximum size of {max_size_kb}KB. Got {file_size / 1024:.1f}KB."
             )
 
         # Check attachment count
         ct = ContentType.objects.get_for_model(content_object)
-        existing_count = Attachment.objects.filter(
-            content_type=ct, object_id=content_object.pk
-        ).count()
+        existing_count = Attachment.objects.filter(content_type=ct, object_id=content_object.pk).count()
 
         if existing_count >= max_attachments:
-            raise ValidationError(
-                f"Maximum of {max_attachments} attachments reached for this item."
-            )
+            raise ValidationError(f"Maximum of {max_attachments} attachments reached for this item.")
 
         # Detect mime type
         mime_type, _ = mimetypes.guess_type(filename)
@@ -70,10 +65,7 @@ class AttachmentService:
             size=file_size,
         )
 
-        logger.info(
-            f"Attachment '{filename}' ({mime_type}, {file_size}B) added to "
-            f"{ct.model} #{content_object.pk}"
-        )
+        logger.info(f"Attachment '{filename}' ({mime_type}, {file_size}B) added to {ct.model} #{content_object.pk}")
 
         return attachment
 
@@ -81,9 +73,7 @@ class AttachmentService:
     def get_attachments(content_object):
         """Get all attachments for a content object."""
         ct = ContentType.objects.get_for_model(content_object)
-        return Attachment.objects.filter(
-            content_type=ct, object_id=content_object.pk
-        )
+        return Attachment.objects.filter(content_type=ct, object_id=content_object.pk)
 
     @staticmethod
     def delete_attachment(attachment_id):

--- a/escalated/services/automation_runner.py
+++ b/escalated/services/automation_runner.py
@@ -25,7 +25,6 @@ class AutomationRunner:
         return affected
 
     def _find_matching_tickets(self, automation):
-        from django.db.models import Q
 
         from escalated.models import Ticket
 
@@ -119,7 +118,7 @@ class AutomationRunner:
         For hours_since fields, > hours means < datetime (older).
         """
         mapping = {
-            ">": "__lte",   # more hours ago = earlier datetime
+            ">": "__lte",  # more hours ago = earlier datetime
             ">=": "__lte",
             "<": "__gte",
             "<=": "__gte",

--- a/escalated/services/business_hours_service.py
+++ b/escalated/services/business_hours_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone as dt_tz
+from datetime import UTC, timedelta
 from zoneinfo import ZoneInfo
 
 
@@ -31,36 +31,34 @@ class BusinessHoursCalculator:
             max_iterations -= 1
 
             if self._is_holiday(current, schedule):
-                current = (current + timedelta(days=1)).replace(
-                    hour=0, minute=0, second=0, microsecond=0
-                )
+                current = (current + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
                 continue
 
             day_schedule = self._get_day_schedule(current, schedule)
             if not day_schedule or not day_schedule.get("start") or not day_schedule.get("end"):
-                current = (current + timedelta(days=1)).replace(
-                    hour=0, minute=0, second=0, microsecond=0
-                )
+                current = (current + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
                 continue
 
             start_parts = day_schedule["start"].split(":")
             end_parts = day_schedule["end"].split(":")
             day_start = current.replace(
-                hour=int(start_parts[0]), minute=int(start_parts[1]),
-                second=0, microsecond=0,
+                hour=int(start_parts[0]),
+                minute=int(start_parts[1]),
+                second=0,
+                microsecond=0,
             )
             day_end = current.replace(
-                hour=int(end_parts[0]), minute=int(end_parts[1]),
-                second=0, microsecond=0,
+                hour=int(end_parts[0]),
+                minute=int(end_parts[1]),
+                second=0,
+                microsecond=0,
             )
 
             if current < day_start:
                 current = day_start
 
             if current >= day_end:
-                current = (current + timedelta(days=1)).replace(
-                    hour=0, minute=0, second=0, microsecond=0
-                )
+                current = (current + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
                 continue
 
             available_minutes = (day_end - current).total_seconds() / 60
@@ -70,11 +68,9 @@ class BusinessHoursCalculator:
                 remaining_minutes = 0
             else:
                 remaining_minutes -= available_minutes
-                current = (current + timedelta(days=1)).replace(
-                    hour=0, minute=0, second=0, microsecond=0
-                )
+                current = (current + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
 
-        return current.astimezone(dt_tz.utc)
+        return current.astimezone(UTC)
 
     def _get_day_schedule(self, dt_local, schedule):
         """Get the schedule for a specific day of the week."""
@@ -84,7 +80,7 @@ class BusinessHoursCalculator:
 
     def _is_holiday(self, dt_local, schedule):
         """Check if a date is a holiday."""
-        if not hasattr(schedule, '_prefetched_holidays'):
+        if not hasattr(schedule, "_prefetched_holidays"):
             schedule._prefetched_holidays = list(schedule.holidays.all())
 
         for holiday in schedule._prefetched_holidays:

--- a/escalated/services/escalation_service.py
+++ b/escalated/services/escalation_service.py
@@ -4,8 +4,8 @@ from datetime import timedelta
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-from escalated.models import Ticket, EscalationRule, TicketActivity
-from escalated.signals import ticket_escalated, ticket_priority_changed
+from escalated.models import EscalationRule, Ticket, TicketActivity
+from escalated.signals import ticket_escalated
 
 logger = logging.getLogger("escalated")
 
@@ -24,9 +24,7 @@ class EscalationService:
         Called by the evaluate_escalations management command.
         """
         rules = EscalationRule.objects.filter(is_active=True).order_by("order")
-        open_tickets = Ticket.objects.open().select_related(
-            "assigned_to", "department", "sla_policy"
-        )
+        open_tickets = Ticket.objects.open().select_related("assigned_to", "department", "sla_policy")
 
         actions_taken = 0
         for rule in rules:
@@ -60,10 +58,7 @@ class EscalationService:
 
         # Check trigger type first
         if rule.trigger_type == EscalationRule.TriggerType.SLA_BREACH:
-            if not (
-                ticket.sla_first_response_breached
-                or ticket.sla_resolution_breached
-            ):
+            if not (ticket.sla_first_response_breached or ticket.sla_resolution_breached):
                 return False
 
         elif rule.trigger_type == EscalationRule.TriggerType.NO_RESPONSE:
@@ -150,19 +145,14 @@ class EscalationService:
                 if ticket.assigned_to != agent:
                     ticket.assigned_to = agent
                     acted = True
-                    logger.info(
-                        f"Escalation rule '{rule.name}' assigned "
-                        f"{ticket.reference} to {agent}"
-                    )
+                    logger.info(f"Escalation rule '{rule.name}' assigned {ticket.reference} to {agent}")
             except User.DoesNotExist:
-                logger.warning(
-                    f"Escalation rule '{rule.name}' references non-existent "
-                    f"user {actions['assign_to_id']}"
-                )
+                logger.warning(f"Escalation rule '{rule.name}' references non-existent user {actions['assign_to_id']}")
 
         # Change department
         if "department_id" in actions:
             from escalated.models import Department
+
             try:
                 dept = Department.objects.get(pk=actions["department_id"])
                 if ticket.department != dept:
@@ -170,8 +160,7 @@ class EscalationService:
                     acted = True
             except Department.DoesNotExist:
                 logger.warning(
-                    f"Escalation rule '{rule.name}' references non-existent "
-                    f"department {actions['department_id']}"
+                    f"Escalation rule '{rule.name}' references non-existent department {actions['department_id']}"
                 )
 
         if acted:

--- a/escalated/services/import_service.py
+++ b/escalated/services/import_service.py
@@ -23,7 +23,7 @@ an import is running.
 """
 
 import logging
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from django.apps import apps
 from django.contrib.auth import get_user_model
@@ -82,7 +82,7 @@ class ImportService:
     def run(
         self,
         job: ImportJob,
-        on_progress: Optional[Callable[[str, dict], None]] = None,
+        on_progress: Callable[[str, dict], None] | None = None,
     ) -> None:
         """
         Execute (or resume) the import for *job*.
@@ -150,7 +150,7 @@ class ImportService:
         job: ImportJob,
         adapter,
         entity_type: str,
-        on_progress: Optional[Callable],
+        on_progress: Callable | None,
     ) -> None:
         cursor = job.get_entity_cursor(entity_type)
         progress = (job.progress or {}).get(entity_type, {})
@@ -188,7 +188,10 @@ class ImportService:
                     job.append_error(entity_type, source_id, str(exc))
                     logger.warning(
                         "Import error [job=%s entity=%s source_id=%s]: %s",
-                        job.id, entity_type, source_id, exc,
+                        job.id,
+                        entity_type,
+                        source_id,
+                        exc,
                     )
 
             cursor = result.cursor
@@ -256,9 +259,7 @@ class ImportService:
         try:
             user = User.objects.get(email=record["email"])
         except User.DoesNotExist:
-            raise RuntimeError(
-                f"Agent with email '{record['email']}' not found in host application."
-            )
+            raise RuntimeError(f"Agent with email '{record['email']}' not found in host application.")
         return user.pk
 
     def _persist_contact(self, record: dict, mappings: dict):
@@ -294,21 +295,15 @@ class ImportService:
 
         requester_id = None
         if record.get("requester_source_id"):
-            requester_id = ImportSourceMap.resolve(
-                job.id, "contacts", record["requester_source_id"]
-            )
+            requester_id = ImportSourceMap.resolve(job.id, "contacts", record["requester_source_id"])
 
         assignee_id = None
         if record.get("assignee_source_id"):
-            assignee_id = ImportSourceMap.resolve(
-                job.id, "agents", record["assignee_source_id"]
-            )
+            assignee_id = ImportSourceMap.resolve(job.id, "agents", record["assignee_source_id"])
 
         department_id = None
         if record.get("department_source_id"):
-            department_id = ImportSourceMap.resolve(
-                job.id, "departments", record["department_source_id"]
-            )
+            department_id = ImportSourceMap.resolve(job.id, "departments", record["department_source_id"])
 
         ticket = Ticket(
             subject=record.get("title") or record.get("subject") or "Imported ticket",
@@ -334,20 +329,13 @@ class ImportService:
             if record.get("created_at"):
                 update_fields.append("created_at")
             Ticket.objects.filter(pk=ticket.pk).update(
-                **{
-                    k: record[k[:-3] if k.endswith("_at") else k]
-                    for k in update_fields
-                    if record.get(k)
-                }
+                **{k: record[k[:-3] if k.endswith("_at") else k] for k in update_fields if record.get(k)}
             )
 
         # Attach tags
         if record.get("tag_source_ids"):
-            Tag = apps.get_model("escalated", "Tag")
-            tag_ids = [
-                ImportSourceMap.resolve(job.id, "tags", sid)
-                for sid in record["tag_source_ids"]
-            ]
+            apps.get_model("escalated", "Tag")
+            tag_ids = [ImportSourceMap.resolve(job.id, "tags", sid) for sid in record["tag_source_ids"]]
             tag_ids = [tid for tid in tag_ids if tid]
             if tag_ids:
                 ticket.tags.set(tag_ids)
@@ -357,18 +345,15 @@ class ImportService:
     def _persist_reply(self, job: ImportJob, record: dict, mappings: dict):
         Reply = apps.get_model("escalated", "Reply")
 
-        ticket_id = ImportSourceMap.resolve(
-            job.id, "tickets", record.get("ticket_source_id", "")
-        )
+        ticket_id = ImportSourceMap.resolve(job.id, "tickets", record.get("ticket_source_id", ""))
         if not ticket_id:
             raise RuntimeError("Parent ticket not found for reply.")
 
         author_id = None
         if record.get("author_source_id"):
-            author_id = (
-                ImportSourceMap.resolve(job.id, "agents", record["author_source_id"])
-                or ImportSourceMap.resolve(job.id, "contacts", record["author_source_id"])
-            )
+            author_id = ImportSourceMap.resolve(
+                job.id, "agents", record["author_source_id"]
+            ) or ImportSourceMap.resolve(job.id, "contacts", record["author_source_id"])
 
         reply = Reply(
             ticket_id=ticket_id,
@@ -420,9 +405,7 @@ class ImportService:
     def _persist_satisfaction_rating(self, job: ImportJob, record: dict, mappings: dict):
         SatisfactionRating = apps.get_model("escalated", "SatisfactionRating")
 
-        ticket_id = ImportSourceMap.resolve(
-            job.id, "tickets", record.get("ticket_source_id", "")
-        )
+        ticket_id = ImportSourceMap.resolve(job.id, "tickets", record.get("ticket_source_id", ""))
         if not ticket_id:
             raise RuntimeError("Ticket not found for satisfaction rating.")
 
@@ -436,8 +419,6 @@ class ImportService:
         rating.save()
 
         if record.get("created_at"):
-            SatisfactionRating.objects.filter(pk=rating.pk).update(
-                created_at=record["created_at"]
-            )
+            SatisfactionRating.objects.filter(pk=rating.pk).update(created_at=record["created_at"])
 
         return rating.pk

--- a/escalated/services/inbound_email_service.py
+++ b/escalated/services/inbound_email_service.py
@@ -4,7 +4,6 @@ import re
 import secrets
 
 from django.contrib.auth import get_user_model
-from django.utils import timezone
 
 from escalated.conf import get_setting
 from escalated.mail.inbound_message import InboundMessage
@@ -32,19 +31,82 @@ class InboundEmailService:
     """
 
     ALLOWED_TAGS = {
-        'p', 'br', 'b', 'strong', 'i', 'em', 'u', 'a', 'ul', 'ol', 'li',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'code',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td', 'img', 'hr', 'div', 'span',
-        'sub', 'sup',
+        "p",
+        "br",
+        "b",
+        "strong",
+        "i",
+        "em",
+        "u",
+        "a",
+        "ul",
+        "ol",
+        "li",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "blockquote",
+        "pre",
+        "code",
+        "table",
+        "thead",
+        "tbody",
+        "tr",
+        "th",
+        "td",
+        "img",
+        "hr",
+        "div",
+        "span",
+        "sub",
+        "sup",
     }
 
     BLOCKED_EXTENSIONS = {
-        'exe', 'bat', 'cmd', 'com', 'msi', 'scr', 'pif', 'vbs', 'vbe',
-        'js', 'jse', 'wsf', 'wsh', 'ps1', 'psm1', 'psd1', 'reg',
-        'cpl', 'hta', 'inf', 'lnk', 'sct', 'shb', 'sys', 'drv',
-        'php', 'phtml', 'php3', 'php4', 'php5', 'phar',
-        'sh', 'bash', 'csh', 'ksh', 'pl', 'py', 'rb',
-        'dll', 'so', 'dylib',
+        "exe",
+        "bat",
+        "cmd",
+        "com",
+        "msi",
+        "scr",
+        "pif",
+        "vbs",
+        "vbe",
+        "js",
+        "jse",
+        "wsf",
+        "wsh",
+        "ps1",
+        "psm1",
+        "psd1",
+        "reg",
+        "cpl",
+        "hta",
+        "inf",
+        "lnk",
+        "sct",
+        "shb",
+        "sys",
+        "drv",
+        "php",
+        "phtml",
+        "php3",
+        "php4",
+        "php5",
+        "phar",
+        "sh",
+        "bash",
+        "csh",
+        "ksh",
+        "pl",
+        "py",
+        "rb",
+        "dll",
+        "so",
+        "dylib",
     }
 
     @staticmethod
@@ -56,37 +118,45 @@ class InboundEmailService:
         allowed = InboundEmailService.ALLOWED_TAGS
 
         def replace_tag(match):
-            tag_name = match.group(1).strip().split()[0].lower().lstrip('/')
+            tag_name = match.group(1).strip().split()[0].lower().lstrip("/")
             if tag_name in allowed:
                 return match.group(0)
-            return ''
+            return ""
 
-        clean = re.sub(r'<(/?\s*[a-zA-Z][a-zA-Z0-9]*(?:\s[^>]*)?)>', replace_tag, html)
+        clean = re.sub(r"<(/?\s*[a-zA-Z][a-zA-Z0-9]*(?:\s[^>]*)?)>", replace_tag, html)
 
         # Remove event handler attributes
-        clean = re.sub(r'\s+on\w+\s*=\s*["\'][^"\']*["\']', '', clean, flags=re.IGNORECASE)
-        clean = re.sub(r'\s+on\w+\s*=\s*\S+', '', clean, flags=re.IGNORECASE)
+        clean = re.sub(r'\s+on\w+\s*=\s*["\'][^"\']*["\']', "", clean, flags=re.IGNORECASE)
+        clean = re.sub(r"\s+on\w+\s*=\s*\S+", "", clean, flags=re.IGNORECASE)
 
         # Remove javascript: protocol
         clean = re.sub(
             r'\b(href|src|action)\s*=\s*["\']?\s*javascript\s*:',
-            r'\1="', clean, flags=re.IGNORECASE,
+            r'\1="',
+            clean,
+            flags=re.IGNORECASE,
         )
 
         # Remove data: URLs except data:image
         clean = re.sub(
             r'\b(href|src|action)\s*=\s*["\']?\s*data\s*:(?!image/)',
-            r'\1="', clean, flags=re.IGNORECASE,
+            r'\1="',
+            clean,
+            flags=re.IGNORECASE,
         )
 
         # Remove style with expression()
         clean = re.sub(
             r'style\s*=\s*["\'][^"\']*expression\s*\([^"\']*["\']',
-            '', clean, flags=re.IGNORECASE,
+            "",
+            clean,
+            flags=re.IGNORECASE,
         )
         clean = re.sub(
             r'style\s*=\s*["\'][^"\']*url\s*\(\s*["\']?\s*javascript:[^"\']*["\']',
-            '', clean, flags=re.IGNORECASE,
+            "",
+            clean,
+            flags=re.IGNORECASE,
         )
 
         return clean
@@ -97,8 +167,8 @@ class InboundEmailService:
         if message.body_text:
             return message.body_text
         if message.body_html:
-            return InboundEmailService._sanitize_html(message.body_html) or ''
-        return ''
+            return InboundEmailService._sanitize_html(message.body_html) or ""
+        return ""
 
     @staticmethod
     def process(message: InboundMessage, adapter_name: str = "unknown") -> InboundEmail:
@@ -119,9 +189,7 @@ class InboundEmailService:
                 status=InboundEmail.Status.PROCESSED,
             ).first()
             if existing:
-                logger.info(
-                    f"Duplicate inbound email (message_id={message.message_id}), skipping"
-                )
+                logger.info(f"Duplicate inbound email (message_id={message.message_id}), skipping")
                 return existing
 
         # Create the InboundEmail log record
@@ -133,9 +201,7 @@ class InboundEmailService:
             subject=message.subject,
             body_text=message.body_text,
             body_html=InboundEmailService._sanitize_html(message.body_html),
-            raw_headers="\n".join(
-                f"{k}: {v}" for k, v in message.headers.items()
-            ) if message.headers else None,
+            raw_headers="\n".join(f"{k}: {v}" for k, v in message.headers.items()) if message.headers else None,
             adapter=adapter_name,
             status=InboundEmail.Status.PENDING,
         )
@@ -145,14 +211,11 @@ class InboundEmailService:
             inbound.mark_processed(ticket, reply)
             logger.info(
                 f"Inbound email processed: {message.from_email} -> "
-                f"ticket {ticket.reference}"
-                + (f" (reply #{reply.pk})" if reply else " (new ticket)")
+                f"ticket {ticket.reference}" + (f" (reply #{reply.pk})" if reply else " (new ticket)")
             )
         except Exception as exc:
             inbound.mark_failed(str(exc))
-            logger.error(
-                f"Failed to process inbound email from {message.from_email}: {exc}"
-            )
+            logger.error(f"Failed to process inbound email from {message.from_email}: {exc}")
 
         return inbound
 
@@ -164,7 +227,6 @@ class InboundEmailService:
         Raises an exception on failure (caught by process()).
         """
         from escalated.drivers import get_driver
-        from escalated.services.attachment_service import AttachmentService
 
         driver = get_driver()
 
@@ -173,13 +235,9 @@ class InboundEmailService:
 
         # Also try by In-Reply-To / References headers
         if ticket is None and message.in_reply_to:
-            ticket = InboundEmailService._find_ticket_by_message_id(
-                message.in_reply_to
-            )
+            ticket = InboundEmailService._find_ticket_by_message_id(message.in_reply_to)
         if ticket is None and message.references:
-            ticket = InboundEmailService._find_ticket_by_references(
-                message.references
-            )
+            ticket = InboundEmailService._find_ticket_by_references(message.references)
 
         # Resolve sender — try to find a registered user first
         User = get_user_model()
@@ -193,26 +251,18 @@ class InboundEmailService:
 
         if ticket is not None:
             # Existing ticket — add a reply
-            reply = InboundEmailService._add_reply(
-                driver, ticket, user, message
-            )
+            reply = InboundEmailService._add_reply(driver, ticket, user, message)
 
             # Handle attachments on the reply
-            InboundEmailService._handle_attachments(
-                reply, message.attachments
-            )
+            InboundEmailService._handle_attachments(reply, message.attachments)
 
             return ticket, reply
         else:
             # New ticket
-            ticket, reply = InboundEmailService._create_ticket(
-                driver, user, message
-            )
+            ticket, reply = InboundEmailService._create_ticket(driver, user, message)
 
             # Handle attachments on the ticket
-            InboundEmailService._handle_attachments(
-                ticket, message.attachments
-            )
+            InboundEmailService._handle_attachments(ticket, message.attachments)
 
             return ticket, reply
 
@@ -229,9 +279,7 @@ class InboundEmailService:
             try:
                 return Ticket.objects.get(reference=reference)
             except Ticket.DoesNotExist:
-                logger.debug(
-                    f"Reference '{reference}' found in subject but no matching ticket"
-                )
+                logger.debug(f"Reference '{reference}' found in subject but no matching ticket")
         return None
 
     @staticmethod
@@ -240,11 +288,15 @@ class InboundEmailService:
         Find a ticket by looking for an InboundEmail with the given message_id
         that was already processed.
         """
-        previous = InboundEmail.objects.filter(
-            message_id=message_id,
-            status=InboundEmail.Status.PROCESSED,
-            ticket__isnull=False,
-        ).select_related("ticket").first()
+        previous = (
+            InboundEmail.objects.filter(
+                message_id=message_id,
+                status=InboundEmail.Status.PROCESSED,
+                ticket__isnull=False,
+            )
+            .select_related("ticket")
+            .first()
+        )
         return previous.ticket if previous else None
 
     @staticmethod
@@ -293,16 +345,19 @@ class InboundEmailService:
 
         if user is not None:
             # Authenticated user ticket
-            ticket = driver.create_ticket(user, {
-                "subject": subject,
-                "description": body,
-                "priority": get_setting("DEFAULT_PRIORITY"),
-                "channel": "email",
-                "metadata": {
-                    "source": "inbound_email",
-                    "message_id": message.message_id,
+            ticket = driver.create_ticket(
+                user,
+                {
+                    "subject": subject,
+                    "description": body,
+                    "priority": get_setting("DEFAULT_PRIORITY"),
+                    "channel": "email",
+                    "metadata": {
+                        "source": "inbound_email",
+                        "message_id": message.message_id,
+                    },
                 },
-            })
+            )
         else:
             # Guest ticket (follows the same pattern as views/guest.py)
             guest_token = secrets.token_hex(32)
@@ -346,22 +401,19 @@ class InboundEmailService:
 
         for i, att in enumerate(attachments):
             if i >= max_attachments:
-                logger.warning(
-                    f"Attachment limit ({max_attachments}) reached, "
-                    f"skipping remaining attachments"
-                )
+                logger.warning(f"Attachment limit ({max_attachments}) reached, skipping remaining attachments")
                 break
 
             # Block dangerous file extensions
-            filename = att.get('filename', '')
+            filename = att.get("filename", "")
             _, extension = os.path.splitext(filename)
-            extension = extension.lower().lstrip('.')
+            extension = extension.lower().lstrip(".")
             if extension and extension in InboundEmailService.BLOCKED_EXTENSIONS:
                 logger.info(
-                    f'Escalated: Blocked dangerous inbound attachment.',
+                    "Escalated: Blocked dangerous inbound attachment.",
                     extra={
-                        'filename': filename,
-                        'extension': extension,
+                        "filename": filename,
+                        "extension": extension,
                     },
                 )
                 continue
@@ -404,11 +456,6 @@ class InboundEmailService:
                         original_filename=filename,
                     )
                 else:
-                    logger.warning(
-                        f"Attachment '{att.get('filename', 'unnamed')}' "
-                        f"has no file data, skipping"
-                    )
+                    logger.warning(f"Attachment '{att.get('filename', 'unnamed')}' has no file data, skipping")
             except Exception as exc:
-                logger.error(
-                    f"Failed to attach file '{att.get('filename', 'unnamed')}': {exc}"
-                )
+                logger.error(f"Failed to attach file '{att.get('filename', 'unnamed')}': {exc}")

--- a/escalated/services/macro_service.py
+++ b/escalated/services/macro_service.py
@@ -2,7 +2,7 @@ import logging
 
 from django.contrib.auth import get_user_model
 
-from escalated.models import Macro, Ticket, Tag, Department
+from escalated.models import Department, Macro, Ticket
 
 logger = logging.getLogger("escalated")
 
@@ -16,6 +16,7 @@ class MacroService:
 
     def __init__(self):
         from escalated.services.ticket_service import TicketService
+
         self.ticket_service = TicketService()
 
     def apply(self, macro: Macro, ticket: Ticket, user) -> Ticket:
@@ -44,39 +45,26 @@ class MacroService:
                         agent = User.objects.get(pk=int(value))
                         self.ticket_service.assign(ticket, user, agent)
                     except User.DoesNotExist:
-                        logger.warning(
-                            f"Macro action 'assign' skipped: user {value} not found"
-                        )
+                        logger.warning(f"Macro action 'assign' skipped: user {value} not found")
                 elif action_type == "add_note" or action_type == "note":
                     if value:
                         self.ticket_service.add_note(ticket, user, str(value))
                 elif action_type == "add_tags" or action_type == "tags":
                     tag_ids = value if isinstance(value, list) else [value]
-                    self.ticket_service.add_tags(
-                        ticket, user, [int(t) for t in tag_ids]
-                    )
+                    self.ticket_service.add_tags(ticket, user, [int(t) for t in tag_ids])
                 elif action_type == "send_reply" or action_type == "reply":
                     if value:
-                        self.ticket_service.reply(
-                            ticket, user, {"body": str(value)}
-                        )
+                        self.ticket_service.reply(ticket, user, {"body": str(value)})
                 elif action_type == "department":
                     try:
                         dept = Department.objects.get(pk=int(value))
                         self.ticket_service.change_department(ticket, user, dept)
                     except Department.DoesNotExist:
-                        logger.warning(
-                            f"Macro action 'department' skipped: department {value} not found"
-                        )
+                        logger.warning(f"Macro action 'department' skipped: department {value} not found")
                 else:
-                    logger.warning(
-                        f"Unknown macro action type: {action_type}"
-                    )
+                    logger.warning(f"Unknown macro action type: {action_type}")
             except Exception as e:
-                logger.error(
-                    f"Macro action '{action_type}' failed on ticket "
-                    f"{ticket.reference}: {e}"
-                )
+                logger.error(f"Macro action '{action_type}' failed on ticket {ticket.reference}: {e}")
 
             # Refresh ticket from DB after each action
             ticket.refresh_from_db()

--- a/escalated/services/notification_service.py
+++ b/escalated/services/notification_service.py
@@ -25,7 +25,7 @@ class NotificationService:
 
         if "email" in channels:
             NotificationService._send_email(
-                subject="[%s] %s" % (
+                subject="[{}] {}".format(
                     ticket.reference,
                     _("New ticket: %(subject)s") % {"subject": ticket.subject},
                 ),
@@ -34,12 +34,15 @@ class NotificationService:
                 recipient=NotificationService._get_requester_email(ticket),
             )
 
-        NotificationService._fire_webhook("ticket.created", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "subject": ticket.subject,
-            "priority": ticket.priority,
-        })
+        NotificationService._fire_webhook(
+            "ticket.created",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "subject": ticket.subject,
+                "priority": ticket.priority,
+            },
+        )
 
     @staticmethod
     def notify_reply_added(ticket, reply):
@@ -51,7 +54,7 @@ class NotificationService:
             requester_email = NotificationService._get_requester_email(ticket)
             if requester_email and reply.author != ticket.requester:
                 NotificationService._send_email(
-                    subject="[%s] %s" % (
+                    subject="[{}] {}".format(
                         ticket.reference,
                         _("New reply on: %(subject)s") % {"subject": ticket.subject},
                     ),
@@ -65,7 +68,7 @@ class NotificationService:
                 agent_email = getattr(ticket.assigned_to, "email", None)
                 if agent_email:
                     NotificationService._send_email(
-                        subject="[%s] %s" % (
+                        subject="[{}] {}".format(
                             ticket.reference,
                             _("Customer reply on: %(subject)s") % {"subject": ticket.subject},
                         ),
@@ -78,7 +81,7 @@ class NotificationService:
             NotificationService._notify_followers(
                 ticket,
                 reply.author,
-                subject="[%s] %s" % (
+                subject="[{}] {}".format(
                     ticket.reference,
                     _("New reply on: %(subject)s") % {"subject": ticket.subject},
                 ),
@@ -86,15 +89,20 @@ class NotificationService:
                 context={"ticket": ticket, "reply": reply},
                 exclude_user_ids=[
                     ticket.assigned_to_id,
-                ] if ticket.assigned_to_id else [],
+                ]
+                if ticket.assigned_to_id
+                else [],
             )
 
-        NotificationService._fire_webhook("reply.created", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "reply_id": reply.pk,
-            "is_internal": reply.is_internal_note,
-        })
+        NotificationService._fire_webhook(
+            "reply.created",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "reply_id": reply.pk,
+                "is_internal": reply.is_internal_note,
+            },
+        )
 
     @staticmethod
     def notify_ticket_assigned(ticket, agent):
@@ -105,7 +113,7 @@ class NotificationService:
             agent_email = getattr(agent, "email", None)
             if agent_email:
                 NotificationService._send_email(
-                    subject="[%s] %s" % (
+                    subject="[{}] {}".format(
                         ticket.reference,
                         _("Ticket assigned to you: %(subject)s") % {"subject": ticket.subject},
                     ),
@@ -114,11 +122,14 @@ class NotificationService:
                     recipient=agent_email,
                 )
 
-        NotificationService._fire_webhook("ticket.assigned", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "agent_id": agent.pk,
-        })
+        NotificationService._fire_webhook(
+            "ticket.assigned",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "agent_id": agent.pk,
+            },
+        )
 
     @staticmethod
     def notify_status_changed(ticket, old_status, new_status):
@@ -129,7 +140,7 @@ class NotificationService:
             requester_email = NotificationService._get_requester_email(ticket)
             if requester_email:
                 NotificationService._send_email(
-                    subject="[%s] %s" % (
+                    subject="[{}] {}".format(
                         ticket.reference,
                         _("Status updated: %(subject)s") % {"subject": ticket.subject},
                     ),
@@ -146,7 +157,7 @@ class NotificationService:
             NotificationService._notify_followers(
                 ticket,
                 causer=None,
-                subject="[%s] %s" % (
+                subject="[{}] {}".format(
                     ticket.reference,
                     _("Status updated: %(subject)s") % {"subject": ticket.subject},
                 ),
@@ -158,12 +169,15 @@ class NotificationService:
                 },
             )
 
-        NotificationService._fire_webhook("ticket.status_changed", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "old_status": old_status,
-            "new_status": new_status,
-        })
+        NotificationService._fire_webhook(
+            "ticket.status_changed",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "old_status": old_status,
+                "new_status": new_status,
+            },
+        )
 
     @staticmethod
     def notify_sla_breach(ticket, breach_type):
@@ -174,9 +188,10 @@ class NotificationService:
             agent_email = getattr(ticket.assigned_to, "email", None)
             if agent_email:
                 NotificationService._send_email(
-                    subject="[SLA BREACH] [%s] %s" % (
+                    subject="[SLA BREACH] [{}] {}".format(
                         ticket.reference,
-                        _("%(breach_type)s: %(subject)s") % {
+                        _("%(breach_type)s: %(subject)s")
+                        % {
                             "breach_type": breach_type,
                             "subject": ticket.subject,
                         },
@@ -186,11 +201,14 @@ class NotificationService:
                     recipient=agent_email,
                 )
 
-        NotificationService._fire_webhook("sla.breached", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "breach_type": breach_type,
-        })
+        NotificationService._fire_webhook(
+            "sla.breached",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "breach_type": breach_type,
+            },
+        )
 
     @staticmethod
     def notify_ticket_escalated(ticket, reason):
@@ -201,17 +219,20 @@ class NotificationService:
             agent_email = getattr(ticket.assigned_to, "email", None)
             if agent_email:
                 NotificationService._send_email(
-                    subject="[ESCALATED] [%s] %s" % (ticket.reference, ticket.subject),
+                    subject=f"[ESCALATED] [{ticket.reference}] {ticket.subject}",
                     template="escalated/emails/escalated.html",
                     context={"ticket": ticket, "reason": reason},
                     recipient=agent_email,
                 )
 
-        NotificationService._fire_webhook("ticket.escalated", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-            "reason": reason,
-        })
+        NotificationService._fire_webhook(
+            "ticket.escalated",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+                "reason": reason,
+            },
+        )
 
     @staticmethod
     def notify_ticket_resolved(ticket):
@@ -222,7 +243,7 @@ class NotificationService:
             requester_email = NotificationService._get_requester_email(ticket)
             if requester_email:
                 NotificationService._send_email(
-                    subject="[%s] %s" % (
+                    subject="[{}] {}".format(
                         ticket.reference,
                         _("Status updated: %(subject)s") % {"subject": ticket.subject},
                     ),
@@ -231,10 +252,13 @@ class NotificationService:
                     recipient=requester_email,
                 )
 
-        NotificationService._fire_webhook("ticket.resolved", {
-            "ticket_id": ticket.pk,
-            "reference": ticket.reference,
-        })
+        NotificationService._fire_webhook(
+            "ticket.resolved",
+            {
+                "ticket_id": ticket.pk,
+                "reference": ticket.reference,
+            },
+        )
 
     # ----- Internal helpers -----
 
@@ -293,9 +317,7 @@ class NotificationService:
             send_mail(
                 subject=subject,
                 message="",  # Plain text fallback
-                from_email=getattr(
-                    settings, "DEFAULT_FROM_EMAIL", "support@escalated.dev"
-                ),
+                from_email=getattr(settings, "DEFAULT_FROM_EMAIL", "support@escalated.dev"),
                 recipient_list=[recipient],
                 html_message=html_body,
                 fail_silently=True,
@@ -320,9 +342,7 @@ class NotificationService:
             }
 
             # Add HMAC-SHA256 signature if a webhook secret is configured
-            secret = get_setting("WEBHOOK_SECRET") or getattr(
-                settings, "ESCALATED_WEBHOOK_SECRET", None
-            )
+            secret = get_setting("WEBHOOK_SECRET") or getattr(settings, "ESCALATED_WEBHOOK_SECRET", None)
             if secret:
                 body_bytes = json.dumps(body, default=str).encode("utf-8")
                 signature = hmac.new(

--- a/escalated/services/reporting_service.py
+++ b/escalated/services/reporting_service.py
@@ -1,8 +1,5 @@
-from datetime import timedelta
-
 from django.db import connection
 from django.db.models import Count, Q
-from django.utils import timezone
 
 
 class ReportingService:
@@ -43,9 +40,7 @@ class ReportingService:
         """Get average first response time in hours."""
         from escalated.models import Reply, Ticket
 
-        tickets = Ticket.objects.filter(
-            created_at__gte=start, created_at__lte=end
-        ).values_list("id", "created_at")
+        tickets = Ticket.objects.filter(created_at__gte=start, created_at__lte=end).values_list("id", "created_at")
 
         total_hours = 0
         count = 0
@@ -106,12 +101,14 @@ class ReportingService:
             total = agent_tickets.count()
             resolved = agent_tickets.filter(status__in=["resolved", "closed"]).count()
 
-            results.append({
-                "agent_id": agent.pk,
-                "agent_name": agent.get_full_name() or agent.username,
-                "total_tickets": total,
-                "resolved_tickets": resolved,
-            })
+            results.append(
+                {
+                    "agent_id": agent.pk,
+                    "agent_name": agent.get_full_name() or agent.username,
+                    "total_tickets": total,
+                    "resolved_tickets": resolved,
+                }
+            )
 
         return results
 
@@ -128,8 +125,6 @@ class ReportingService:
         if total == 0:
             return 100.0
 
-        breached = tickets.filter(
-            Q(sla_first_response_at__isnull=False) | Q(sla_resolution_at__isnull=False)
-        ).count()
+        breached = tickets.filter(Q(sla_first_response_at__isnull=False) | Q(sla_resolution_at__isnull=False)).count()
 
         return round(((total - breached) / total) * 100, 1)

--- a/escalated/services/skill_routing_service.py
+++ b/escalated/services/skill_routing_service.py
@@ -21,9 +21,7 @@ class SkillRoutingService:
 
         # Find user IDs who have these skills
         agent_user_ids = list(
-            AgentSkill.objects.filter(skill_id__in=skill_ids)
-            .values_list("user_id", flat=True)
-            .distinct()
+            AgentSkill.objects.filter(skill_id__in=skill_ids).values_list("user_id", flat=True).distinct()
         )
         if not agent_user_ids:
             return User.objects.none()

--- a/escalated/services/sla_service.py
+++ b/escalated/services/sla_service.py
@@ -1,10 +1,10 @@
 import logging
-from datetime import datetime, time, timedelta
+from datetime import datetime, timedelta
 
 from django.utils import timezone
 
 from escalated.conf import get_setting
-from escalated.models import Ticket, SlaPolicy
+from escalated.models import SlaPolicy, Ticket
 from escalated.signals import sla_breached, sla_warning
 
 logger = logging.getLogger("escalated")
@@ -32,21 +32,15 @@ class SlaService:
         first_response_hours = policy.get_first_response_hours(priority)
         if first_response_hours is not None:
             if policy.business_hours_only:
-                ticket.first_response_due_at = SlaService._add_business_hours(
-                    now, first_response_hours
-                )
+                ticket.first_response_due_at = SlaService._add_business_hours(now, first_response_hours)
             else:
-                ticket.first_response_due_at = now + timedelta(
-                    hours=first_response_hours
-                )
+                ticket.first_response_due_at = now + timedelta(hours=first_response_hours)
 
         # Resolution deadline
         resolution_hours = policy.get_resolution_hours(priority)
         if resolution_hours is not None:
             if policy.business_hours_only:
-                ticket.resolution_due_at = SlaService._add_business_hours(
-                    now, resolution_hours
-                )
+                ticket.resolution_due_at = SlaService._add_business_hours(now, resolution_hours)
             else:
                 ticket.resolution_due_at = now + timedelta(hours=resolution_hours)
 
@@ -76,9 +70,7 @@ class SlaService:
                 ticket=ticket,
                 breach_type="first_response",
             )
-            logger.warning(
-                f"SLA first response breached on ticket {ticket.reference}"
-            )
+            logger.warning(f"SLA first response breached on ticket {ticket.reference}")
 
         # Check resolution breach
         if (
@@ -94,9 +86,7 @@ class SlaService:
                 ticket=ticket,
                 breach_type="resolution",
             )
-            logger.warning(
-                f"SLA resolution breached on ticket {ticket.reference}"
-            )
+            logger.warning(f"SLA resolution breached on ticket {ticket.reference}")
 
         if breached:
             ticket.save(
@@ -122,11 +112,7 @@ class SlaService:
         warned = False
 
         # First response warning
-        if (
-            ticket.first_response_due_at
-            and not ticket.first_response_at
-            and not ticket.sla_first_response_breached
-        ):
+        if ticket.first_response_due_at and not ticket.first_response_at and not ticket.sla_first_response_breached:
             remaining = ticket.first_response_due_at - now
             if timedelta(0) < remaining <= threshold:
                 sla_warning.send(
@@ -138,11 +124,7 @@ class SlaService:
                 warned = True
 
         # Resolution warning
-        if (
-            ticket.resolution_due_at
-            and not ticket.resolved_at
-            and not ticket.sla_resolution_breached
-        ):
+        if ticket.resolution_due_at and not ticket.resolved_at and not ticket.sla_resolution_breached:
             remaining = ticket.resolution_due_at - now
             if timedelta(0) < remaining <= threshold:
                 sla_warning.send(
@@ -161,9 +143,7 @@ class SlaService:
         Check SLA breaches and warnings for all open tickets.
         Called by the check_sla management command.
         """
-        open_tickets = Ticket.objects.open().filter(
-            sla_policy__isnull=False
-        ).select_related("sla_policy")
+        open_tickets = Ticket.objects.open().filter(sla_policy__isnull=False).select_related("sla_policy")
 
         breached_count = 0
         warned_count = 0

--- a/escalated/services/sso_service.py
+++ b/escalated/services/sso_service.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import hmac
 import json
-import struct
 import time
 import xml.etree.ElementTree as ET
 
@@ -109,9 +108,7 @@ class SsoService:
                 raise SsoValidationError("SAML assertion missing Issuer element.")
             issuer = (issuer_el.text or "").strip()
             if issuer != entity_id:
-                raise SsoValidationError(
-                    f"SAML Issuer mismatch: expected '{entity_id}', got '{issuer}'."
-                )
+                raise SsoValidationError(f"SAML Issuer mismatch: expected '{entity_id}', got '{issuer}'.")
 
         # Validate conditions
         conditions_el = root.find(".//saml:Conditions", self.SAML_NS)
@@ -148,7 +145,6 @@ class SsoService:
 
         not_before = conditions_el.get("NotBefore")
         if not_before:
-            from email.utils import parsedate_to_datetime
             import datetime
 
             try:
@@ -171,9 +167,7 @@ class SsoService:
 
     def _extract_saml_attributes(self, root):
         attributes = {}
-        for attr_el in root.findall(
-            ".//saml:AttributeStatement/saml:Attribute", self.SAML_NS
-        ):
+        for attr_el in root.findall(".//saml:AttributeStatement/saml:Attribute", self.SAML_NS):
             name = attr_el.get("Name", "")
             value_el = attr_el.find("saml:AttributeValue", self.SAML_NS)
             if value_el is not None:
@@ -201,7 +195,7 @@ class SsoService:
 
         # Decode header
         try:
-            header = json.loads(self._base64url_decode(header_b64))
+            json.loads(self._base64url_decode(header_b64))
         except (json.JSONDecodeError, Exception):
             raise SsoValidationError("Invalid JWT: malformed header.")
 
@@ -259,9 +253,7 @@ class SsoService:
             "HS512": hashlib.sha512,
         }
         if algorithm in hmac_algos:
-            expected = hmac.new(
-                secret.encode(), signing_input, hmac_algos[algorithm]
-            ).digest()
+            expected = hmac.new(secret.encode(), signing_input, hmac_algos[algorithm]).digest()
             return hmac.compare_digest(expected, signature)
 
         raise SsoValidationError(f"Unsupported JWT algorithm: {algorithm}")

--- a/escalated/services/ticket_service.py
+++ b/escalated/services/ticket_service.py
@@ -1,5 +1,5 @@
-from escalated.drivers import get_driver
 from escalated.conf import get_setting
+from escalated.drivers import get_driver
 
 
 class TicketService:
@@ -49,10 +49,14 @@ class TicketService:
 
     def add_note(self, ticket, user, body):
         """Add an internal note to a ticket."""
-        return self.driver.add_reply(ticket, user, {
-            "body": body,
-            "is_internal_note": True,
-        })
+        return self.driver.add_reply(
+            ticket,
+            user,
+            {
+                "body": body,
+                "is_internal_note": True,
+            },
+        )
 
     def get(self, ticket_id):
         """Retrieve a ticket by ID."""
@@ -81,19 +85,23 @@ class TicketService:
     def close(self, ticket, user):
         """Close a ticket."""
         from escalated.models import Ticket
+
         return self.driver.transition_status(ticket, user, Ticket.Status.CLOSED)
 
     def resolve(self, ticket, user):
         """Resolve a ticket."""
         from escalated.models import Ticket
+
         return self.driver.transition_status(ticket, user, Ticket.Status.RESOLVED)
 
     def reopen(self, ticket, user):
         """Reopen a closed or resolved ticket."""
         from escalated.models import Ticket
+
         return self.driver.transition_status(ticket, user, Ticket.Status.REOPENED)
 
     def escalate(self, ticket, user):
         """Escalate a ticket."""
         from escalated.models import Ticket
+
         return self.driver.transition_status(ticket, user, Ticket.Status.ESCALATED)

--- a/escalated/services/two_factor_service.py
+++ b/escalated/services/two_factor_service.py
@@ -59,7 +59,7 @@ class TwoFactorService:
 
         # Dynamic truncation
         offset = hmac_digest[-1] & 0x0F
-        truncated = struct.unpack(">I", hmac_digest[offset:offset + 4])[0] & 0x7FFFFFFF
+        truncated = struct.unpack(">I", hmac_digest[offset : offset + 4])[0] & 0x7FFFFFFF
 
-        code = truncated % (10 ** self.DIGITS)
+        code = truncated % (10**self.DIGITS)
         return str(code).zfill(self.DIGITS)

--- a/escalated/services/webhook_dispatcher.py
+++ b/escalated/services/webhook_dispatcher.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import requests
 
@@ -25,11 +25,13 @@ class WebhookDispatcher:
         """Send a single webhook delivery."""
         from escalated.models import WebhookDelivery
 
-        body = json.dumps({
-            "event": event,
-            "payload": payload,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        })
+        body = json.dumps(
+            {
+                "event": event,
+                "payload": payload,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        )
 
         headers = {
             "Content-Type": "application/json",
@@ -37,9 +39,7 @@ class WebhookDispatcher:
         }
 
         if webhook.secret:
-            signature = hmac.new(
-                webhook.secret.encode(), body.encode(), hashlib.sha256
-            ).hexdigest()
+            signature = hmac.new(webhook.secret.encode(), body.encode(), hashlib.sha256).hexdigest()
             headers["X-Escalated-Signature"] = signature
 
         delivery = WebhookDelivery.objects.create(
@@ -50,12 +50,10 @@ class WebhookDispatcher:
         )
 
         try:
-            response = requests.post(
-                webhook.url, data=body, headers=headers, timeout=10
-            )
+            response = requests.post(webhook.url, data=body, headers=headers, timeout=10)
             delivery.response_code = response.status_code
             delivery.response_body = response.text[:2000]
-            delivery.delivered_at = datetime.now(timezone.utc)
+            delivery.delivered_at = datetime.now(UTC)
             delivery.attempts = attempt
             delivery.save()
 

--- a/escalated/signals.py
+++ b/escalated/signals.py
@@ -1,28 +1,28 @@
 import django.dispatch
 
 # Ticket lifecycle signals
-ticket_created = django.dispatch.Signal()          # sender=Ticket, ticket, user
-ticket_updated = django.dispatch.Signal()          # sender=Ticket, ticket, user, changes
-ticket_status_changed = django.dispatch.Signal()   # sender=Ticket, ticket, user, old_status, new_status
-ticket_assigned = django.dispatch.Signal()          # sender=Ticket, ticket, user, agent
-ticket_unassigned = django.dispatch.Signal()        # sender=Ticket, ticket, user, previous_agent
+ticket_created = django.dispatch.Signal()  # sender=Ticket, ticket, user
+ticket_updated = django.dispatch.Signal()  # sender=Ticket, ticket, user, changes
+ticket_status_changed = django.dispatch.Signal()  # sender=Ticket, ticket, user, old_status, new_status
+ticket_assigned = django.dispatch.Signal()  # sender=Ticket, ticket, user, agent
+ticket_unassigned = django.dispatch.Signal()  # sender=Ticket, ticket, user, previous_agent
 ticket_priority_changed = django.dispatch.Signal()  # sender=Ticket, ticket, user, old_priority, new_priority
-ticket_escalated = django.dispatch.Signal()         # sender=Ticket, ticket, user, reason
-ticket_resolved = django.dispatch.Signal()          # sender=Ticket, ticket, user
-ticket_closed = django.dispatch.Signal()            # sender=Ticket, ticket, user
-ticket_reopened = django.dispatch.Signal()          # sender=Ticket, ticket, user
+ticket_escalated = django.dispatch.Signal()  # sender=Ticket, ticket, user, reason
+ticket_resolved = django.dispatch.Signal()  # sender=Ticket, ticket, user
+ticket_closed = django.dispatch.Signal()  # sender=Ticket, ticket, user
+ticket_reopened = django.dispatch.Signal()  # sender=Ticket, ticket, user
 
 # Reply signals
-reply_created = django.dispatch.Signal()            # sender=Reply, reply, ticket, user
-internal_note_added = django.dispatch.Signal()      # sender=Reply, reply, ticket, user
+reply_created = django.dispatch.Signal()  # sender=Reply, reply, ticket, user
+internal_note_added = django.dispatch.Signal()  # sender=Reply, reply, ticket, user
 
 # SLA signals
-sla_breached = django.dispatch.Signal()             # sender=Ticket, ticket, breach_type
-sla_warning = django.dispatch.Signal()              # sender=Ticket, ticket, warning_type, remaining
+sla_breached = django.dispatch.Signal()  # sender=Ticket, ticket, breach_type
+sla_warning = django.dispatch.Signal()  # sender=Ticket, ticket, warning_type, remaining
 
 # Tag signals
-tag_added = django.dispatch.Signal()                # sender=Tag, tag, ticket, user
-tag_removed = django.dispatch.Signal()              # sender=Tag, tag, ticket, user
+tag_added = django.dispatch.Signal()  # sender=Tag, tag, ticket, user
+tag_removed = django.dispatch.Signal()  # sender=Tag, tag, ticket, user
 
 # Department signals
-department_changed = django.dispatch.Signal()       # sender=Ticket, ticket, user, old_department, new_department
+department_changed = django.dispatch.Signal()  # sender=Ticket, ticket, user, old_department, new_department

--- a/escalated/support/extract_result.py
+++ b/escalated/support/extract_result.py
@@ -6,7 +6,6 @@ source is exhausted), and an optional total-count hint for progress display.
 """
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -25,8 +24,8 @@ class ExtractResult:
     """
 
     records: list = field(default_factory=list)
-    cursor: Optional[str] = None
-    total_count: Optional[int] = None
+    cursor: str | None = None
+    total_count: int | None = None
 
     def is_exhausted(self) -> bool:
         """Return True when there are no more pages to fetch."""

--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -1,7 +1,7 @@
-from django.urls import path, include
+from django.urls import include, path
 
 from escalated.conf import get_setting
-from escalated.views import customer, agent, admin, guest, inbound, admin_plugins, import_views
+from escalated.views import admin, admin_plugins, agent, customer, guest, import_views, inbound
 
 app_name = "escalated"
 
@@ -59,14 +59,34 @@ admin_patterns = [
     # Ticket Links
     path("admin/tickets/<int:ticket_id>/links/", admin.ticket_links_index, name="admin_ticket_links_index"),
     path("admin/tickets/<int:ticket_id>/links/store/", admin.ticket_links_store, name="admin_ticket_links_store"),
-    path("admin/tickets/<int:ticket_id>/links/<int:link_id>/delete/", admin.ticket_links_destroy, name="admin_ticket_links_destroy"),
+    path(
+        "admin/tickets/<int:ticket_id>/links/<int:link_id>/delete/",
+        admin.ticket_links_destroy,
+        name="admin_ticket_links_destroy",
+    ),
     # Ticket Merging
     path("admin/tickets/<int:ticket_id>/merge/", admin.ticket_merge, name="admin_ticket_merge"),
     # Side Conversations
-    path("admin/tickets/<int:ticket_id>/side-conversations/", admin.side_conversations_index, name="admin_side_conversations_index"),
-    path("admin/tickets/<int:ticket_id>/side-conversations/store/", admin.side_conversations_store, name="admin_side_conversations_store"),
-    path("admin/tickets/<int:ticket_id>/side-conversations/<int:conversation_id>/reply/", admin.side_conversations_reply, name="admin_side_conversations_reply"),
-    path("admin/tickets/<int:ticket_id>/side-conversations/<int:conversation_id>/close/", admin.side_conversations_close, name="admin_side_conversations_close"),
+    path(
+        "admin/tickets/<int:ticket_id>/side-conversations/",
+        admin.side_conversations_index,
+        name="admin_side_conversations_index",
+    ),
+    path(
+        "admin/tickets/<int:ticket_id>/side-conversations/store/",
+        admin.side_conversations_store,
+        name="admin_side_conversations_store",
+    ),
+    path(
+        "admin/tickets/<int:ticket_id>/side-conversations/<int:conversation_id>/reply/",
+        admin.side_conversations_reply,
+        name="admin_side_conversations_reply",
+    ),
+    path(
+        "admin/tickets/<int:ticket_id>/side-conversations/<int:conversation_id>/close/",
+        admin.side_conversations_close,
+        name="admin_side_conversations_close",
+    ),
     # Departments
     path("admin/departments/", admin.departments_index, name="admin_departments_index"),
     path("admin/departments/create/", admin.departments_create, name="admin_departments_create"),
@@ -81,7 +101,11 @@ admin_patterns = [
     path("admin/escalation-rules/", admin.escalation_rules_index, name="admin_escalation_rules_index"),
     path("admin/escalation-rules/create/", admin.escalation_rules_create, name="admin_escalation_rules_create"),
     path("admin/escalation-rules/<int:rule_id>/edit/", admin.escalation_rules_edit, name="admin_escalation_rules_edit"),
-    path("admin/escalation-rules/<int:rule_id>/delete/", admin.escalation_rules_delete, name="admin_escalation_rules_delete"),
+    path(
+        "admin/escalation-rules/<int:rule_id>/delete/",
+        admin.escalation_rules_delete,
+        name="admin_escalation_rules_delete",
+    ),
     # Tags
     path("admin/tags/", admin.tags_index, name="admin_tags_index"),
     path("admin/tags/create/", admin.tags_create, name="admin_tags_create"),
@@ -90,8 +114,16 @@ admin_patterns = [
     # Canned Responses
     path("admin/canned-responses/", admin.canned_responses_index, name="admin_canned_responses_index"),
     path("admin/canned-responses/create/", admin.canned_responses_create, name="admin_canned_responses_create"),
-    path("admin/canned-responses/<int:response_id>/edit/", admin.canned_responses_edit, name="admin_canned_responses_edit"),
-    path("admin/canned-responses/<int:response_id>/delete/", admin.canned_responses_delete, name="admin_canned_responses_delete"),
+    path(
+        "admin/canned-responses/<int:response_id>/edit/",
+        admin.canned_responses_edit,
+        name="admin_canned_responses_edit",
+    ),
+    path(
+        "admin/canned-responses/<int:response_id>/delete/",
+        admin.canned_responses_delete,
+        name="admin_canned_responses_delete",
+    ),
     # Macros
     path("admin/macros/", admin.macros_index, name="admin_macros_index"),
     path("admin/macros/create/", admin.macros_create, name="admin_macros_create"),
@@ -111,7 +143,11 @@ admin_patterns = [
     path("admin/business-hours/", admin.business_hours_index, name="admin_business_hours_index"),
     path("admin/business-hours/create/", admin.business_hours_create, name="admin_business_hours_create"),
     path("admin/business-hours/<int:schedule_id>/edit/", admin.business_hours_edit, name="admin_business_hours_edit"),
-    path("admin/business-hours/<int:schedule_id>/delete/", admin.business_hours_delete, name="admin_business_hours_delete"),
+    path(
+        "admin/business-hours/<int:schedule_id>/delete/",
+        admin.business_hours_delete,
+        name="admin_business_hours_delete",
+    ),
     # Roles
     path("admin/roles/", admin.roles_index, name="admin_roles_index"),
     path("admin/roles/create/", admin.roles_create, name="admin_roles_create"),
@@ -131,8 +167,12 @@ admin_patterns = [
     # Knowledge Base - Categories
     path("admin/kb/categories/", admin.kb_categories_index, name="admin_kb_categories_index"),
     path("admin/kb/categories/store/", admin.kb_categories_store, name="admin_kb_categories_store"),
-    path("admin/kb/categories/<int:category_id>/update/", admin.kb_categories_update, name="admin_kb_categories_update"),
-    path("admin/kb/categories/<int:category_id>/delete/", admin.kb_categories_delete, name="admin_kb_categories_delete"),
+    path(
+        "admin/kb/categories/<int:category_id>/update/", admin.kb_categories_update, name="admin_kb_categories_update"
+    ),
+    path(
+        "admin/kb/categories/<int:category_id>/delete/", admin.kb_categories_delete, name="admin_kb_categories_delete"
+    ),
     # Plugins
     path("admin/plugins/", admin_plugins.plugin_list, name="admin_plugins_index"),
     path("admin/plugins/upload/", admin_plugins.plugin_upload, name="admin_plugins_upload"),
@@ -170,11 +210,27 @@ admin_patterns = [
     path("admin/custom-objects/", admin.custom_objects_index, name="admin_custom_objects_index"),
     path("admin/custom-objects/create/", admin.custom_objects_create, name="admin_custom_objects_create"),
     path("admin/custom-objects/<int:object_id>/edit/", admin.custom_objects_edit, name="admin_custom_objects_edit"),
-    path("admin/custom-objects/<int:object_id>/delete/", admin.custom_objects_delete, name="admin_custom_objects_delete"),
-    path("admin/custom-objects/<int:object_id>/records/", admin.custom_object_records, name="admin_custom_object_records"),
-    path("admin/custom-objects/<int:object_id>/records/store/", admin.custom_object_records_store, name="admin_custom_object_records_store"),
-    path("admin/custom-objects/<int:object_id>/records/<int:record_id>/update/", admin.custom_object_records_update, name="admin_custom_object_records_update"),
-    path("admin/custom-objects/<int:object_id>/records/<int:record_id>/delete/", admin.custom_object_records_delete, name="admin_custom_object_records_delete"),
+    path(
+        "admin/custom-objects/<int:object_id>/delete/", admin.custom_objects_delete, name="admin_custom_objects_delete"
+    ),
+    path(
+        "admin/custom-objects/<int:object_id>/records/", admin.custom_object_records, name="admin_custom_object_records"
+    ),
+    path(
+        "admin/custom-objects/<int:object_id>/records/store/",
+        admin.custom_object_records_store,
+        name="admin_custom_object_records_store",
+    ),
+    path(
+        "admin/custom-objects/<int:object_id>/records/<int:record_id>/update/",
+        admin.custom_object_records_update,
+        name="admin_custom_object_records_update",
+    ),
+    path(
+        "admin/custom-objects/<int:object_id>/records/<int:record_id>/delete/",
+        admin.custom_object_records_delete,
+        name="admin_custom_object_records_delete",
+    ),
     # Reports
     path("admin/reports/dashboard/", admin.reports_dashboard, name="admin_reports_dashboard"),
     # Import
@@ -182,9 +238,13 @@ admin_patterns = [
     path("admin/import/create/", import_views.import_create, name="admin_import_create"),
     path("admin/import/store/", import_views.import_store, name="admin_import_store"),
     path("admin/import/<uuid:job_uuid>/", import_views.import_show, name="admin_import_show"),
-    path("admin/import/<uuid:job_uuid>/authenticate/", import_views.import_authenticate, name="admin_import_authenticate"),
+    path(
+        "admin/import/<uuid:job_uuid>/authenticate/", import_views.import_authenticate, name="admin_import_authenticate"
+    ),
     path("admin/import/<uuid:job_uuid>/mapping/", import_views.import_mapping, name="admin_import_mapping"),
-    path("admin/import/<uuid:job_uuid>/mapping/save/", import_views.import_mapping_save, name="admin_import_mapping_save"),
+    path(
+        "admin/import/<uuid:job_uuid>/mapping/save/", import_views.import_mapping_save, name="admin_import_mapping_save"
+    ),
     path("admin/import/<uuid:job_uuid>/run/", import_views.import_run, name="admin_import_run"),
     path("admin/import/<uuid:job_uuid>/pause/", import_views.import_pause, name="admin_import_pause"),
     path("admin/import/<uuid:job_uuid>/progress/", import_views.import_progress, name="admin_import_progress"),
@@ -210,18 +270,13 @@ urlpatterns = list(inbound_patterns)
 
 # UI routes (only when UI is enabled)
 if get_setting("UI_ENABLED"):
-    urlpatterns = (
-        customer_patterns
-        + agent_patterns
-        + admin_patterns
-        + guest_patterns
-        + urlpatterns
-    )
+    urlpatterns = customer_patterns + agent_patterns + admin_patterns + guest_patterns + urlpatterns
 
 # Inject plugin bridge routes (pages, API endpoints, webhooks) if the SDK
 # bridge has booted and registered patterns from plugin manifests.
 try:
     from escalated.bridge.plugin_bridge import get_bridge as _get_bridge
+
     _bridge = _get_bridge()
     _plugin_urls = _bridge.get_plugin_urls()
     if _plugin_urls:
@@ -231,7 +286,7 @@ except Exception:
 
 # Conditionally include API URLs when API is enabled
 if get_setting("API_ENABLED"):
-    from escalated.api_urls import api_patterns, admin_api_token_patterns
+    from escalated.api_urls import admin_api_token_patterns, api_patterns
 
     api_prefix = get_setting("API_PREFIX").strip("/")
 

--- a/escalated/validators.py
+++ b/escalated/validators.py
@@ -33,10 +33,7 @@ class BaseValidator(forms.Form):
 
         form = cls(raw)
         if not form.is_valid():
-            errors = {
-                field: msgs[0] if isinstance(msgs, list) else msgs
-                for field, msgs in form.errors.items()
-            }
+            errors = {field: msgs[0] if isinstance(msgs, list) else msgs for field, msgs in form.errors.items()}
             return None, JsonResponse(
                 {"message": "Validation failed.", "errors": errors},
                 status=422,
@@ -104,8 +101,12 @@ class UpdateTagsValidator(BaseValidator):
 
 class BulkActionValidator(BaseValidator):
     ALLOWED_ACTIONS = [
-        "change_status", "change_priority", "assign",
-        "add_tags", "remove_tags", "delete",
+        "change_status",
+        "change_priority",
+        "assign",
+        "add_tags",
+        "remove_tags",
+        "delete",
     ]
 
     ticket_ids = forms.JSONField(required=True)

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -5,83 +5,78 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.core.paginator import Paginator
-from django.db.models import Count, Q, Avg, F, Max
+from django.db.models import Avg, Count, Max, Q
 from django.http import HttpResponseForbidden, HttpResponseNotFound, JsonResponse
 from django.shortcuts import redirect
 from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
-from escalated.rendering import render_page
 
 from escalated.models import (
-    Ticket,
-    Tag,
-    Department,
-    SlaPolicy,
-    EscalationRule,
-    CannedResponse,
-    EscalatedSetting,
-    Macro,
-    Reply,
-    SatisfactionRating,
-    AuditLog,
-    TicketStatus,
-    BusinessSchedule,
-    Holiday,
-    Role,
-    Permission,
-    CustomField,
-    CustomFieldValue,
-    TicketLink,
-    SideConversation,
-    SideConversationReply,
-    ArticleCategory,
-    Article,
-    AgentProfile,
-    Skill,
-    AgentSkill,
     AgentCapacity,
-    Webhook,
-    WebhookDelivery,
+    Article,
+    ArticleCategory,
+    AuditLog,
     Automation,
-    TwoFactor,
+    BusinessSchedule,
+    CannedResponse,
+    CustomField,
     CustomObject,
     CustomObjectRecord,
+    Department,
+    EscalatedSetting,
+    EscalationRule,
+    Holiday,
+    Macro,
+    Permission,
+    Reply,
+    Role,
+    SatisfactionRating,
+    SideConversation,
+    SideConversationReply,
+    Skill,
+    SlaPolicy,
+    Tag,
+    Ticket,
+    TicketLink,
+    TicketStatus,
+    TwoFactor,
+    Webhook,
+    WebhookDelivery,
 )
 from escalated.permissions import is_admin, is_agent
+from escalated.rendering import render_page
 from escalated.serializers import (
-    TicketSerializer,
-    ReplySerializer,
-    TagSerializer,
-    DepartmentSerializer,
-    SlaPolicySerializer,
-    EscalationRuleSerializer,
-    CannedResponseSerializer,
-    EscalatedSettingSerializer,
     ActivitySerializer,
-    AttachmentSerializer,
-    MacroSerializer,
-    SatisfactionRatingSerializer,
-    AuditLogSerializer,
-    TicketStatusSerializer,
-    BusinessScheduleSerializer,
-    HolidaySerializer,
-    RoleSerializer,
-    PermissionSerializer,
-    CustomFieldSerializer,
-    TicketLinkSerializer,
-    SideConversationSerializer,
-    SideConversationReplySerializer,
+    AgentCapacitySerializer,
     ArticleCategorySerializer,
     ArticleSerializer,
-    AgentProfileSerializer,
-    SkillSerializer,
-    AgentCapacitySerializer,
-    WebhookSerializer,
-    WebhookDeliverySerializer,
+    AttachmentSerializer,
+    AuditLogSerializer,
     AutomationSerializer,
-    CustomObjectSerializer,
+    BusinessScheduleSerializer,
+    CannedResponseSerializer,
+    CustomFieldSerializer,
     CustomObjectRecordSerializer,
+    CustomObjectSerializer,
+    DepartmentSerializer,
+    EscalatedSettingSerializer,
+    EscalationRuleSerializer,
+    MacroSerializer,
+    PermissionSerializer,
+    ReplySerializer,
+    RoleSerializer,
+    SatisfactionRatingSerializer,
+    SideConversationReplySerializer,
+    SideConversationSerializer,
+    SkillSerializer,
+    SlaPolicySerializer,
+    TagSerializer,
+    TicketLinkSerializer,
+    TicketSerializer,
+    TicketStatusSerializer,
+    WebhookDeliverySerializer,
+    WebhookSerializer,
 )
 from escalated.services.ticket_service import TicketService
 
@@ -108,17 +103,17 @@ _SENSITIVE_SETTING_KEYS = {
 def _mask_secret(value: str) -> str:
     """Mask a secret value, showing only the first 3 characters."""
     if not value:
-        return ''
+        return ""
     if len(value) <= 6:
-        return '*' * len(value)
-    return value[:3] + '*' * min(len(value) - 3, 12)
+        return "*" * len(value)
+    return value[:3] + "*" * min(len(value) - 3, 12)
 
 
 def _is_masked_value(value: str | None) -> bool:
     """Return True if the value looks like a masked secret (e.g. 'abc************')."""
     if not value:
         return False
-    return bool(re_module.match(r'^.{0,3}\*{3,}$', value))
+    return bool(re_module.match(r"^.{0,3}\*{3,}$", value))
 
 
 # ---------------------------------------------------------------------------
@@ -138,57 +133,47 @@ def reports(request):
 
     total_tickets = Ticket.objects.count()
     open_tickets = Ticket.objects.open().count()
-    resolved_last_30 = Ticket.objects.filter(
-        resolved_at__gte=thirty_days_ago
-    ).count()
-    created_last_30 = Ticket.objects.filter(
-        created_at__gte=thirty_days_ago
-    ).count()
+    resolved_last_30 = Ticket.objects.filter(resolved_at__gte=thirty_days_ago).count()
+    created_last_30 = Ticket.objects.filter(created_at__gte=thirty_days_ago).count()
     sla_breaches = Ticket.objects.breached_sla().count()
 
     by_department = list(
-        Department.objects.filter(is_active=True)
-        .annotate(ticket_count=Count("tickets"))
-        .values("name", "ticket_count")
+        Department.objects.filter(is_active=True).annotate(ticket_count=Count("tickets")).values("name", "ticket_count")
     )
 
-    by_priority = {
-        p.value: Ticket.objects.filter(priority=p.value).count()
-        for p in Ticket.Priority
-    }
+    by_priority = {p.value: Ticket.objects.filter(priority=p.value).count() for p in Ticket.Priority}
 
-    by_status = {
-        s.value: Ticket.objects.filter(status=s.value).count()
-        for s in Ticket.Status
-    }
+    by_status = {s.value: Ticket.objects.filter(status=s.value).count() for s in Ticket.Status}
 
     # CSAT stats
-    csat_ratings = SatisfactionRating.objects.filter(
-        created_at__gte=thirty_days_ago
-    )
+    csat_ratings = SatisfactionRating.objects.filter(created_at__gte=thirty_days_ago)
     avg_csat = csat_ratings.aggregate(avg_rating=Avg("rating"))["avg_rating"]
     total_ratings = csat_ratings.count()
     csat_breakdown = {}
     for r in range(1, 6):
         csat_breakdown[str(r)] = csat_ratings.filter(rating=r).count()
 
-    return render_page(request, "Escalated/Admin/Reports", props={
-        "stats": {
-            "total_tickets": total_tickets,
-            "open_tickets": open_tickets,
-            "resolved_last_30": resolved_last_30,
-            "created_last_30": created_last_30,
-            "sla_breaches": sla_breaches,
+    return render_page(
+        request,
+        "Escalated/Admin/Reports",
+        props={
+            "stats": {
+                "total_tickets": total_tickets,
+                "open_tickets": open_tickets,
+                "resolved_last_30": resolved_last_30,
+                "created_last_30": created_last_30,
+                "sla_breaches": sla_breaches,
+            },
+            "by_department": by_department,
+            "by_priority": by_priority,
+            "by_status": by_status,
+            "csat": {
+                "average": round(avg_csat, 1) if avg_csat else None,
+                "total": total_ratings,
+                "breakdown": csat_breakdown,
+            },
         },
-        "by_department": by_department,
-        "by_priority": by_priority,
-        "by_status": by_status,
-        "csat": {
-            "average": round(avg_csat, 1) if avg_csat else None,
-            "total": total_ratings,
-            "breakdown": csat_breakdown,
-        },
-    })
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -199,6 +184,7 @@ def reports(request):
 def _get_agents():
     """Return list of users who are agents or admins."""
     from django.contrib.auth import get_user_model
+
     User = get_user_model()
     users = User.objects.filter(is_active=True)
     return [
@@ -215,9 +201,7 @@ def tickets_index(request):
     if check:
         return check
 
-    tickets = Ticket.objects.select_related(
-        "assigned_to", "department"
-    ).prefetch_related("tags")
+    tickets = Ticket.objects.select_related("assigned_to", "department").prefetch_related("tags")
 
     # Apply filters
     status = request.GET.get("status")
@@ -257,8 +241,12 @@ def tickets_index(request):
 
     sort = request.GET.get("sort", "-created_at")
     allowed_sorts = [
-        "created_at", "-created_at", "priority", "-priority",
-        "updated_at", "-updated_at",
+        "created_at",
+        "-created_at",
+        "priority",
+        "-priority",
+        "updated_at",
+        "-updated_at",
     ]
     if sort in allowed_sorts:
         tickets = tickets.order_by(sort)
@@ -266,31 +254,33 @@ def tickets_index(request):
     paginator = Paginator(tickets, 25)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render_page(request, "Escalated/Admin/Tickets/Index", props={
-        "tickets": TicketSerializer.serialize_list(page.object_list),
-        "pagination": {
-            "current_page": page.number,
-            "total_pages": paginator.num_pages,
-            "total_count": paginator.count,
-            "has_next": page.has_next(),
-            "has_previous": page.has_previous(),
+    return render_page(
+        request,
+        "Escalated/Admin/Tickets/Index",
+        props={
+            "tickets": TicketSerializer.serialize_list(page.object_list),
+            "pagination": {
+                "current_page": page.number,
+                "total_pages": paginator.num_pages,
+                "total_count": paginator.count,
+                "has_next": page.has_next(),
+                "has_previous": page.has_previous(),
+            },
+            "filters": {
+                "status": status,
+                "priority": priority,
+                "assigned": assigned,
+                "department": department,
+                "tag": tag,
+                "search": search,
+                "sort": sort,
+                "following": following,
+            },
+            "departments": DepartmentSerializer.serialize_list(Department.objects.filter(is_active=True)),
+            "tags": TagSerializer.serialize_list(Tag.objects.all()),
+            "agents": _get_agents(),
         },
-        "filters": {
-            "status": status,
-            "priority": priority,
-            "assigned": assigned,
-            "department": department,
-            "tag": tag,
-            "search": search,
-            "sort": sort,
-            "following": following,
-        },
-        "departments": DepartmentSerializer.serialize_list(
-            Department.objects.filter(is_active=True)
-        ),
-        "tags": TagSerializer.serialize_list(Tag.objects.all()),
-        "agents": _get_agents(),
-    })
+    )
 
 
 @login_required
@@ -301,34 +291,32 @@ def tickets_show(request, ticket_id):
         return check
 
     try:
-        ticket = Ticket.objects.select_related(
-            "assigned_to", "department", "sla_policy"
-        ).prefetch_related(
-            "tags",
-            "replies__author",
-            "replies__attachments",
-            "activities",
-            "attachments",
-        ).get(pk=ticket_id)
+        ticket = (
+            Ticket.objects.select_related("assigned_to", "department", "sla_policy")
+            .prefetch_related(
+                "tags",
+                "replies__author",
+                "replies__attachments",
+                "activities",
+                "attachments",
+            )
+            .get(pk=ticket_id)
+        )
     except Ticket.DoesNotExist:
         return HttpResponseNotFound(_("Ticket not found"))
 
     replies = ticket.replies.filter(is_deleted=False).select_related("author")
     activities = ticket.activities.all()[:50]
 
-    canned_responses = CannedResponse.objects.filter(
-        Q(is_shared=True) | Q(created_by=request.user)
-    )
+    canned_responses = CannedResponse.objects.filter(Q(is_shared=True) | Q(created_by=request.user))
 
     # Macros available to this user (shared + own)
-    macros = Macro.objects.filter(
-        Q(is_shared=True) | Q(created_by=request.user)
-    ).order_by("order")
+    macros = Macro.objects.filter(Q(is_shared=True) | Q(created_by=request.user)).order_by("order")
 
     # Pinned notes
-    pinned_notes = ticket.replies.filter(
-        is_deleted=False, is_internal_note=True, is_pinned=True
-    ).select_related("author")
+    pinned_notes = ticket.replies.filter(is_deleted=False, is_internal_note=True, is_pinned=True).select_related(
+        "author"
+    )
 
     # Satisfaction rating
     try:
@@ -337,25 +325,27 @@ def tickets_show(request, ticket_id):
     except SatisfactionRating.DoesNotExist:
         satisfaction_data = None
 
-    return render_page(request, "Escalated/Admin/Tickets/Show", props={
-        "ticket": TicketSerializer.serialize(ticket),
-        "replies": ReplySerializer.serialize_list(replies),
-        "activities": [ActivitySerializer.serialize(a) for a in activities],
-        "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
-        "agents": _get_agents(),
-        "departments": DepartmentSerializer.serialize_list(
-            Department.objects.filter(is_active=True)
-        ),
-        "tags": TagSerializer.serialize_list(Tag.objects.all()),
-        "canned_responses": CannedResponseSerializer.serialize_list(canned_responses),
-        "macros": MacroSerializer.serialize_list(macros),
-        "statuses": [{"value": s.value, "label": s.label} for s in Ticket.Status],
-        "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
-        "is_following": ticket.is_followed_by(request.user.pk),
-        "followers_count": ticket.followers_count,
-        "pinned_notes": ReplySerializer.serialize_list(pinned_notes),
-        "satisfaction_rating": satisfaction_data,
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Tickets/Show",
+        props={
+            "ticket": TicketSerializer.serialize(ticket),
+            "replies": ReplySerializer.serialize_list(replies),
+            "activities": [ActivitySerializer.serialize(a) for a in activities],
+            "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
+            "agents": _get_agents(),
+            "departments": DepartmentSerializer.serialize_list(Department.objects.filter(is_active=True)),
+            "tags": TagSerializer.serialize_list(Tag.objects.all()),
+            "canned_responses": CannedResponseSerializer.serialize_list(canned_responses),
+            "macros": MacroSerializer.serialize_list(macros),
+            "statuses": [{"value": s.value, "label": s.label} for s in Ticket.Status],
+            "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+            "is_following": ticket.is_followed_by(request.user.pk),
+            "followers_count": ticket.followers_count,
+            "pinned_notes": ReplySerializer.serialize_list(pinned_notes),
+            "satisfaction_rating": satisfaction_data,
+        },
+    )
 
 
 @login_required
@@ -382,9 +372,10 @@ def tickets_reply(request, ticket_id):
 
     files = request.FILES.getlist("attachments")
     if files:
-        from escalated.services.attachment_service import AttachmentService
         from escalated.conf import get_setting
-        for f in files[:get_setting("MAX_ATTACHMENTS")]:
+        from escalated.services.attachment_service import AttachmentService
+
+        for f in files[: get_setting("MAX_ATTACHMENTS")]:
             try:
                 AttachmentService.attach(reply, f)
             except Exception:
@@ -434,6 +425,7 @@ def tickets_assign(request, ticket_id):
         return HttpResponseNotFound(_("Ticket not found"))
 
     from django.contrib.auth import get_user_model
+
     User = get_user_model()
 
     agent_id = request.POST.get("agent_id")
@@ -575,9 +567,13 @@ def departments_index(request):
         ticket_count=Count("tickets"),
     )
 
-    return render_page(request, "Escalated/Admin/Departments/Index", props={
-        "departments": DepartmentSerializer.serialize_list(departments),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Departments/Index",
+        props={
+            "departments": DepartmentSerializer.serialize_list(departments),
+        },
+    )
 
 
 @login_required
@@ -593,13 +589,15 @@ def departments_create(request):
         is_active = request.POST.get("is_active", "true") == "true"
 
         if not name:
-            return render_page(request, "Escalated/Admin/Departments/Create", props={
-                "errors": {"name": _("Name is required.")},
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/Departments/Create",
+                props={
+                    "errors": {"name": _("Name is required.")},
+                },
+            )
 
-        Department.objects.create(
-            name=name, slug=slug, description=description, is_active=is_active
-        )
+        Department.objects.create(name=name, slug=slug, description=description, is_active=is_active)
         return redirect("escalated:admin_departments_index")
 
     return render_page(request, "Escalated/Admin/Departments/Create", props={})
@@ -618,12 +616,8 @@ def departments_edit(request, department_id):
 
     if request.method == "POST":
         department.name = request.POST.get("name", department.name)
-        department.slug = slugify(
-            request.POST.get("slug", "") or department.name
-        )
-        department.description = request.POST.get(
-            "description", department.description
-        )
+        department.slug = slugify(request.POST.get("slug", "") or department.name)
+        department.description = request.POST.get("description", department.description)
         department.is_active = request.POST.get("is_active", "true") == "true"
         department.save()
 
@@ -635,16 +629,21 @@ def departments_edit(request, department_id):
         return redirect("escalated:admin_departments_index")
 
     from django.contrib.auth import get_user_model
+
     User = get_user_model()
 
-    return render_page(request, "Escalated/Admin/Departments/Edit", props={
-        "department": DepartmentSerializer.serialize(department),
-        "all_agents": [
-            {"id": u.pk, "name": u.get_full_name() or u.username, "email": u.email}
-            for u in User.objects.filter(is_active=True)
-        ],
-        "current_agent_ids": list(department.agents.values_list("pk", flat=True)),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Departments/Edit",
+        props={
+            "department": DepartmentSerializer.serialize(department),
+            "all_agents": [
+                {"id": u.pk, "name": u.get_full_name() or u.username, "email": u.email}
+                for u in User.objects.filter(is_active=True)
+            ],
+            "current_agent_ids": list(department.agents.values_list("pk", flat=True)),
+        },
+    )
 
 
 @login_required
@@ -677,9 +676,13 @@ def sla_policies_index(request):
         return check
 
     policies = SlaPolicy.objects.all()
-    return render_page(request, "Escalated/Admin/SlaPolicies/Index", props={
-        "policies": SlaPolicySerializer.serialize_list(policies),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/SlaPolicies/Index",
+        props={
+            "policies": SlaPolicySerializer.serialize_list(policies),
+        },
+    )
 
 
 @login_required
@@ -693,21 +696,21 @@ def sla_policies_create(request):
 
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/SlaPolicies/Create", props={
-                "errors": {"name": _("Name is required.")},
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/SlaPolicies/Create",
+                props={
+                    "errors": {"name": _("Name is required.")},
+                },
+            )
 
         try:
-            first_response_hours = json.loads(
-                request.POST.get("first_response_hours", "{}")
-            )
+            first_response_hours = json.loads(request.POST.get("first_response_hours", "{}"))
         except (json.JSONDecodeError, TypeError):
             first_response_hours = {}
 
         try:
-            resolution_hours = json.loads(
-                request.POST.get("resolution_hours", "{}")
-            )
+            resolution_hours = json.loads(request.POST.get("resolution_hours", "{}"))
         except (json.JSONDecodeError, TypeError):
             resolution_hours = {}
 
@@ -728,9 +731,13 @@ def sla_policies_create(request):
         )
         return redirect("escalated:admin_sla_policies_index")
 
-    return render_page(request, "Escalated/Admin/SlaPolicies/Create", props={
-        "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/SlaPolicies/Create",
+        props={
+            "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+        },
+    )
 
 
 @login_required
@@ -749,9 +756,7 @@ def sla_policies_edit(request, policy_id):
 
         policy.name = request.POST.get("name", policy.name)
         policy.description = request.POST.get("description", policy.description)
-        policy.business_hours_only = (
-            request.POST.get("business_hours_only", "false") == "true"
-        )
+        policy.business_hours_only = request.POST.get("business_hours_only", "false") == "true"
         policy.is_active = request.POST.get("is_active", "true") == "true"
 
         is_default = request.POST.get("is_default", "false") == "true"
@@ -760,26 +765,26 @@ def sla_policies_edit(request, policy_id):
         policy.is_default = is_default
 
         try:
-            policy.first_response_hours = json.loads(
-                request.POST.get("first_response_hours", "{}")
-            )
+            policy.first_response_hours = json.loads(request.POST.get("first_response_hours", "{}"))
         except (json.JSONDecodeError, TypeError):
             pass
 
         try:
-            policy.resolution_hours = json.loads(
-                request.POST.get("resolution_hours", "{}")
-            )
+            policy.resolution_hours = json.loads(request.POST.get("resolution_hours", "{}"))
         except (json.JSONDecodeError, TypeError):
             pass
 
         policy.save()
         return redirect("escalated:admin_sla_policies_index")
 
-    return render_page(request, "Escalated/Admin/SlaPolicies/Edit", props={
-        "policy": SlaPolicySerializer.serialize(policy),
-        "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/SlaPolicies/Edit",
+        props={
+            "policy": SlaPolicySerializer.serialize(policy),
+            "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+        },
+    )
 
 
 @login_required
@@ -812,9 +817,13 @@ def escalation_rules_index(request):
         return check
 
     rules = EscalationRule.objects.all()
-    return render_page(request, "Escalated/Admin/EscalationRules/Index", props={
-        "rules": EscalationRuleSerializer.serialize_list(rules),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/EscalationRules/Index",
+        props={
+            "rules": EscalationRuleSerializer.serialize_list(rules),
+        },
+    )
 
 
 @login_required
@@ -828,13 +837,14 @@ def escalation_rules_create(request):
 
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/EscalationRules/Create", props={
-                "errors": {"name": _("Name is required.")},
-                "trigger_types": [
-                    {"value": t.value, "label": t.label}
-                    for t in EscalationRule.TriggerType
-                ],
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/EscalationRules/Create",
+                props={
+                    "errors": {"name": _("Name is required.")},
+                    "trigger_types": [{"value": t.value, "label": t.label} for t in EscalationRule.TriggerType],
+                },
+            )
 
         try:
             conditions = json.loads(request.POST.get("conditions", "{}"))
@@ -857,12 +867,13 @@ def escalation_rules_create(request):
         )
         return redirect("escalated:admin_escalation_rules_index")
 
-    return render_page(request, "Escalated/Admin/EscalationRules/Create", props={
-        "trigger_types": [
-            {"value": t.value, "label": t.label}
-            for t in EscalationRule.TriggerType
-        ],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/EscalationRules/Create",
+        props={
+            "trigger_types": [{"value": t.value, "label": t.label} for t in EscalationRule.TriggerType],
+        },
+    )
 
 
 @login_required
@@ -898,13 +909,14 @@ def escalation_rules_edit(request, rule_id):
         rule.save()
         return redirect("escalated:admin_escalation_rules_index")
 
-    return render_page(request, "Escalated/Admin/EscalationRules/Edit", props={
-        "rule": EscalationRuleSerializer.serialize(rule),
-        "trigger_types": [
-            {"value": t.value, "label": t.label}
-            for t in EscalationRule.TriggerType
-        ],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/EscalationRules/Edit",
+        props={
+            "rule": EscalationRuleSerializer.serialize(rule),
+            "trigger_types": [{"value": t.value, "label": t.label} for t in EscalationRule.TriggerType],
+        },
+    )
 
 
 @login_required
@@ -937,12 +949,13 @@ def tags_index(request):
         return check
 
     tags = Tag.objects.annotate(ticket_count=Count("tickets"))
-    return render_page(request, "Escalated/Admin/Tags/Index", props={
-        "tags": [
-            {**TagSerializer.serialize(t), "ticket_count": t.ticket_count}
-            for t in tags
-        ],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Tags/Index",
+        props={
+            "tags": [{**TagSerializer.serialize(t), "ticket_count": t.ticket_count} for t in tags],
+        },
+    )
 
 
 @login_required
@@ -954,9 +967,13 @@ def tags_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/Tags/Create", props={
-                "errors": {"name": _("Name is required.")},
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/Tags/Create",
+                props={
+                    "errors": {"name": _("Name is required.")},
+                },
+            )
 
         Tag.objects.create(
             name=name,
@@ -986,9 +1003,13 @@ def tags_edit(request, tag_id):
         tag.save()
         return redirect("escalated:admin_tags_index")
 
-    return render_page(request, "Escalated/Admin/Tags/Edit", props={
-        "tag": TagSerializer.serialize(tag),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Tags/Edit",
+        props={
+            "tag": TagSerializer.serialize(tag),
+        },
+    )
 
 
 @login_required
@@ -1021,9 +1042,13 @@ def canned_responses_index(request):
         return check
 
     responses = CannedResponse.objects.select_related("created_by")
-    return render_page(request, "Escalated/Admin/CannedResponses/Index", props={
-        "canned_responses": CannedResponseSerializer.serialize_list(responses),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/CannedResponses/Index",
+        props={
+            "canned_responses": CannedResponseSerializer.serialize_list(responses),
+        },
+    )
 
 
 @login_required
@@ -1035,9 +1060,13 @@ def canned_responses_create(request):
     if request.method == "POST":
         title = request.POST.get("title", "").strip()
         if not title:
-            return render_page(request, "Escalated/Admin/CannedResponses/Create", props={
-                "errors": {"title": _("Title is required.")},
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/CannedResponses/Create",
+                props={
+                    "errors": {"title": _("Title is required.")},
+                },
+            )
 
         CannedResponse.objects.create(
             title=title,
@@ -1070,9 +1099,13 @@ def canned_responses_edit(request, response_id):
         canned.save()
         return redirect("escalated:admin_canned_responses_index")
 
-    return render_page(request, "Escalated/Admin/CannedResponses/Edit", props={
-        "canned_response": CannedResponseSerializer.serialize(canned),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/CannedResponses/Edit",
+        props={
+            "canned_response": CannedResponseSerializer.serialize(canned),
+        },
+    )
 
 
 @login_required
@@ -1113,9 +1146,13 @@ def settings_index(request):
         if key in settings_dict and settings_dict[key]:
             settings_dict[key] = _mask_secret(settings_dict[key])
 
-    return render_page(request, "Escalated/Admin/Settings", props={
-        "settings": settings_dict,
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Settings",
+        props={
+            "settings": settings_dict,
+        },
+    )
 
 
 @login_required
@@ -1279,13 +1316,12 @@ def tickets_apply_macro(request, ticket_id):
         return redirect("escalated:admin_tickets_show", ticket_id=ticket_id)
 
     try:
-        macro = Macro.objects.filter(
-            Q(is_shared=True) | Q(created_by=request.user)
-        ).get(pk=macro_id)
+        macro = Macro.objects.filter(Q(is_shared=True) | Q(created_by=request.user)).get(pk=macro_id)
     except Macro.DoesNotExist:
         return HttpResponseNotFound(_("Macro not found"))
 
     from escalated.services.macro_service import MacroService
+
     macro_service = MacroService()
     macro_service.apply(macro, ticket, request.user)
 
@@ -1414,9 +1450,13 @@ def macros_index(request):
         return check
 
     macros = Macro.objects.select_related("created_by").order_by("order")
-    return render_page(request, "Escalated/Admin/Macros/Index", props={
-        "macros": MacroSerializer.serialize_list(macros),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Macros/Index",
+        props={
+            "macros": MacroSerializer.serialize_list(macros),
+        },
+    )
 
 
 @login_required
@@ -1429,9 +1469,13 @@ def macros_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/Macros/Create", props={
-                "errors": {"name": _("Name is required.")},
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/Macros/Create",
+                props={
+                    "errors": {"name": _("Name is required.")},
+                },
+            )
 
         try:
             actions = json.loads(request.POST.get("actions", "[]"))
@@ -1477,9 +1521,13 @@ def macros_edit(request, macro_id):
         macro.save()
         return redirect("escalated:admin_macros_index")
 
-    return render_page(request, "Escalated/Admin/Macros/Edit", props={
-        "macro": MacroSerializer.serialize(macro),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Macros/Edit",
+        props={
+            "macro": MacroSerializer.serialize(macro),
+        },
+    )
 
 
 @login_required
@@ -1537,33 +1585,32 @@ def audit_logs_index(request):
     paginator = Paginator(logs, 50)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render_page(request, "Escalated/Admin/AuditLog/Index", props={
-        "logs": AuditLogSerializer.serialize_list(page.object_list),
-        "pagination": {
-            "current_page": page.number,
-            "total_pages": paginator.num_pages,
-            "total_count": paginator.count,
-            "has_next": page.has_next(),
-            "has_previous": page.has_previous(),
+    return render_page(
+        request,
+        "Escalated/Admin/AuditLog/Index",
+        props={
+            "logs": AuditLogSerializer.serialize_list(page.object_list),
+            "pagination": {
+                "current_page": page.number,
+                "total_pages": paginator.num_pages,
+                "total_count": paginator.count,
+                "has_next": page.has_next(),
+                "has_previous": page.has_previous(),
+            },
+            "filters": {
+                "user_id": user_id,
+                "action": action,
+                "auditable_type": auditable_type,
+                "date_from": date_from,
+                "date_to": date_to,
+            },
+            "users": [
+                {"id": u.pk, "name": u.get_full_name() or u.username} for u in User.objects.filter(is_active=True)
+            ],
+            "actions": ["created", "updated", "deleted"],
+            "resource_types": list(AuditLog.objects.values_list("auditable_content_type__model", flat=True).distinct()),
         },
-        "filters": {
-            "user_id": user_id,
-            "action": action,
-            "auditable_type": auditable_type,
-            "date_from": date_from,
-            "date_to": date_to,
-        },
-        "users": [
-            {"id": u.pk, "name": u.get_full_name() or u.username}
-            for u in User.objects.filter(is_active=True)
-        ],
-        "actions": ["created", "updated", "deleted"],
-        "resource_types": list(
-            AuditLog.objects.values_list(
-                "auditable_content_type__model", flat=True
-            ).distinct()
-        ),
-    })
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1578,10 +1625,14 @@ def statuses_index(request):
         return check
 
     statuses = TicketStatus.objects.all()
-    return render_page(request, "Escalated/Admin/Statuses/Index", props={
-        "statuses": TicketStatusSerializer.serialize_list(statuses),
-        "categories": ["new", "open", "pending", "on_hold", "solved"],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Statuses/Index",
+        props={
+            "statuses": TicketStatusSerializer.serialize_list(statuses),
+            "categories": ["new", "open", "pending", "on_hold", "solved"],
+        },
+    )
 
 
 @login_required
@@ -1593,10 +1644,14 @@ def statuses_create(request):
     if request.method == "POST":
         label = request.POST.get("label", "").strip()
         if not label:
-            return render_page(request, "Escalated/Admin/Statuses/Form", props={
-                "errors": {"label": _("Label is required.")},
-                "categories": ["new", "open", "pending", "on_hold", "solved"],
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/Statuses/Form",
+                props={
+                    "errors": {"label": _("Label is required.")},
+                    "categories": ["new", "open", "pending", "on_hold", "solved"],
+                },
+            )
 
         category = request.POST.get("category", "open")
         is_default = request.POST.get("is_default", "false") == "true"
@@ -1614,9 +1669,13 @@ def statuses_create(request):
         )
         return redirect("escalated:admin_statuses_index")
 
-    return render_page(request, "Escalated/Admin/Statuses/Form", props={
-        "categories": ["new", "open", "pending", "on_hold", "solved"],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Statuses/Form",
+        props={
+            "categories": ["new", "open", "pending", "on_hold", "solved"],
+        },
+    )
 
 
 @login_required
@@ -1639,18 +1698,20 @@ def statuses_edit(request, status_id):
 
         is_default = request.POST.get("is_default", "false") == "true"
         if is_default and not status.is_default:
-            TicketStatus.objects.filter(category=status.category).exclude(
-                pk=status.pk
-            ).update(is_default=False)
+            TicketStatus.objects.filter(category=status.category).exclude(pk=status.pk).update(is_default=False)
         status.is_default = is_default
 
         status.save()
         return redirect("escalated:admin_statuses_index")
 
-    return render_page(request, "Escalated/Admin/Statuses/Form", props={
-        "status": TicketStatusSerializer.serialize(status),
-        "categories": ["new", "open", "pending", "on_hold", "solved"],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Statuses/Form",
+        props={
+            "status": TicketStatusSerializer.serialize(status),
+            "categories": ["new", "open", "pending", "on_hold", "solved"],
+        },
+    )
 
 
 @login_required
@@ -1683,9 +1744,13 @@ def business_hours_index(request):
         return check
 
     schedules = BusinessSchedule.objects.prefetch_related("holidays").all()
-    return render_page(request, "Escalated/Admin/BusinessHours/Index", props={
-        "schedules": BusinessScheduleSerializer.serialize_list(schedules),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/BusinessHours/Index",
+        props={
+            "schedules": BusinessScheduleSerializer.serialize_list(schedules),
+        },
+    )
 
 
 @login_required
@@ -1697,9 +1762,13 @@ def business_hours_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/BusinessHours/Form", props={
-                "errors": {"name": _("Name is required.")},
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/BusinessHours/Form",
+                props={
+                    "errors": {"name": _("Name is required.")},
+                },
+            )
 
         is_default = request.POST.get("is_default", "false") == "true"
         if is_default:
@@ -1733,9 +1802,14 @@ def business_hours_create(request):
         return redirect("escalated:admin_business_hours_index")
 
     from zoneinfo import available_timezones
-    return render_page(request, "Escalated/Admin/BusinessHours/Form", props={
-        "timezones": sorted(available_timezones()),
-    })
+
+    return render_page(
+        request,
+        "Escalated/Admin/BusinessHours/Form",
+        props={
+            "timezones": sorted(available_timezones()),
+        },
+    )
 
 
 @login_required
@@ -1755,9 +1829,7 @@ def business_hours_edit(request, schedule_id):
 
         is_default = request.POST.get("is_default", "false") == "true"
         if is_default and not sched.is_default:
-            BusinessSchedule.objects.filter(is_default=True).exclude(
-                pk=sched.pk
-            ).update(is_default=False)
+            BusinessSchedule.objects.filter(is_default=True).exclude(pk=sched.pk).update(is_default=False)
         sched.is_default = is_default
 
         try:
@@ -1785,10 +1857,15 @@ def business_hours_edit(request, schedule_id):
         return redirect("escalated:admin_business_hours_index")
 
     from zoneinfo import available_timezones
-    return render_page(request, "Escalated/Admin/BusinessHours/Edit", props={
-        "schedule": BusinessScheduleSerializer.serialize(sched),
-        "timezones": sorted(available_timezones()),
-    })
+
+    return render_page(
+        request,
+        "Escalated/Admin/BusinessHours/Edit",
+        props={
+            "schedule": BusinessScheduleSerializer.serialize(sched),
+            "timezones": sorted(available_timezones()),
+        },
+    )
 
 
 @login_required
@@ -1821,9 +1898,13 @@ def roles_index(request):
         return check
 
     roles = Role.objects.annotate(users__count=Count("users"))
-    return render_page(request, "Escalated/Admin/Roles/Index", props={
-        "roles": RoleSerializer.serialize_list(roles),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Roles/Index",
+        props={
+            "roles": RoleSerializer.serialize_list(roles),
+        },
+    )
 
 
 @login_required
@@ -1835,10 +1916,14 @@ def roles_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/Roles/Form", props={
-                "errors": {"name": _("Name is required.")},
-                "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/Roles/Form",
+                props={
+                    "errors": {"name": _("Name is required.")},
+                    "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
+                },
+            )
 
         role = Role.objects.create(
             name=name,
@@ -1851,9 +1936,13 @@ def roles_create(request):
 
         return redirect("escalated:admin_roles_index")
 
-    return render_page(request, "Escalated/Admin/Roles/Form", props={
-        "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Roles/Form",
+        props={
+            "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
+        },
+    )
 
 
 @login_required
@@ -1877,10 +1966,14 @@ def roles_edit(request, role_id):
 
         return redirect("escalated:admin_roles_index")
 
-    return render_page(request, "Escalated/Admin/Roles/Form", props={
-        "role": RoleSerializer.serialize(role, include_permissions=True),
-        "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Roles/Form",
+        props={
+            "role": RoleSerializer.serialize(role, include_permissions=True),
+            "permissions": PermissionSerializer.serialize_grouped(Permission.objects.all()),
+        },
+    )
 
 
 @login_required
@@ -1916,9 +2009,13 @@ def custom_fields_index(request):
         return check
 
     fields = CustomField.objects.all().order_by("position")
-    return render_page(request, "Escalated/Admin/CustomFields/Index", props={
-        "custom_fields": CustomFieldSerializer.serialize_list(fields),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/CustomFields/Index",
+        props={
+            "custom_fields": CustomFieldSerializer.serialize_list(fields),
+        },
+    )
 
 
 @login_required
@@ -1931,13 +2028,14 @@ def custom_fields_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/CustomFields/Create", props={
-                "errors": {"name": _("Name is required.")},
-                "contexts": [
-                    {"value": c.value, "label": c.label}
-                    for c in CustomField.Context
-                ],
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/CustomFields/Create",
+                props={
+                    "errors": {"name": _("Name is required.")},
+                    "contexts": [{"value": c.value, "label": c.label} for c in CustomField.Context],
+                },
+            )
 
         try:
             options = json.loads(request.POST.get("options", "null"))
@@ -1945,9 +2043,7 @@ def custom_fields_create(request):
             options = None
 
         try:
-            validation_rules = json.loads(
-                request.POST.get("validation_rules", "null")
-            )
+            validation_rules = json.loads(request.POST.get("validation_rules", "null"))
         except (json.JSONDecodeError, TypeError):
             validation_rules = None
 
@@ -1972,12 +2068,13 @@ def custom_fields_create(request):
         )
         return redirect("escalated:admin_custom_fields_index")
 
-    return render_page(request, "Escalated/Admin/CustomFields/Create", props={
-        "contexts": [
-            {"value": c.value, "label": c.label}
-            for c in CustomField.Context
-        ],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/CustomFields/Create",
+        props={
+            "contexts": [{"value": c.value, "label": c.label} for c in CustomField.Context],
+        },
+    )
 
 
 @login_required
@@ -2009,29 +2106,26 @@ def custom_fields_edit(request, field_id):
             pass
 
         try:
-            field.validation_rules = json.loads(
-                request.POST.get("validation_rules", "null")
-            )
+            field.validation_rules = json.loads(request.POST.get("validation_rules", "null"))
         except (json.JSONDecodeError, TypeError):
             pass
 
         try:
-            field.conditions = json.loads(
-                request.POST.get("conditions", "null")
-            )
+            field.conditions = json.loads(request.POST.get("conditions", "null"))
         except (json.JSONDecodeError, TypeError):
             pass
 
         field.save()
         return redirect("escalated:admin_custom_fields_index")
 
-    return render_page(request, "Escalated/Admin/CustomFields/Edit", props={
-        "custom_field": CustomFieldSerializer.serialize(field),
-        "contexts": [
-            {"value": c.value, "label": c.label}
-            for c in CustomField.Context
-        ],
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/CustomFields/Edit",
+        props={
+            "custom_field": CustomFieldSerializer.serialize(field),
+            "contexts": [{"value": c.value, "label": c.label} for c in CustomField.Context],
+        },
+    )
 
 
 @login_required
@@ -2070,9 +2164,7 @@ def custom_fields_reorder(request):
 
     positions = body.get("positions", [])
     for item in positions:
-        CustomField.objects.filter(pk=item.get("id")).update(
-            position=item.get("position", 0)
-        )
+        CustomField.objects.filter(pk=item.get("id")).update(position=item.get("position", 0))
 
     return JsonResponse({"success": True})
 
@@ -2099,9 +2191,9 @@ def ticket_links_index(request, ticket_id):
 
     links = []
     for link in parent_links:
-        links.append(TicketLinkSerializer.serialize(link, direction='parent'))
+        links.append(TicketLinkSerializer.serialize(link, direction="parent"))
     for link in child_links:
-        links.append(TicketLinkSerializer.serialize(link, direction='child'))
+        links.append(TicketLinkSerializer.serialize(link, direction="child"))
 
     return JsonResponse({"links": links})
 
@@ -2142,11 +2234,10 @@ def ticket_links_store(request, ticket_id):
         return JsonResponse({"error": "Cannot link a ticket to itself"}, status=400)
 
     # Prevent duplicates
-    exists = TicketLink.objects.filter(
-        parent_ticket=ticket, child_ticket=target, link_type=link_type
-    ).exists() or TicketLink.objects.filter(
-        parent_ticket=target, child_ticket=ticket, link_type=link_type
-    ).exists()
+    exists = (
+        TicketLink.objects.filter(parent_ticket=ticket, child_ticket=target, link_type=link_type).exists()
+        or TicketLink.objects.filter(parent_ticket=target, child_ticket=ticket, link_type=link_type).exists()
+    )
 
     if exists:
         return JsonResponse({"error": "Link already exists"}, status=400)
@@ -2157,9 +2248,11 @@ def ticket_links_store(request, ticket_id):
         link_type=link_type,
     )
 
-    return JsonResponse({
-        "link": TicketLinkSerializer.serialize(link, direction='parent'),
-    })
+    return JsonResponse(
+        {
+            "link": TicketLinkSerializer.serialize(link, direction="parent"),
+        }
+    )
 
 
 @login_required
@@ -2202,24 +2295,23 @@ def ticket_merge_search(request):
 
     tickets = (
         Ticket.objects.filter(merged_into__isnull=True)
-        .filter(
-            Q(reference__icontains=q)
-            | Q(subject__icontains=q)
-        )
+        .filter(Q(reference__icontains=q) | Q(subject__icontains=q))
         .order_by("-created_at")[:10]
     )
 
-    return JsonResponse({
-        "tickets": [
-            {
-                "id": t.pk,
-                "reference": t.reference,
-                "subject": t.subject,
-                "status": t.status,
-            }
-            for t in tickets
-        ]
-    })
+    return JsonResponse(
+        {
+            "tickets": [
+                {
+                    "id": t.pk,
+                    "reference": t.reference,
+                    "subject": t.subject,
+                    "status": t.status,
+                }
+                for t in tickets
+            ]
+        }
+    )
 
 
 @login_required
@@ -2255,6 +2347,7 @@ def ticket_merge(request, ticket_id):
         return JsonResponse({"error": "Cannot merge a ticket into itself"}, status=400)
 
     from escalated.services.ticket_merge_service import TicketMergeService
+
     merge_service = TicketMergeService()
     merge_service.merge(source, target, merged_by_user_id=request.user.pk)
 
@@ -2279,16 +2372,17 @@ def side_conversations_index(request, ticket_id):
         return JsonResponse({"error": "Ticket not found"}, status=404)
 
     conversations = (
-        ticket.side_conversations
-        .select_related("created_by")
+        ticket.side_conversations.select_related("created_by")
         .prefetch_related("replies__author")
         .annotate(reply_count=Count("replies"))
         .order_by("-created_at")
     )
 
-    return JsonResponse({
-        "side_conversations": SideConversationSerializer.serialize_list(conversations),
-    })
+    return JsonResponse(
+        {
+            "side_conversations": SideConversationSerializer.serialize_list(conversations),
+        }
+    )
 
 
 @login_required
@@ -2334,15 +2428,16 @@ def side_conversations_store(request, ticket_id):
 
     # Re-fetch with relations for serialization
     conversation = (
-        SideConversation.objects
-        .select_related("created_by")
+        SideConversation.objects.select_related("created_by")
         .prefetch_related("replies__author")
         .get(pk=conversation.pk)
     )
 
-    return JsonResponse({
-        "side_conversation": SideConversationSerializer.serialize(conversation),
-    })
+    return JsonResponse(
+        {
+            "side_conversation": SideConversationSerializer.serialize(conversation),
+        }
+    )
 
 
 @login_required
@@ -2361,9 +2456,7 @@ def side_conversations_reply(request, ticket_id, conversation_id):
         return JsonResponse({"error": "Ticket not found"}, status=404)
 
     try:
-        conversation = SideConversation.objects.get(
-            pk=conversation_id, ticket=ticket
-        )
+        conversation = SideConversation.objects.get(pk=conversation_id, ticket=ticket)
     except SideConversation.DoesNotExist:
         return JsonResponse({"error": "Side conversation not found"}, status=404)
 
@@ -2382,9 +2475,11 @@ def side_conversations_reply(request, ticket_id, conversation_id):
         author=request.user,
     )
 
-    return JsonResponse({
-        "reply": SideConversationReplySerializer.serialize(reply),
-    })
+    return JsonResponse(
+        {
+            "reply": SideConversationReplySerializer.serialize(reply),
+        }
+    )
 
 
 @login_required
@@ -2403,9 +2498,7 @@ def side_conversations_close(request, ticket_id, conversation_id):
         return JsonResponse({"error": "Ticket not found"}, status=404)
 
     try:
-        conversation = SideConversation.objects.get(
-            pk=conversation_id, ticket=ticket
-        )
+        conversation = SideConversation.objects.get(pk=conversation_id, ticket=ticket)
     except SideConversation.DoesNotExist:
         return JsonResponse({"error": "Side conversation not found"}, status=404)
 
@@ -2444,24 +2537,26 @@ def articles_index(request):
     paginator = Paginator(articles, 20)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render_page(request, "Escalated/Admin/KB/Articles/Index", props={
-        "articles": ArticleSerializer.serialize_list(page.object_list),
-        "pagination": {
-            "current_page": page.number,
-            "total_pages": paginator.num_pages,
-            "total_count": paginator.count,
-            "has_next": page.has_next(),
-            "has_previous": page.has_previous(),
+    return render_page(
+        request,
+        "Escalated/Admin/KB/Articles/Index",
+        props={
+            "articles": ArticleSerializer.serialize_list(page.object_list),
+            "pagination": {
+                "current_page": page.number,
+                "total_pages": paginator.num_pages,
+                "total_count": paginator.count,
+                "has_next": page.has_next(),
+                "has_previous": page.has_previous(),
+            },
+            "filters": {
+                "search": search,
+                "status": status_filter,
+                "category": category_filter,
+            },
+            "categories": ArticleCategorySerializer.serialize_list(ArticleCategory.objects.ordered()),
         },
-        "filters": {
-            "search": search,
-            "status": status_filter,
-            "category": category_filter,
-        },
-        "categories": ArticleCategorySerializer.serialize_list(
-            ArticleCategory.objects.ordered()
-        ),
-    })
+    )
 
 
 @login_required
@@ -2474,12 +2569,14 @@ def articles_create(request):
     if request.method == "POST":
         title = request.POST.get("title", "").strip()
         if not title:
-            return render_page(request, "Escalated/Admin/KB/Articles/Create", props={
-                "errors": {"title": _("Title is required.")},
-                "categories": ArticleCategorySerializer.serialize_list(
-                    ArticleCategory.objects.ordered()
-                ),
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/KB/Articles/Create",
+                props={
+                    "errors": {"title": _("Title is required.")},
+                    "categories": ArticleCategorySerializer.serialize_list(ArticleCategory.objects.ordered()),
+                },
+            )
 
         status = request.POST.get("status", Article.Status.DRAFT)
         published_at = None
@@ -2499,11 +2596,13 @@ def articles_create(request):
         )
         return redirect("escalated:admin_articles_index")
 
-    return render_page(request, "Escalated/Admin/KB/Articles/Create", props={
-        "categories": ArticleCategorySerializer.serialize_list(
-            ArticleCategory.objects.ordered()
-        ),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/KB/Articles/Create",
+        props={
+            "categories": ArticleCategorySerializer.serialize_list(ArticleCategory.objects.ordered()),
+        },
+    )
 
 
 @login_required
@@ -2514,9 +2613,7 @@ def articles_edit(request, article_id):
         return check
 
     try:
-        article = Article.objects.select_related("category", "author").get(
-            pk=article_id
-        )
+        article = Article.objects.select_related("category", "author").get(pk=article_id)
     except Article.DoesNotExist:
         return HttpResponseNotFound(_("Article not found"))
 
@@ -2536,12 +2633,14 @@ def articles_edit(request, article_id):
         article.save()
         return redirect("escalated:admin_articles_index")
 
-    return render_page(request, "Escalated/Admin/KB/Articles/Edit", props={
-        "article": ArticleSerializer.serialize(article),
-        "categories": ArticleCategorySerializer.serialize_list(
-            ArticleCategory.objects.ordered()
-        ),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/KB/Articles/Edit",
+        props={
+            "article": ArticleSerializer.serialize(article),
+            "categories": ArticleCategorySerializer.serialize_list(ArticleCategory.objects.ordered()),
+        },
+    )
 
 
 @login_required
@@ -2575,13 +2674,15 @@ def kb_categories_index(request):
     if check:
         return check
 
-    categories = ArticleCategory.objects.annotate(
-        articles_count=Count("articles")
-    ).order_by("position", "name")
+    categories = ArticleCategory.objects.annotate(articles_count=Count("articles")).order_by("position", "name")
 
-    return render_page(request, "Escalated/Admin/KB/Categories/Index", props={
-        "categories": ArticleCategorySerializer.serialize_list(categories),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/KB/Categories/Index",
+        props={
+            "categories": ArticleCategorySerializer.serialize_list(categories),
+        },
+    )
 
 
 @login_required
@@ -2669,7 +2770,9 @@ def skills_index(request):
     if check:
         return check
     skills = Skill.objects.annotate(agents_count=Count("agents")).order_by("name")
-    return render_page(request, "Escalated/Admin/Skills/Index", props={"skills": SkillSerializer.serialize_list(skills)})
+    return render_page(
+        request, "Escalated/Admin/Skills/Index", props={"skills": SkillSerializer.serialize_list(skills)}
+    )
 
 
 @login_required
@@ -2680,7 +2783,9 @@ def skills_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/Skills/Form", props={"errors": {"name": _("Name is required.")}})
+            return render_page(
+                request, "Escalated/Admin/Skills/Form", props={"errors": {"name": _("Name is required.")}}
+            )
         Skill.objects.create(name=name)
         return redirect("escalated:admin_skills_index")
     return render_page(request, "Escalated/Admin/Skills/Form", props={})
@@ -2727,7 +2832,11 @@ def capacity_index(request):
     if check:
         return check
     capacities = AgentCapacity.objects.select_related("user").order_by("user_id")
-    return render_page(request, "Escalated/Admin/Capacity/Index", props={"capacities": AgentCapacitySerializer.serialize_list(capacities)})
+    return render_page(
+        request,
+        "Escalated/Admin/Capacity/Index",
+        props={"capacities": AgentCapacitySerializer.serialize_list(capacities)},
+    )
 
 
 @login_required
@@ -2759,10 +2868,14 @@ def webhooks_index(request):
     if check:
         return check
     webhooks = Webhook.objects.annotate(deliveries_count=Count("deliveries")).order_by("-created_at")
-    return render_page(request, "Escalated/Admin/Webhooks/Index", props={
-        "webhooks": WebhookSerializer.serialize_list(webhooks),
-        "available_events": WebhookSerializer.AVAILABLE_EVENTS,
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Webhooks/Index",
+        props={
+            "webhooks": WebhookSerializer.serialize_list(webhooks),
+            "available_events": WebhookSerializer.AVAILABLE_EVENTS,
+        },
+    )
 
 
 @login_required
@@ -2773,10 +2886,14 @@ def webhooks_create(request):
     if request.method == "POST":
         url = request.POST.get("url", "").strip()
         if not url:
-            return render_page(request, "Escalated/Admin/Webhooks/Form", props={
-                "errors": {"url": _("URL is required.")},
-                "available_events": WebhookSerializer.AVAILABLE_EVENTS,
-            })
+            return render_page(
+                request,
+                "Escalated/Admin/Webhooks/Form",
+                props={
+                    "errors": {"url": _("URL is required.")},
+                    "available_events": WebhookSerializer.AVAILABLE_EVENTS,
+                },
+            )
         try:
             events = json.loads(request.POST.get("events", "[]"))
         except (json.JSONDecodeError, TypeError):
@@ -2788,7 +2905,9 @@ def webhooks_create(request):
             active=request.POST.get("active", "true") == "true",
         )
         return redirect("escalated:admin_webhooks_index")
-    return render_page(request, "Escalated/Admin/Webhooks/Form", props={"available_events": WebhookSerializer.AVAILABLE_EVENTS})
+    return render_page(
+        request, "Escalated/Admin/Webhooks/Form", props={"available_events": WebhookSerializer.AVAILABLE_EVENTS}
+    )
 
 
 @login_required
@@ -2812,10 +2931,14 @@ def webhooks_edit(request, webhook_id):
         webhook.active = request.POST.get("active", "true") == "true"
         webhook.save()
         return redirect("escalated:admin_webhooks_index")
-    return render_page(request, "Escalated/Admin/Webhooks/Form", props={
-        "webhook": WebhookSerializer.serialize(webhook),
-        "available_events": WebhookSerializer.AVAILABLE_EVENTS,
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Webhooks/Form",
+        props={
+            "webhook": WebhookSerializer.serialize(webhook),
+            "available_events": WebhookSerializer.AVAILABLE_EVENTS,
+        },
+    )
 
 
 @login_required
@@ -2844,17 +2967,21 @@ def webhooks_deliveries(request, webhook_id):
     deliveries = webhook.deliveries.order_by("-created_at")
     paginator = Paginator(deliveries, 25)
     page = paginator.get_page(request.GET.get("page", 1))
-    return render_page(request, "Escalated/Admin/Webhooks/Deliveries", props={
-        "webhook": WebhookSerializer.serialize(webhook),
-        "deliveries": WebhookDeliverySerializer.serialize_list(page.object_list),
-        "pagination": {
-            "current_page": page.number,
-            "total_pages": paginator.num_pages,
-            "total_count": paginator.count,
-            "has_next": page.has_next(),
-            "has_previous": page.has_previous(),
+    return render_page(
+        request,
+        "Escalated/Admin/Webhooks/Deliveries",
+        props={
+            "webhook": WebhookSerializer.serialize(webhook),
+            "deliveries": WebhookDeliverySerializer.serialize_list(page.object_list),
+            "pagination": {
+                "current_page": page.number,
+                "total_pages": paginator.num_pages,
+                "total_count": paginator.count,
+                "has_next": page.has_next(),
+                "has_previous": page.has_previous(),
+            },
         },
-    })
+    )
 
 
 @login_required
@@ -2869,6 +2996,7 @@ def webhooks_retry(request, delivery_id):
     except WebhookDelivery.DoesNotExist:
         return JsonResponse({"error": "Delivery not found"}, status=404)
     from escalated.services.webhook_dispatcher import WebhookDispatcher
+
     dispatcher = WebhookDispatcher()
     dispatcher.retry_delivery(delivery)
     return JsonResponse({"success": True})
@@ -2900,20 +3028,24 @@ def automations_index(request):
     paginator = Paginator(automations, 20)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render_page(request, "Escalated/Admin/Automations/Index", props={
-        "automations": AutomationSerializer.serialize_list(page.object_list),
-        "pagination": {
-            "current_page": page.number,
-            "total_pages": paginator.num_pages,
-            "total_count": paginator.count,
-            "has_next": page.has_next(),
-            "has_previous": page.has_previous(),
+    return render_page(
+        request,
+        "Escalated/Admin/Automations/Index",
+        props={
+            "automations": AutomationSerializer.serialize_list(page.object_list),
+            "pagination": {
+                "current_page": page.number,
+                "total_pages": paginator.num_pages,
+                "total_count": paginator.count,
+                "has_next": page.has_next(),
+                "has_previous": page.has_previous(),
+            },
+            "filters": {
+                "active": active_filter,
+                "search": search,
+            },
         },
-        "filters": {
-            "active": active_filter,
-            "search": search,
-        },
-    })
+    )
 
 
 @login_required
@@ -2979,14 +3111,20 @@ def automations_edit(request, automation_id):
         if not isinstance(actions, list) or len(actions) < 1:
             errors["actions"] = _("At least one action is required.")
         if errors:
-            return render_page(request, "Escalated/Admin/Automations/Form", props={"automation": AutomationSerializer.serialize(automation), "errors": errors})
+            return render_page(
+                request,
+                "Escalated/Admin/Automations/Form",
+                props={"automation": AutomationSerializer.serialize(automation), "errors": errors},
+            )
         automation.name = name
         automation.conditions = conditions
         automation.actions = actions
         automation.active = request.POST.get("active", "true") == "true"
         automation.save()
         return redirect("escalated:admin_automations_index")
-    return render_page(request, "Escalated/Admin/Automations/Form", props={"automation": AutomationSerializer.serialize(automation)})
+    return render_page(
+        request, "Escalated/Admin/Automations/Form", props={"automation": AutomationSerializer.serialize(automation)}
+    )
 
 
 @login_required
@@ -3014,6 +3152,7 @@ def settings_csat(request):
     if check:
         return check
     from escalated.models import EscalatedSetting
+
     defaults = {
         "csat_question_text": "How would you rate your support experience?",
         "csat_scale": "1-5",
@@ -3039,6 +3178,7 @@ def settings_sso(request):
     if check:
         return check
     from escalated.services.sso_service import SsoService
+
     sso = SsoService()
     if request.method == "POST":
         sso.save_config(request.POST.dict())
@@ -3052,10 +3192,14 @@ def settings_two_factor(request):
     if check:
         return check
     two_factor = TwoFactor.objects.filter(user=request.user).first()
-    return render_page(request, "Escalated/Admin/Settings/TwoFactor", props={
-        "enabled": two_factor.is_confirmed() if two_factor else False,
-        "pending": two_factor is not None and not two_factor.is_confirmed() if two_factor else False,
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Settings/TwoFactor",
+        props={
+            "enabled": two_factor.is_confirmed() if two_factor else False,
+            "pending": two_factor is not None and not two_factor.is_confirmed() if two_factor else False,
+        },
+    )
 
 
 @login_required
@@ -3066,6 +3210,7 @@ def two_factor_setup(request):
     if request.method != "POST":
         return HttpResponseForbidden(_("Method not allowed"))
     from escalated.services.two_factor_service import TwoFactorService
+
     service = TwoFactorService()
     TwoFactor.objects.filter(user=request.user, confirmed_at__isnull=True).delete()
     secret = service.generate_secret()
@@ -3093,10 +3238,12 @@ def two_factor_confirm(request):
     if not two_factor:
         return JsonResponse({"error": "No pending 2FA setup"}, status=400)
     from escalated.services.two_factor_service import TwoFactorService
+
     service = TwoFactorService()
     if not service.verify(two_factor.secret, code):
         return JsonResponse({"error": "Invalid code"}, status=400)
     from django.utils import timezone as tz
+
     two_factor.confirmed_at = tz.now()
     two_factor.save(update_fields=["confirmed_at", "updated_at"])
     return JsonResponse({"success": True})
@@ -3124,7 +3271,11 @@ def custom_objects_index(request):
     if check:
         return check
     objects = CustomObject.objects.annotate(records_count=Count("records")).order_by("name")
-    return render_page(request, "Escalated/Admin/CustomObjects/Index", props={"custom_objects": CustomObjectSerializer.serialize_list(objects)})
+    return render_page(
+        request,
+        "Escalated/Admin/CustomObjects/Index",
+        props={"custom_objects": CustomObjectSerializer.serialize_list(objects)},
+    )
 
 
 @login_required
@@ -3135,7 +3286,9 @@ def custom_objects_create(request):
     if request.method == "POST":
         name = request.POST.get("name", "").strip()
         if not name:
-            return render_page(request, "Escalated/Admin/CustomObjects/Form", props={"errors": {"name": _("Name is required.")}})
+            return render_page(
+                request, "Escalated/Admin/CustomObjects/Form", props={"errors": {"name": _("Name is required.")}}
+            )
         slug_val = slugify(request.POST.get("slug", "") or name)
         try:
             fields_schema = json.loads(request.POST.get("fields_schema", "[]"))
@@ -3164,7 +3317,9 @@ def custom_objects_edit(request, object_id):
             pass
         obj.save()
         return redirect("escalated:admin_custom_objects_index")
-    return render_page(request, "Escalated/Admin/CustomObjects/Form", props={"custom_object": CustomObjectSerializer.serialize(obj)})
+    return render_page(
+        request, "Escalated/Admin/CustomObjects/Form", props={"custom_object": CustomObjectSerializer.serialize(obj)}
+    )
 
 
 @login_required
@@ -3193,17 +3348,21 @@ def custom_object_records(request, object_id):
     records = obj.records.order_by("-created_at")
     paginator = Paginator(records, 25)
     page = paginator.get_page(request.GET.get("page", 1))
-    return render_page(request, "Escalated/Admin/CustomObjects/Records", props={
-        "custom_object": CustomObjectSerializer.serialize(obj),
-        "records": CustomObjectRecordSerializer.serialize_list(page.object_list),
-        "pagination": {
-            "current_page": page.number,
-            "total_pages": paginator.num_pages,
-            "total_count": paginator.count,
-            "has_next": page.has_next(),
-            "has_previous": page.has_previous(),
+    return render_page(
+        request,
+        "Escalated/Admin/CustomObjects/Records",
+        props={
+            "custom_object": CustomObjectSerializer.serialize(obj),
+            "records": CustomObjectRecordSerializer.serialize_list(page.object_list),
+            "pagination": {
+                "current_page": page.number,
+                "total_pages": paginator.num_pages,
+                "total_count": paginator.count,
+                "has_next": page.has_next(),
+                "has_previous": page.has_previous(),
+            },
         },
-    })
+    )
 
 
 @login_required
@@ -3270,17 +3429,24 @@ def reports_dashboard(request):
     check = _require_admin(request)
     if check:
         return check
-    from escalated.services.reporting_service import ReportingService
     from datetime import timedelta
+
     from django.utils import timezone as tz
+
+    from escalated.services.reporting_service import ReportingService
+
     service = ReportingService()
     end = tz.now()
     start = end - timedelta(days=30)
-    return render_page(request, "Escalated/Admin/Reports/Dashboard", props={
-        "ticket_volume": service.get_ticket_volume_by_date(start, end),
-        "by_status": service.get_tickets_by_status(),
-        "by_priority": service.get_tickets_by_priority(),
-        "avg_response_hours": service.get_average_response_time(start, end),
-        "avg_resolution_hours": service.get_average_resolution_time(start, end),
-        "agent_performance": service.get_agent_performance(start, end),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Reports/Dashboard",
+        props={
+            "ticket_volume": service.get_ticket_volume_by_date(start, end),
+            "by_status": service.get_tickets_by_status(),
+            "by_priority": service.get_tickets_by_priority(),
+            "avg_response_hours": service.get_average_response_time(start, end),
+            "avg_resolution_hours": service.get_average_resolution_time(start, end),
+            "agent_performance": service.get_agent_performance(start, end),
+        },
+    )

--- a/escalated/views/admin_api_tokens.py
+++ b/escalated/views/admin_api_tokens.py
@@ -53,11 +53,15 @@ def api_tokens_index(request):
     tokens = ApiToken.objects.order_by("-created_at")
     token_data = ApiTokenSerializer.serialize_list(tokens)
 
-    return render_page(request, "Escalated/Admin/ApiTokens/Index", props={
-        "tokens": token_data,
-        "users": _get_agent_users(),
-        "api_enabled": get_setting("API_ENABLED"),
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/ApiTokens/Index",
+        props={
+            "tokens": token_data,
+            "users": _get_agent_users(),
+            "api_enabled": get_setting("API_ENABLED"),
+        },
+    )
 
 
 @login_required

--- a/escalated/views/admin_plugins.py
+++ b/escalated/views/admin_plugins.py
@@ -11,11 +11,11 @@ import logging
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseForbidden
 from django.shortcuts import redirect
-from escalated.rendering import render_page
 
 from escalated.conf import get_setting
 from escalated.permissions import is_admin
 from escalated.plugin_service import PluginService
+from escalated.rendering import render_page
 
 logger = logging.getLogger("escalated.plugins")
 
@@ -55,9 +55,13 @@ def plugin_list(request):
     service = PluginService()
     plugins = service.get_all_plugins()
 
-    return render_page(request, "Escalated/Admin/Plugins/Index", props={
-        "plugins": plugins,
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Plugins/Index",
+        props={
+            "plugins": plugins,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/escalated/views/agent.py
+++ b/escalated/views/agent.py
@@ -4,32 +4,32 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.core.paginator import Paginator
-from django.db.models import Count, Q, Avg
+from django.db.models import Avg, Q
 from django.http import HttpResponseForbidden, HttpResponseNotFound, JsonResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
-from escalated.rendering import render_page
 
 from escalated.models import (
-    Ticket,
-    Tag,
-    Department,
     CannedResponse,
+    Department,
     Macro,
     Reply,
     SatisfactionRating,
+    Tag,
+    Ticket,
 )
-from escalated.permissions import is_agent, is_admin, can_view_ticket, can_update_ticket
+from escalated.permissions import can_update_ticket, can_view_ticket, is_admin, is_agent
+from escalated.rendering import render_page
 from escalated.serializers import (
-    TicketSerializer,
-    ReplySerializer,
-    TagSerializer,
-    DepartmentSerializer,
-    CannedResponseSerializer,
     ActivitySerializer,
     AttachmentSerializer,
+    CannedResponseSerializer,
+    DepartmentSerializer,
     MacroSerializer,
+    ReplySerializer,
     SatisfactionRatingSerializer,
+    TagSerializer,
+    TicketSerializer,
 )
 from escalated.services.ticket_service import TicketService
 
@@ -56,9 +56,7 @@ def dashboard(request):
     my_tickets = Ticket.objects.assigned_to(user.pk)
 
     # CSAT stats
-    avg_csat = SatisfactionRating.objects.aggregate(
-        avg_rating=Avg("rating")
-    )["avg_rating"]
+    avg_csat = SatisfactionRating.objects.aggregate(avg_rating=Avg("rating"))["avg_rating"]
     total_ratings = SatisfactionRating.objects.count()
     resolved_with_rating = SatisfactionRating.objects.filter(
         ticket__status__in=[Ticket.Status.RESOLVED, Ticket.Status.CLOSED]
@@ -69,27 +67,23 @@ def dashboard(request):
         "my_open": my_tickets.open().count(),
         "unassigned": Ticket.objects.unassigned().open().count(),
         "breached_sla": Ticket.objects.breached_sla().open().count(),
-        "by_priority": {
-            p.value: Ticket.objects.open().filter(priority=p.value).count()
-            for p in Ticket.Priority
-        },
-        "by_status": {
-            s.value: Ticket.objects.filter(status=s.value).count()
-            for s in Ticket.Status
-        },
+        "by_priority": {p.value: Ticket.objects.open().filter(priority=p.value).count() for p in Ticket.Priority},
+        "by_status": {s.value: Ticket.objects.filter(status=s.value).count() for s in Ticket.Status},
         "avg_csat_rating": round(avg_csat, 1) if avg_csat else None,
         "total_ratings": total_ratings,
         "resolved_with_rating_count": resolved_with_rating,
     }
 
-    recent_tickets = my_tickets.open().select_related(
-        "department"
-    ).prefetch_related("tags")[:10]
+    recent_tickets = my_tickets.open().select_related("department").prefetch_related("tags")[:10]
 
-    return render_page(request, "Escalated/Agent/Dashboard", props={
-        "stats": stats,
-        "recent_tickets": TicketSerializer.serialize_list(recent_tickets),
-    })
+    return render_page(
+        request,
+        "Escalated/Agent/Dashboard",
+        props={
+            "stats": stats,
+            "recent_tickets": TicketSerializer.serialize_list(recent_tickets),
+        },
+    )
 
 
 @login_required
@@ -99,9 +93,7 @@ def ticket_list(request):
     if check:
         return check
 
-    tickets = Ticket.objects.select_related(
-        "assigned_to", "department"
-    ).prefetch_related("tags")
+    tickets = Ticket.objects.select_related("assigned_to", "department").prefetch_related("tags")
 
     # Apply filters
     status = request.GET.get("status")
@@ -143,8 +135,12 @@ def ticket_list(request):
 
     sort = request.GET.get("sort", "-created_at")
     allowed_sorts = [
-        "created_at", "-created_at", "priority", "-priority",
-        "updated_at", "-updated_at",
+        "created_at",
+        "-created_at",
+        "priority",
+        "-priority",
+        "updated_at",
+        "-updated_at",
     ]
     if sort in allowed_sorts:
         tickets = tickets.order_by(sort)
@@ -152,32 +148,34 @@ def ticket_list(request):
     paginator = Paginator(tickets, 25)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render_page(request, "Escalated/Agent/Tickets/Index", props={
-        "tickets": TicketSerializer.serialize_list(page.object_list),
-        "pagination": {
-            "current_page": page.number,
-            "total_pages": paginator.num_pages,
-            "total_count": paginator.count,
-            "has_next": page.has_next(),
-            "has_previous": page.has_previous(),
+    return render_page(
+        request,
+        "Escalated/Agent/Tickets/Index",
+        props={
+            "tickets": TicketSerializer.serialize_list(page.object_list),
+            "pagination": {
+                "current_page": page.number,
+                "total_pages": paginator.num_pages,
+                "total_count": paginator.count,
+                "has_next": page.has_next(),
+                "has_previous": page.has_previous(),
+            },
+            "filters": {
+                "status": status,
+                "priority": priority,
+                "assigned": assigned,
+                "department": department,
+                "tag": tag,
+                "search": search,
+                "sort": sort,
+                "following": following,
+            },
+            "statuses": [{"value": s.value, "label": s.label} for s in Ticket.Status],
+            "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+            "departments": DepartmentSerializer.serialize_list(Department.objects.filter(is_active=True)),
+            "tags": TagSerializer.serialize_list(Tag.objects.all()),
         },
-        "filters": {
-            "status": status,
-            "priority": priority,
-            "assigned": assigned,
-            "department": department,
-            "tag": tag,
-            "search": search,
-            "sort": sort,
-            "following": following,
-        },
-        "statuses": [{"value": s.value, "label": s.label} for s in Ticket.Status],
-        "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
-        "departments": DepartmentSerializer.serialize_list(
-            Department.objects.filter(is_active=True)
-        ),
-        "tags": TagSerializer.serialize_list(Tag.objects.all()),
-    })
+    )
 
 
 @login_required
@@ -188,15 +186,17 @@ def ticket_show(request, ticket_id):
         return check
 
     try:
-        ticket = Ticket.objects.select_related(
-            "assigned_to", "department", "sla_policy"
-        ).prefetch_related(
-            "tags",
-            "replies__author",
-            "replies__attachments",
-            "activities",
-            "attachments",
-        ).get(pk=ticket_id)
+        ticket = (
+            Ticket.objects.select_related("assigned_to", "department", "sla_policy")
+            .prefetch_related(
+                "tags",
+                "replies__author",
+                "replies__attachments",
+                "activities",
+                "attachments",
+            )
+            .get(pk=ticket_id)
+        )
     except Ticket.DoesNotExist:
         return HttpResponseNotFound(_("Ticket not found"))
 
@@ -207,23 +207,17 @@ def ticket_show(request, ticket_id):
     activities = ticket.activities.all()[:50]
 
     # Available agents for assignment
-    agents = User.objects.filter(
-        escalated_departments__is_active=True
-    ).distinct()
+    agents = User.objects.filter(escalated_departments__is_active=True).distinct()
 
-    canned_responses = CannedResponse.objects.filter(
-        Q(is_shared=True) | Q(created_by=request.user)
-    )
+    canned_responses = CannedResponse.objects.filter(Q(is_shared=True) | Q(created_by=request.user))
 
     # Macros available to this agent (shared + own)
-    macros = Macro.objects.filter(
-        Q(is_shared=True) | Q(created_by=request.user)
-    ).order_by("order")
+    macros = Macro.objects.filter(Q(is_shared=True) | Q(created_by=request.user)).order_by("order")
 
     # Pinned notes
-    pinned_notes = ticket.replies.filter(
-        is_deleted=False, is_internal_note=True, is_pinned=True
-    ).select_related("author")
+    pinned_notes = ticket.replies.filter(is_deleted=False, is_internal_note=True, is_pinned=True).select_related(
+        "author"
+    )
 
     # Satisfaction rating
     try:
@@ -232,29 +226,28 @@ def ticket_show(request, ticket_id):
     except SatisfactionRating.DoesNotExist:
         satisfaction_data = None
 
-    return render_page(request, "Escalated/Agent/Tickets/Show", props={
-        "ticket": TicketSerializer.serialize(ticket),
-        "replies": ReplySerializer.serialize_list(replies),
-        "activities": [ActivitySerializer.serialize(a) for a in activities],
-        "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
-        "agents": [
-            {"id": a.pk, "name": a.get_full_name() or a.username, "email": a.email}
-            for a in agents
-        ],
-        "departments": DepartmentSerializer.serialize_list(
-            Department.objects.filter(is_active=True)
-        ),
-        "tags": TagSerializer.serialize_list(Tag.objects.all()),
-        "canned_responses": CannedResponseSerializer.serialize_list(canned_responses),
-        "macros": MacroSerializer.serialize_list(macros),
-        "statuses": [{"value": s.value, "label": s.label} for s in Ticket.Status],
-        "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
-        "can_update": can_update_ticket(request.user, ticket),
-        "is_following": ticket.is_followed_by(request.user.pk),
-        "followers_count": ticket.followers_count,
-        "pinned_notes": ReplySerializer.serialize_list(pinned_notes),
-        "satisfaction_rating": satisfaction_data,
-    })
+    return render_page(
+        request,
+        "Escalated/Agent/Tickets/Show",
+        props={
+            "ticket": TicketSerializer.serialize(ticket),
+            "replies": ReplySerializer.serialize_list(replies),
+            "activities": [ActivitySerializer.serialize(a) for a in activities],
+            "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
+            "agents": [{"id": a.pk, "name": a.get_full_name() or a.username, "email": a.email} for a in agents],
+            "departments": DepartmentSerializer.serialize_list(Department.objects.filter(is_active=True)),
+            "tags": TagSerializer.serialize_list(Tag.objects.all()),
+            "canned_responses": CannedResponseSerializer.serialize_list(canned_responses),
+            "macros": MacroSerializer.serialize_list(macros),
+            "statuses": [{"value": s.value, "label": s.label} for s in Ticket.Status],
+            "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+            "can_update": can_update_ticket(request.user, ticket),
+            "is_following": ticket.is_followed_by(request.user.pk),
+            "followers_count": ticket.followers_count,
+            "pinned_notes": ReplySerializer.serialize_list(pinned_notes),
+            "satisfaction_rating": satisfaction_data,
+        },
+    )
 
 
 @login_required
@@ -311,9 +304,10 @@ def ticket_reply(request, ticket_id):
     # Handle attachments
     files = request.FILES.getlist("attachments")
     if files:
-        from escalated.services.attachment_service import AttachmentService
         from escalated.conf import get_setting
-        for f in files[:get_setting("MAX_ATTACHMENTS")]:
+        from escalated.services.attachment_service import AttachmentService
+
+        for f in files[: get_setting("MAX_ATTACHMENTS")]:
             try:
                 AttachmentService.attach(reply, f)
             except Exception:
@@ -579,13 +573,12 @@ def ticket_apply_macro(request, ticket_id):
         return redirect("escalated:agent_ticket_show", ticket_id=ticket_id)
 
     try:
-        macro = Macro.objects.filter(
-            Q(is_shared=True) | Q(created_by=request.user)
-        ).get(pk=macro_id)
+        macro = Macro.objects.filter(Q(is_shared=True) | Q(created_by=request.user)).get(pk=macro_id)
     except Macro.DoesNotExist:
         return HttpResponseNotFound(_("Macro not found"))
 
     from escalated.services.macro_service import MacroService
+
     macro_service = MacroService()
     macro_service.apply(macro, ticket, request.user)
 

--- a/escalated/views/api.py
+++ b/escalated/views/api.py
@@ -14,14 +14,13 @@ from django.db.models import Q
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_GET, require_POST, require_http_methods
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
 
 from escalated.api_serializers import (
     ApiAgentSerializer,
     ApiCannedResponseSerializer,
     ApiDepartmentSerializer,
     ApiMacroSerializer,
-    ApiReplySerializer,
     ApiTagSerializer,
     ApiTicketCollectionSerializer,
     ApiTicketDetailSerializer,
@@ -33,14 +32,14 @@ from escalated.models import (
     Tag,
     Ticket,
 )
-from escalated.permissions import is_agent, is_admin
+from escalated.permissions import is_admin, is_agent
 from escalated.services.ticket_service import TicketService
 from escalated.validators import (
+    AssignTicketValidator,
+    ChangePriorityValidator,
+    ChangeStatusValidator,
     CreateTicketValidator,
     ReplyToTicketValidator,
-    ChangeStatusValidator,
-    ChangePriorityValidator,
-    AssignTicketValidator,
     UpdateTagsValidator,
 )
 
@@ -77,14 +76,16 @@ def _resolve_ticket(reference):
     Returns (ticket, None) on success, or (None, JsonResponse) on failure.
     """
     try:
-        ticket = Ticket.objects.select_related(
-            "assigned_to", "department", "sla_policy"
-        ).prefetch_related(
-            "tags",
-            "replies__author",
-            "replies__attachments",
-            "activities",
-        ).get(reference=reference)
+        ticket = (
+            Ticket.objects.select_related("assigned_to", "department", "sla_policy")
+            .prefetch_related(
+                "tags",
+                "replies__author",
+                "replies__attachments",
+                "activities",
+            )
+            .get(reference=reference)
+        )
         return ticket, None
     except Ticket.DoesNotExist:
         pass
@@ -92,14 +93,16 @@ def _resolve_ticket(reference):
     # Fall back to lookup by numeric ID
     try:
         ticket_id = int(reference)
-        ticket = Ticket.objects.select_related(
-            "assigned_to", "department", "sla_policy"
-        ).prefetch_related(
-            "tags",
-            "replies__author",
-            "replies__attachments",
-            "activities",
-        ).get(pk=ticket_id)
+        ticket = (
+            Ticket.objects.select_related("assigned_to", "department", "sla_policy")
+            .prefetch_related(
+                "tags",
+                "replies__author",
+                "replies__attachments",
+                "activities",
+            )
+            .get(pk=ticket_id)
+        )
         return ticket, None
     except (ValueError, Ticket.DoesNotExist):
         return None, JsonResponse({"message": "Ticket not found."}, status=404)
@@ -121,20 +124,20 @@ def auth_validate(request):
     user = request.user
     api_token = getattr(request, "api_token", None)
 
-    return JsonResponse({
-        "user": {
-            "id": user.pk,
-            "name": getattr(user, "get_full_name", lambda: str(user))(),
-            "email": getattr(user, "email", ""),
-        },
-        "abilities": api_token.abilities if api_token else [],
-        "is_agent": is_agent(user),
-        "is_admin": is_admin(user),
-        "token_name": api_token.name if api_token else None,
-        "expires_at": (
-            api_token.expires_at.isoformat() if api_token and api_token.expires_at else None
-        ),
-    })
+    return JsonResponse(
+        {
+            "user": {
+                "id": user.pk,
+                "name": getattr(user, "get_full_name", lambda: str(user))(),
+                "email": getattr(user, "email", ""),
+            },
+            "abilities": api_token.abilities if api_token else [],
+            "is_agent": is_agent(user),
+            "is_admin": is_admin(user),
+            "token_name": api_token.name if api_token else None,
+            "expires_at": (api_token.expires_at.isoformat() if api_token and api_token.expires_at else None),
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -158,15 +161,10 @@ def dashboard(request):
         "my_assigned": Ticket.objects.assigned_to(user_id).open().count(),
         "unassigned": Ticket.objects.unassigned().open().count(),
         "sla_breached": Ticket.objects.open().breached_sla().count(),
-        "resolved_today": Ticket.objects.filter(
-            resolved_at__gte=today_start
-        ).count(),
+        "resolved_today": Ticket.objects.filter(resolved_at__gte=today_start).count(),
     }
 
-    recent_tickets = (
-        Ticket.objects.select_related("assigned_to", "department")
-        .order_by("-created_at")[:10]
-    )
+    recent_tickets = Ticket.objects.select_related("assigned_to", "department").order_by("-created_at")[:10]
 
     recent_tickets_data = [
         {
@@ -177,9 +175,7 @@ def dashboard(request):
             "priority": t.priority,
             "requester_name": t.requester_name,
             "assignee_name": (
-                getattr(t.assigned_to, "get_full_name", lambda: str(t.assigned_to))()
-                if t.assigned_to
-                else None
+                getattr(t.assigned_to, "get_full_name", lambda: str(t.assigned_to))() if t.assigned_to else None
             ),
             "created_at": t.created_at.isoformat(),
         }
@@ -187,9 +183,7 @@ def dashboard(request):
     ]
 
     # Needs attention: SLA breaching tickets
-    sla_breaching = Ticket.objects.open().breached_sla().select_related(
-        "assigned_to"
-    )[:5]
+    sla_breaching = Ticket.objects.open().breached_sla().select_related("assigned_to")[:5]
     sla_breaching_data = [
         {
             "reference": t.reference,
@@ -201,11 +195,7 @@ def dashboard(request):
     ]
 
     # Unassigned urgent tickets
-    unassigned_urgent = (
-        Ticket.objects.unassigned()
-        .open()
-        .filter(priority__in=["urgent", "critical"])[:5]
-    )
+    unassigned_urgent = Ticket.objects.unassigned().open().filter(priority__in=["urgent", "critical"])[:5]
     unassigned_urgent_data = [
         {
             "reference": t.reference,
@@ -217,21 +207,21 @@ def dashboard(request):
     ]
 
     # My performance
-    my_resolved_this_week = Ticket.objects.assigned_to(user_id).filter(
-        resolved_at__gte=week_start
-    ).count()
+    my_resolved_this_week = Ticket.objects.assigned_to(user_id).filter(resolved_at__gte=week_start).count()
 
-    return JsonResponse({
-        "stats": stats,
-        "recent_tickets": recent_tickets_data,
-        "needs_attention": {
-            "sla_breaching": sla_breaching_data,
-            "unassigned_urgent": unassigned_urgent_data,
-        },
-        "my_performance": {
-            "resolved_this_week": my_resolved_this_week,
-        },
-    })
+    return JsonResponse(
+        {
+            "stats": stats,
+            "recent_tickets": recent_tickets_data,
+            "needs_attention": {
+                "sla_breaching": sla_breaching_data,
+                "unassigned_urgent": unassigned_urgent_data,
+            },
+            "my_performance": {
+                "resolved_this_week": my_resolved_this_week,
+            },
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -248,9 +238,7 @@ def ticket_list(request):
     Query params: status, priority, department_id, assigned_to, unassigned,
                   search, sla_breached, following, sort_by, sort_dir, per_page, page
     """
-    tickets = Ticket.objects.select_related(
-        "assigned_to", "department"
-    ).prefetch_related("tags")
+    tickets = Ticket.objects.select_related("assigned_to", "department").prefetch_related("tags")
 
     # Filters
     status = request.GET.get("status")
@@ -293,7 +281,11 @@ def ticket_list(request):
     sort_by = request.GET.get("sort_by", "created_at")
     sort_dir = request.GET.get("sort_dir", "desc")
     allowed_sort_fields = [
-        "created_at", "updated_at", "priority", "status", "subject",
+        "created_at",
+        "updated_at",
+        "priority",
+        "status",
+        "subject",
     ]
     if sort_by in allowed_sort_fields:
         order = f"-{sort_by}" if sort_dir == "desc" else sort_by
@@ -312,15 +304,17 @@ def ticket_list(request):
         page_num = 1
     page = paginator.get_page(page_num)
 
-    return JsonResponse({
-        "data": ApiTicketCollectionSerializer.serialize_list(page.object_list),
-        "meta": {
-            "current_page": page.number,
-            "last_page": paginator.num_pages,
-            "per_page": per_page,
-            "total": paginator.count,
-        },
-    })
+    return JsonResponse(
+        {
+            "data": ApiTicketCollectionSerializer.serialize_list(page.object_list),
+            "meta": {
+                "current_page": page.number,
+                "last_page": paginator.num_pages,
+                "per_page": per_page,
+                "total": paginator.count,
+            },
+        }
+    )
 
 
 @require_GET
@@ -334,9 +328,11 @@ def ticket_show(request, reference):
     if error:
         return error
 
-    return JsonResponse({
-        "data": ApiTicketDetailSerializer.serialize(ticket),
-    })
+    return JsonResponse(
+        {
+            "data": ApiTicketDetailSerializer.serialize(ticket),
+        }
+    )
 
 
 @csrf_exempt
@@ -371,15 +367,11 @@ def ticket_create(request):
     ticket = service.create(request.user, ticket_data)
 
     # Reload with relations
-    ticket = Ticket.objects.select_related(
-        "assigned_to", "department"
-    ).prefetch_related("tags").get(pk=ticket.pk)
+    ticket = Ticket.objects.select_related("assigned_to", "department").prefetch_related("tags").get(pk=ticket.pk)
 
     return JsonResponse(
         {
-            "data": ApiTicketDetailSerializer.serialize(
-                ticket, include_replies=False, include_activities=False
-            ),
+            "data": ApiTicketDetailSerializer.serialize(ticket, include_replies=False, include_activities=False),
             "message": "Ticket created.",
         },
         status=201,
@@ -557,9 +549,7 @@ def ticket_apply_macro(request, reference):
         )
 
     try:
-        macro = Macro.objects.filter(
-            Q(is_shared=True) | Q(created_by=request.user)
-        ).get(pk=int(macro_id))
+        macro = Macro.objects.filter(Q(is_shared=True) | Q(created_by=request.user)).get(pk=int(macro_id))
     except (Macro.DoesNotExist, ValueError, TypeError):
         return JsonResponse({"message": "Macro not found."}, status=404)
 
@@ -670,9 +660,7 @@ def resource_canned_responses(request):
 
     List canned responses available to the authenticated user.
     """
-    responses = CannedResponse.objects.filter(
-        Q(is_shared=True) | Q(created_by=request.user)
-    )
+    responses = CannedResponse.objects.filter(Q(is_shared=True) | Q(created_by=request.user))
     return JsonResponse({"data": ApiCannedResponseSerializer.serialize_list(responses)})
 
 
@@ -683,9 +671,7 @@ def resource_macros(request):
 
     List macros available to the authenticated user.
     """
-    macros = Macro.objects.filter(
-        Q(is_shared=True) | Q(created_by=request.user)
-    ).order_by("order")
+    macros = Macro.objects.filter(Q(is_shared=True) | Q(created_by=request.user)).order_by("order")
     return JsonResponse({"data": ApiMacroSerializer.serialize_list(macros)})
 
 

--- a/escalated/views/customer.py
+++ b/escalated/views/customer.py
@@ -4,12 +4,12 @@ from django.core.paginator import Paginator
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
-from escalated.rendering import render_page
 
 from escalated.conf import get_setting
-from escalated.models import Ticket, Tag, Department, SatisfactionRating
-from escalated.permissions import can_view_ticket, can_reply_ticket, can_close_ticket
-from escalated.serializers import TicketSerializer, TagSerializer, DepartmentSerializer
+from escalated.models import Department, SatisfactionRating, Ticket
+from escalated.permissions import can_close_ticket, can_reply_ticket, can_view_ticket
+from escalated.rendering import render_page
+from escalated.serializers import DepartmentSerializer, TicketSerializer
 from escalated.services.ticket_service import TicketService
 
 
@@ -17,10 +17,14 @@ from escalated.services.ticket_service import TicketService
 def ticket_list(request):
     """List all tickets for the authenticated customer."""
     ct = ContentType.objects.get_for_model(request.user)
-    tickets = Ticket.objects.filter(
-        requester_content_type=ct,
-        requester_object_id=request.user.pk,
-    ).select_related("assigned_to", "department").prefetch_related("tags")
+    tickets = (
+        Ticket.objects.filter(
+            requester_content_type=ct,
+            requester_object_id=request.user.pk,
+        )
+        .select_related("assigned_to", "department")
+        .prefetch_related("tags")
+    )
 
     # Optional filtering
     status = request.GET.get("status")
@@ -34,37 +38,39 @@ def ticket_list(request):
     paginator = Paginator(tickets, 15)
     page = paginator.get_page(request.GET.get("page", 1))
 
-    return render_page(request, "Escalated/Customer/Index", props={
-        "tickets": TicketSerializer.serialize_list(page.object_list),
-        "pagination": {
-            "current_page": page.number,
-            "total_pages": paginator.num_pages,
-            "total_count": paginator.count,
-            "has_next": page.has_next(),
-            "has_previous": page.has_previous(),
+    return render_page(
+        request,
+        "Escalated/Customer/Index",
+        props={
+            "tickets": TicketSerializer.serialize_list(page.object_list),
+            "pagination": {
+                "current_page": page.number,
+                "total_pages": paginator.num_pages,
+                "total_count": paginator.count,
+                "has_next": page.has_next(),
+                "has_previous": page.has_previous(),
+            },
+            "filters": {
+                "status": status,
+                "search": search,
+            },
+            "statuses": [{"value": s.value, "label": s.label} for s in Ticket.Status],
         },
-        "filters": {
-            "status": status,
-            "search": search,
-        },
-        "statuses": [
-            {"value": s.value, "label": s.label} for s in Ticket.Status
-        ],
-    })
+    )
 
 
 @login_required
 def ticket_create(request):
     """Show the ticket creation form."""
-    return render_page(request, "Escalated/Customer/Create", props={
-        "departments": DepartmentSerializer.serialize_list(
-            Department.objects.filter(is_active=True)
-        ),
-        "priorities": [
-            {"value": p.value, "label": p.label} for p in Ticket.Priority
-        ],
-        "default_priority": get_setting("DEFAULT_PRIORITY"),
-    })
+    return render_page(
+        request,
+        "Escalated/Customer/Create",
+        props={
+            "departments": DepartmentSerializer.serialize_list(Department.objects.filter(is_active=True)),
+            "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+            "default_priority": get_setting("DEFAULT_PRIORITY"),
+        },
+    )
 
 
 @login_required
@@ -89,17 +95,17 @@ def ticket_store(request):
         errors["description"] = _("Description is required.")
 
     if errors:
-        return render_page(request, "Escalated/Customer/Create", props={
-            "errors": errors,
-            "old": data,
-            "departments": DepartmentSerializer.serialize_list(
-                Department.objects.filter(is_active=True)
-            ),
-            "priorities": [
-                {"value": p.value, "label": p.label} for p in Ticket.Priority
-            ],
-            "default_priority": get_setting("DEFAULT_PRIORITY"),
-        })
+        return render_page(
+            request,
+            "Escalated/Customer/Create",
+            props={
+                "errors": errors,
+                "old": data,
+                "departments": DepartmentSerializer.serialize_list(Department.objects.filter(is_active=True)),
+                "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+                "default_priority": get_setting("DEFAULT_PRIORITY"),
+            },
+        )
 
     ticket = service.create(request.user, data)
 
@@ -107,13 +113,15 @@ def ticket_store(request):
     files = request.FILES.getlist("attachments")
     if files:
         from escalated.services.attachment_service import AttachmentService
-        for f in files[:get_setting("MAX_ATTACHMENTS")]:
+
+        for f in files[: get_setting("MAX_ATTACHMENTS")]:
             try:
                 AttachmentService.attach(ticket, f)
             except Exception:
                 pass  # Non-blocking; attachment errors don't fail ticket creation
 
     from django.shortcuts import redirect
+
     return redirect("escalated:customer_ticket_show", ticket_id=ticket.pk)
 
 
@@ -121,11 +129,11 @@ def ticket_store(request):
 def ticket_show(request, ticket_id):
     """Show a single ticket and its replies."""
     try:
-        ticket = Ticket.objects.select_related(
-            "assigned_to", "department", "sla_policy"
-        ).prefetch_related(
-            "tags", "replies__author", "replies__attachments", "attachments"
-        ).get(pk=ticket_id)
+        ticket = (
+            Ticket.objects.select_related("assigned_to", "department", "sla_policy")
+            .prefetch_related("tags", "replies__author", "replies__attachments", "attachments")
+            .get(pk=ticket_id)
+        )
     except Ticket.DoesNotExist:
         return HttpResponseNotFound(_("Ticket not found"))
 
@@ -135,14 +143,19 @@ def ticket_show(request, ticket_id):
     # Filter out internal notes for customers
     replies = ticket.replies.filter(is_deleted=False, is_internal_note=False)
 
-    from escalated.serializers import ReplySerializer, AttachmentSerializer
-    return render_page(request, "Escalated/Customer/Show", props={
-        "ticket": TicketSerializer.serialize(ticket),
-        "replies": ReplySerializer.serialize_list(replies),
-        "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
-        "can_reply": can_reply_ticket(request.user, ticket),
-        "can_close": can_close_ticket(request.user, ticket),
-    })
+    from escalated.serializers import AttachmentSerializer, ReplySerializer
+
+    return render_page(
+        request,
+        "Escalated/Customer/Show",
+        props={
+            "ticket": TicketSerializer.serialize(ticket),
+            "replies": ReplySerializer.serialize_list(replies),
+            "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
+            "can_reply": can_reply_ticket(request.user, ticket),
+            "can_close": can_close_ticket(request.user, ticket),
+        },
+    )
 
 
 @login_required
@@ -162,6 +175,7 @@ def ticket_reply(request, ticket_id):
     body = request.POST.get("body", "").strip()
     if not body:
         from django.shortcuts import redirect
+
         return redirect("escalated:customer_ticket_show", ticket_id=ticket_id)
 
     service = TicketService()
@@ -171,13 +185,15 @@ def ticket_reply(request, ticket_id):
     files = request.FILES.getlist("attachments")
     if files:
         from escalated.services.attachment_service import AttachmentService
-        for f in files[:get_setting("MAX_ATTACHMENTS")]:
+
+        for f in files[: get_setting("MAX_ATTACHMENTS")]:
             try:
                 AttachmentService.attach(reply, f)
             except Exception:
                 pass
 
     from django.shortcuts import redirect
+
     return redirect("escalated:customer_ticket_show", ticket_id=ticket_id)
 
 
@@ -199,6 +215,7 @@ def ticket_close(request, ticket_id):
     service.close(ticket, request.user)
 
     from django.shortcuts import redirect
+
     return redirect("escalated:customer_ticket_show", ticket_id=ticket_id)
 
 
@@ -214,10 +231,7 @@ def ticket_reopen(request, ticket_id):
         return HttpResponseNotFound(_("Ticket not found"))
 
     ct = ContentType.objects.get_for_model(request.user)
-    is_requester = (
-        ticket.requester_content_type == ct
-        and ticket.requester_object_id == request.user.pk
-    )
+    is_requester = ticket.requester_content_type == ct and ticket.requester_object_id == request.user.pk
     if not is_requester:
         return HttpResponseForbidden(_("You cannot reopen this ticket."))
 

--- a/escalated/views/guest.py
+++ b/escalated/views/guest.py
@@ -3,15 +3,15 @@ import secrets
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
-from escalated.rendering import render_page
 
 from escalated.conf import get_setting
-from escalated.models import Ticket, Department, EscalatedSetting, SatisfactionRating
+from escalated.models import Department, EscalatedSetting, SatisfactionRating, Ticket
+from escalated.rendering import render_page
 from escalated.serializers import (
-    TicketSerializer,
-    ReplySerializer,
-    DepartmentSerializer,
     AttachmentSerializer,
+    DepartmentSerializer,
+    ReplySerializer,
+    TicketSerializer,
 )
 
 
@@ -25,15 +25,15 @@ def ticket_create(request):
     if not _guest_tickets_enabled():
         return HttpResponseNotFound(_("Guest tickets are not enabled."))
 
-    return render_page(request, "Escalated/Guest/Create", props={
-        "departments": DepartmentSerializer.serialize_list(
-            Department.objects.filter(is_active=True)
-        ),
-        "priorities": [
-            {"value": p.value, "label": p.label} for p in Ticket.Priority
-        ],
-        "default_priority": get_setting("DEFAULT_PRIORITY"),
-    })
+    return render_page(
+        request,
+        "Escalated/Guest/Create",
+        props={
+            "departments": DepartmentSerializer.serialize_list(Department.objects.filter(is_active=True)),
+            "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+            "default_priority": get_setting("DEFAULT_PRIORITY"),
+        },
+    )
 
 
 def ticket_store(request):
@@ -63,24 +63,24 @@ def ticket_store(request):
         errors["description"] = _("Description is required.")
 
     if errors:
-        return render_page(request, "Escalated/Guest/Create", props={
-            "errors": errors,
-            "old": {
-                "name": name,
-                "email": email,
-                "subject": subject,
-                "description": description,
-                "priority": priority,
-                "department_id": department_id,
+        return render_page(
+            request,
+            "Escalated/Guest/Create",
+            props={
+                "errors": errors,
+                "old": {
+                    "name": name,
+                    "email": email,
+                    "subject": subject,
+                    "description": description,
+                    "priority": priority,
+                    "department_id": department_id,
+                },
+                "departments": DepartmentSerializer.serialize_list(Department.objects.filter(is_active=True)),
+                "priorities": [{"value": p.value, "label": p.label} for p in Ticket.Priority],
+                "default_priority": get_setting("DEFAULT_PRIORITY"),
             },
-            "departments": DepartmentSerializer.serialize_list(
-                Department.objects.filter(is_active=True)
-            ),
-            "priorities": [
-                {"value": p.value, "label": p.label} for p in Ticket.Priority
-            ],
-            "default_priority": get_setting("DEFAULT_PRIORITY"),
-        })
+        )
 
     # Generate a unique guest token
     guest_token = secrets.token_hex(32)  # 64-character hex string
@@ -103,7 +103,7 @@ def ticket_store(request):
     if files:
         from escalated.services.attachment_service import AttachmentService
 
-        for f in files[:get_setting("MAX_ATTACHMENTS")]:
+        for f in files[: get_setting("MAX_ATTACHMENTS")]:
             try:
                 AttachmentService.attach(ticket, f)
             except Exception:
@@ -115,24 +115,28 @@ def ticket_store(request):
 def ticket_show(request, token):
     """Show a guest ticket by its token."""
     try:
-        ticket = Ticket.objects.select_related(
-            "assigned_to", "department", "sla_policy"
-        ).prefetch_related(
-            "tags", "replies__author", "replies__attachments", "attachments"
-        ).get(guest_token=token)
+        ticket = (
+            Ticket.objects.select_related("assigned_to", "department", "sla_policy")
+            .prefetch_related("tags", "replies__author", "replies__attachments", "attachments")
+            .get(guest_token=token)
+        )
     except Ticket.DoesNotExist:
         return HttpResponseNotFound(_("Ticket not found."))
 
     # Filter out internal notes for guest users
     replies = ticket.replies.filter(is_deleted=False, is_internal_note=False)
 
-    return render_page(request, "Escalated/Guest/Show", props={
-        "ticket": TicketSerializer.serialize(ticket),
-        "replies": ReplySerializer.serialize_list(replies),
-        "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
-        "token": token,
-        "can_reply": ticket.is_open,
-    })
+    return render_page(
+        request,
+        "Escalated/Guest/Show",
+        props={
+            "ticket": TicketSerializer.serialize(ticket),
+            "replies": ReplySerializer.serialize_list(replies),
+            "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
+            "token": token,
+            "can_reply": ticket.is_open,
+        },
+    )
 
 
 def ticket_reply(request, token):
@@ -164,7 +168,7 @@ def ticket_reply(request, token):
     if files:
         from escalated.services.attachment_service import AttachmentService
 
-        for f in files[:get_setting("MAX_ATTACHMENTS")]:
+        for f in files[: get_setting("MAX_ATTACHMENTS")]:
             try:
                 AttachmentService.attach(reply_obj, f)
             except Exception:

--- a/escalated/views/import_views.py
+++ b/escalated/views/import_views.py
@@ -28,10 +28,10 @@ from django.http import (
 )
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
-from escalated.rendering import render_page
 
 from escalated.models import ImportJob
 from escalated.permissions import is_admin
+from escalated.rendering import render_page
 from escalated.services.import_service import ImportService
 
 logger = logging.getLogger("escalated.import")
@@ -70,10 +70,7 @@ def import_index(request):
         return check
 
     service = ImportService()
-    adapters = [
-        {"name": a.name(), "display_name": a.display_name()}
-        for a in service.available_adapters()
-    ]
+    adapters = [{"name": a.name(), "display_name": a.display_name()} for a in service.available_adapters()]
 
     jobs = list(
         ImportJob.objects.order_by("-created_at").values(
@@ -92,10 +89,14 @@ def import_index(request):
             if job[ts_field]:
                 job[ts_field] = job[ts_field].isoformat()
 
-    return render_page(request, "Escalated/Admin/Import/Index", props={
-        "jobs": jobs,
-        "adapters": adapters,
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Import/Index",
+        props={
+            "jobs": jobs,
+            "adapters": adapters,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -120,9 +121,13 @@ def import_create(request):
         for a in service.available_adapters()
     ]
 
-    return render_page(request, "Escalated/Admin/Import/Create", props={
-        "adapters": adapters,
-    })
+    return render_page(
+        request,
+        "Escalated/Admin/Import/Create",
+        props={
+            "adapters": adapters,
+        },
+    )
 
 
 @login_required
@@ -140,8 +145,7 @@ def import_store(request):
         return HttpResponseForbidden(_("Method not allowed."))
 
     platform = request.POST.get("platform") or (
-        request.content_type == "application/json"
-        and __import__("json").loads(request.body or "{}").get("platform")
+        request.content_type == "application/json" and __import__("json").loads(request.body or "{}").get("platform")
     )
 
     service = ImportService()
@@ -234,15 +238,19 @@ def import_mapping(request, job_uuid):
             "current": mappings.get(et, adapter.default_field_mappings(et)),
         }
 
-    return render_page(request, "Escalated/Admin/Import/Mapping", props={
-        "job": {
-            "id": str(job.id),
-            "platform": job.platform,
-            "status": job.status,
+    return render_page(
+        request,
+        "Escalated/Admin/Import/Mapping",
+        props={
+            "job": {
+                "id": str(job.id),
+                "platform": job.platform,
+                "status": job.status,
+            },
+            "entity_types": entity_types,
+            "mapping_data": mapping_data,
         },
-        "entity_types": entity_types,
-        "mapping_data": mapping_data,
-    })
+    )
 
 
 @login_required
@@ -260,6 +268,7 @@ def import_mapping_save(request, job_uuid):
         return HttpResponseNotFound(_("Import job not found."))
 
     import json as _json
+
     try:
         body = _json.loads(request.body or "{}")
         mappings = body.get("mappings", {})
@@ -351,12 +360,14 @@ def import_progress(request, job_uuid):
     if not job:
         return HttpResponseNotFound(_("Import job not found."))
 
-    return JsonResponse({
-        "id": str(job.id),
-        "status": job.status,
-        "progress": job.progress or {},
-        "error_count": len(job.error_log or []),
-    })
+    return JsonResponse(
+        {
+            "id": str(job.id),
+            "status": job.status,
+            "progress": job.progress or {},
+            "error_count": len(job.error_log or []),
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -379,21 +390,25 @@ def import_show(request, job_uuid):
     adapter = service.resolve_adapter(job.platform)
     entity_types = adapter.entity_types() if adapter else []
 
-    return render_page(request, "Escalated/Admin/Import/Show", props={
-        "job": {
-            "id": str(job.id),
-            "platform": job.platform,
-            "status": job.status,
-            "progress": job.progress or {},
-            "error_log": (job.error_log or [])[:100],  # cap for page load
-            "field_mappings": job.field_mappings or {},
-            "started_at": job.started_at.isoformat() if job.started_at else None,
-            "completed_at": job.completed_at.isoformat() if job.completed_at else None,
-            "created_at": job.created_at.isoformat() if job.created_at else None,
-            "is_resumable": job.is_resumable(),
+    return render_page(
+        request,
+        "Escalated/Admin/Import/Show",
+        props={
+            "job": {
+                "id": str(job.id),
+                "platform": job.platform,
+                "status": job.status,
+                "progress": job.progress or {},
+                "error_log": (job.error_log or [])[:100],  # cap for page load
+                "field_mappings": job.field_mappings or {},
+                "started_at": job.started_at.isoformat() if job.started_at else None,
+                "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+                "created_at": job.created_at.isoformat() if job.created_at else None,
+                "is_resumable": job.is_resumable(),
+            },
+            "entity_types": entity_types,
         },
-        "entity_types": entity_types,
-    })
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/escalated/views/inbound.py
+++ b/escalated/views/inbound.py
@@ -33,10 +33,7 @@ def inbound_webhook(request, adapter_name):
     """
     # Check if inbound email processing is enabled
     if not get_setting("INBOUND_EMAIL_ENABLED"):
-        logger.warning(
-            f"Inbound email webhook called but feature is disabled "
-            f"(adapter={adapter_name})"
-        )
+        logger.warning(f"Inbound email webhook called but feature is disabled (adapter={adapter_name})")
         return HttpResponseBadRequest(_("Inbound email processing is disabled."))
 
     # Resolve the adapter
@@ -49,8 +46,7 @@ def inbound_webhook(request, adapter_name):
     # Verify the request authenticity
     if not adapter.verify_request(request):
         logger.warning(
-            f"Inbound email webhook verification failed "
-            f"(adapter={adapter_name}, ip={request.META.get('REMOTE_ADDR')})"
+            f"Inbound email webhook verification failed (adapter={adapter_name}, ip={request.META.get('REMOTE_ADDR')})"
         )
         return HttpResponseForbidden(_("Request verification failed."))
 
@@ -61,10 +57,7 @@ def inbound_webhook(request, adapter_name):
         # Special case: SNS subscription confirmation is handled inside parse
         if "SubscriptionConfirmation" in str(exc):
             return HttpResponse("OK", status=200)
-        logger.error(
-            f"Failed to parse inbound email webhook "
-            f"(adapter={adapter_name}): {exc}"
-        )
+        logger.error(f"Failed to parse inbound email webhook (adapter={adapter_name}): {exc}")
         return HttpResponseBadRequest(f"Failed to parse request: {exc}")
 
     # Process the inbound email
@@ -76,10 +69,7 @@ def inbound_webhook(request, adapter_name):
     elif inbound.status == "failed":
         # Still return 200 to prevent the sender from retrying
         # (the error is logged and stored in the InboundEmail record)
-        logger.error(
-            f"Inbound email processing failed but returning 200 to "
-            f"prevent retry: {inbound.error_message}"
-        )
+        logger.error(f"Inbound email processing failed but returning 200 to prevent retry: {inbound.error_message}")
         return HttpResponse("Accepted", status=200)
     else:
         return HttpResponse("Accepted", status=200)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "pytest-django>=4.5",
     "factory-boy>=3.2",
     "faker>=18.0",
+    "ruff>=0.4",
 ]
 
 [tool.pytest.ini_options]
@@ -29,3 +30,14 @@ DJANGO_SETTINGS_MODULE = "tests.settings"
 
 [project.urls]
 Homepage = "https://github.com/escalated-dev/escalated-django"
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP", "DJ"]
+ignore = ["DJ001"]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/stubs/plugins/hello-world/plugin.py
+++ b/stubs/plugins/hello-world/plugin.py
@@ -16,8 +16,8 @@ Delete it whenever you want -- it will not be offended.
 
 import logging
 
-from escalated.hooks import add_action, add_filter
-from escalated.plugin_ui_service import add_page_component, register_menu_item
+from escalated.hooks import add_action
+from escalated.plugin_ui_service import add_page_component
 
 logger = logging.getLogger("escalated.plugins.hello-world")
 
@@ -75,11 +75,15 @@ def on_plugin_loaded(slug, manifest):
     )
 
     # Register a component to appear on the agent dashboard header slot
-    add_page_component("dashboard", "header", {
-        "component": "HelloWorldBanner",
-        "plugin": "hello-world",
-        "position": 1,
-    })
+    add_page_component(
+        "dashboard",
+        "header",
+        {
+            "component": "HelloWorldBanner",
+            "plugin": "hello-world",
+            "position": 1,
+        },
+    )
 
 
 add_action("plugin_loaded", on_plugin_loaded)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,29 +1,28 @@
 import pytest
+
 from tests.factories import (
-    UserFactory,
-    TicketFactory,
-    ReplyFactory,
-    TagFactory,
-    DepartmentFactory,
-    SlaPolicyFactory,
-    EscalationRuleFactory,
-    CannedResponseFactory,
-    MacroFactory,
     ApiTokenFactory,
-    TicketStatusFactory,
-    BusinessScheduleFactory,
-    HolidayFactory,
-    PermissionFactory,
-    RoleFactory,
-    AuditLogFactory,
-    CustomFieldFactory,
-    CustomFieldValueFactory,
-    TicketLinkFactory,
-    SideConversationFactory,
-    SideConversationReplyFactory,
     ArticleCategoryFactory,
     ArticleFactory,
+    AuditLogFactory,
+    BusinessScheduleFactory,
+    CannedResponseFactory,
+    CustomFieldFactory,
+    DepartmentFactory,
+    EscalationRuleFactory,
+    HolidayFactory,
+    MacroFactory,
+    PermissionFactory,
+    RoleFactory,
+    SideConversationFactory,
+    SlaPolicyFactory,
+    TagFactory,
+    TicketFactory,
+    TicketLinkFactory,
+    TicketStatusFactory,
+    UserFactory,
 )
+
 
 @pytest.fixture
 def user(db):
@@ -123,6 +122,7 @@ def role(db):
 @pytest.fixture
 def audit_log(db, admin_user, ticket):
     from django.contrib.contenttypes.models import ContentType
+
     return AuditLogFactory(
         user=admin_user,
         auditable_content_type=ContentType.objects.get_for_model(ticket),

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,37 +6,37 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 
 from escalated.models import (
+    AgentCapacity,
+    AgentProfile,
     ApiToken,
-    Ticket,
-    Reply,
-    Tag,
-    Department,
-    SlaPolicy,
-    EscalationRule,
-    CannedResponse,
-    Macro,
+    Article,
+    ArticleCategory,
     AuditLog,
-    TicketStatus,
+    Automation,
     BusinessSchedule,
-    Holiday,
-    Role,
-    Permission,
+    CannedResponse,
     CustomField,
     CustomFieldValue,
-    TicketLink,
-    SideConversation,
-    SideConversationReply,
-    ArticleCategory,
-    Article,
-    AgentProfile,
-    Skill,
-    AgentCapacity,
-    Webhook,
-    WebhookDelivery,
-    Automation,
-    TwoFactor,
     CustomObject,
     CustomObjectRecord,
+    Department,
+    EscalationRule,
+    Holiday,
+    Macro,
+    Permission,
+    Reply,
+    Role,
+    SideConversation,
+    SideConversationReply,
+    Skill,
+    SlaPolicy,
+    Tag,
+    Ticket,
+    TicketLink,
+    TicketStatus,
+    TwoFactor,
+    Webhook,
+    WebhookDelivery,
 )
 
 
@@ -197,9 +197,7 @@ class ApiTokenFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
     plain_text = factory.LazyFunction(lambda: secrets.token_hex(32))
     name = factory.Sequence(lambda n: f"Test Token {n}")
-    token = factory.LazyAttribute(
-        lambda o: hashlib.sha256(o.plain_text.encode()).hexdigest()
-    )
+    token = factory.LazyAttribute(lambda o: hashlib.sha256(o.plain_text.encode()).hexdigest())
     abilities = factory.LazyFunction(lambda: ["*"])
     expires_at = None
 
@@ -241,13 +239,15 @@ class BusinessScheduleFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Schedule {n}")
     timezone = "UTC"
     is_default = False
-    schedule = factory.LazyFunction(lambda: {
-        "monday": {"start": "09:00", "end": "17:00"},
-        "tuesday": {"start": "09:00", "end": "17:00"},
-        "wednesday": {"start": "09:00", "end": "17:00"},
-        "thursday": {"start": "09:00", "end": "17:00"},
-        "friday": {"start": "09:00", "end": "17:00"},
-    })
+    schedule = factory.LazyFunction(
+        lambda: {
+            "monday": {"start": "09:00", "end": "17:00"},
+            "tuesday": {"start": "09:00", "end": "17:00"},
+            "wednesday": {"start": "09:00", "end": "17:00"},
+            "thursday": {"start": "09:00", "end": "17:00"},
+            "friday": {"start": "09:00", "end": "17:00"},
+        }
+    )
 
 
 class HolidayFactory(factory.django.DjangoModelFactory):
@@ -256,7 +256,7 @@ class HolidayFactory(factory.django.DjangoModelFactory):
 
     schedule = factory.SubFactory(BusinessScheduleFactory)
     name = factory.Sequence(lambda n: f"Holiday {n}")
-    date = factory.LazyFunction(lambda: __import__('datetime').date(2026, 12, 25))
+    date = factory.LazyFunction(lambda: __import__("datetime").date(2026, 12, 25))
     recurring = False
 
 
@@ -287,9 +287,7 @@ class AuditLogFactory(factory.django.DjangoModelFactory):
 
     user = factory.SubFactory(UserFactory)
     action = "created"
-    auditable_content_type = factory.LazyAttribute(
-        lambda o: ContentType.objects.get_for_model(Ticket)
-    )
+    auditable_content_type = factory.LazyAttribute(lambda o: ContentType.objects.get_for_model(Ticket))
     auditable_object_id = 1
     old_values = None
     new_values = factory.LazyFunction(lambda: {"status": "open"})
@@ -315,9 +313,7 @@ class CustomFieldValueFactory(factory.django.DjangoModelFactory):
         model = CustomFieldValue
 
     custom_field = factory.SubFactory(CustomFieldFactory)
-    entity_content_type = factory.LazyAttribute(
-        lambda o: ContentType.objects.get_for_model(Ticket)
-    )
+    entity_content_type = factory.LazyAttribute(lambda o: ContentType.objects.get_for_model(Ticket))
     entity_object_id = 1
     value = factory.Faker("word")
 

--- a/tests/integration/test_admin_api_tokens.py
+++ b/tests/integration/test_admin_api_tokens.py
@@ -3,7 +3,7 @@ Integration tests for the admin API token management views.
 """
 
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import RequestFactory
@@ -25,6 +25,7 @@ def rf():
 def _attach_session(request):
     """Attach a mock session to the request."""
     from django.contrib.sessions.backends.db import SessionStore
+
     request.session = SessionStore()
 
 
@@ -82,12 +83,14 @@ class TestAdminApiTokensCreate:
 
         request = rf.post(
             "/admin/api-tokens/create/",
-            data=json.dumps({
-                "name": "Test Token",
-                "user_id": user.pk,
-                "abilities": ["agent"],
-                "expires_in_days": 30,
-            }),
+            data=json.dumps(
+                {
+                    "name": "Test Token",
+                    "user_id": user.pk,
+                    "abilities": ["agent"],
+                    "expires_in_days": 30,
+                }
+            ),
             content_type="application/json",
         )
         request.user = admin
@@ -176,10 +179,12 @@ class TestAdminApiTokensUpdate:
 
         request = rf.post(
             f"/admin/api-tokens/{token.pk}/update/",
-            data=json.dumps({
-                "name": "Updated Name",
-                "abilities": ["agent", "admin"],
-            }),
+            data=json.dumps(
+                {
+                    "name": "Updated Name",
+                    "abilities": ["agent", "admin"],
+                }
+            ),
             content_type="application/json",
         )
         request.user = admin

--- a/tests/integration/test_api_views.py
+++ b/tests/integration/test_api_views.py
@@ -7,18 +7,12 @@ and request.api_token (as the middleware would do).
 """
 
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import RequestFactory
-from django.utils import timezone
 
 from escalated.models import (
-    ApiToken,
-    CannedResponse,
-    Department,
-    Macro,
-    Tag,
     Ticket,
 )
 from escalated.views import api
@@ -176,9 +170,7 @@ class TestApiTicketList:
         TicketFactory(status=Ticket.Status.OPEN)
         TicketFactory(status=Ticket.Status.CLOSED)
 
-        request = _api_get(
-            rf, "/api/tickets/", user, token, {"status": "open"}
-        )
+        request = _api_get(rf, "/api/tickets/", user, token, {"status": "open"})
         response = api.ticket_list(request)
 
         data = json.loads(response.content)
@@ -194,9 +186,7 @@ class TestApiTicketList:
         TicketFactory(priority=Ticket.Priority.HIGH)
         TicketFactory(priority=Ticket.Priority.LOW)
 
-        request = _api_get(
-            rf, "/api/tickets/", user, token, {"priority": "high"}
-        )
+        request = _api_get(rf, "/api/tickets/", user, token, {"priority": "high"})
         response = api.ticket_list(request)
 
         data = json.loads(response.content)
@@ -212,9 +202,7 @@ class TestApiTicketList:
         TicketFactory(subject="Payment refund issue")
         TicketFactory(subject="General question")
 
-        request = _api_get(
-            rf, "/api/tickets/", user, token, {"search": "Payment"}
-        )
+        request = _api_get(rf, "/api/tickets/", user, token, {"search": "Payment"})
         response = api.ticket_list(request)
 
         data = json.loads(response.content)
@@ -229,9 +217,7 @@ class TestApiTicketList:
         for _ in range(30):
             TicketFactory()
 
-        request = _api_get(
-            rf, "/api/tickets/", user, token, {"per_page": "10", "page": "2"}
-        )
+        request = _api_get(rf, "/api/tickets/", user, token, {"per_page": "10", "page": "2"})
         response = api.ticket_list(request)
 
         data = json.loads(response.content)
@@ -322,19 +308,23 @@ class TestApiTicketCreate:
         token = ApiTokenFactory(user=user)
 
         # Create real ticket to return
-        ticket = TicketFactory(
-            requester=user, subject="API Test", description="API Description"
-        )
+        ticket = TicketFactory(requester=user, subject="API Test", description="API Description")
 
         mock_svc = MagicMock()
         mock_svc.create.return_value = ticket
         MockService.return_value = mock_svc
 
-        request = _api_post(rf, "/api/tickets/create/", user, token, {
-            "subject": "API Test",
-            "description": "API Description",
-            "priority": "high",
-        })
+        request = _api_post(
+            rf,
+            "/api/tickets/create/",
+            user,
+            token,
+            {
+                "subject": "API Test",
+                "description": "API Description",
+                "priority": "high",
+            },
+        )
         response = api.ticket_create(request)
 
         assert response.status_code == 201
@@ -348,9 +338,15 @@ class TestApiTicketCreate:
         department.agents.add(user)
         token = ApiTokenFactory(user=user)
 
-        request = _api_post(rf, "/api/tickets/create/", user, token, {
-            "description": "Some desc",
-        })
+        request = _api_post(
+            rf,
+            "/api/tickets/create/",
+            user,
+            token,
+            {
+                "description": "Some desc",
+            },
+        )
         response = api.ticket_create(request)
 
         assert response.status_code == 422
@@ -363,9 +359,15 @@ class TestApiTicketCreate:
         department.agents.add(user)
         token = ApiTokenFactory(user=user)
 
-        request = _api_post(rf, "/api/tickets/create/", user, token, {
-            "subject": "Subject only",
-        })
+        request = _api_post(
+            rf,
+            "/api/tickets/create/",
+            user,
+            token,
+            {
+                "subject": "Subject only",
+            },
+        )
         response = api.ticket_create(request)
 
         assert response.status_code == 422
@@ -378,11 +380,17 @@ class TestApiTicketCreate:
         department.agents.add(user)
         token = ApiTokenFactory(user=user)
 
-        request = _api_post(rf, "/api/tickets/create/", user, token, {
-            "subject": "Test",
-            "description": "Test",
-            "priority": "invalid_priority",
-        })
+        request = _api_post(
+            rf,
+            "/api/tickets/create/",
+            user,
+            token,
+            {
+                "subject": "Test",
+                "description": "Test",
+                "priority": "invalid_priority",
+            },
+        )
         response = api.ticket_create(request)
 
         assert response.status_code == 422
@@ -412,7 +420,10 @@ class TestApiTicketReply:
         MockService.return_value = mock_svc
 
         request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/reply/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/reply/",
+            user,
+            token,
             {"body": "Reply body"},
         )
         response = api.ticket_reply(request, ticket.reference)
@@ -430,9 +441,7 @@ class TestApiTicketReply:
 
         ticket = TicketFactory()
 
-        request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/reply/", user, token, {}
-        )
+        request = _api_post(rf, f"/api/tickets/{ticket.reference}/reply/", user, token, {})
         response = api.ticket_reply(request, ticket.reference)
 
         assert response.status_code == 422
@@ -444,7 +453,10 @@ class TestApiTicketReply:
         token = ApiTokenFactory(user=user)
 
         request = _api_post(
-            rf, "/api/tickets/NONEXIST/reply/", user, token,
+            rf,
+            "/api/tickets/NONEXIST/reply/",
+            user,
+            token,
             {"body": "Reply"},
         )
         response = api.ticket_reply(request, "NONEXIST")
@@ -472,7 +484,10 @@ class TestApiTicketStatus:
         MockService.return_value = mock_svc
 
         request = _api_patch(
-            rf, f"/api/tickets/{ticket.reference}/status/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/status/",
+            user,
+            token,
             {"status": "in_progress"},
         )
         response = api.ticket_status(request, ticket.reference)
@@ -491,7 +506,10 @@ class TestApiTicketStatus:
         ticket = TicketFactory()
 
         request = _api_patch(
-            rf, f"/api/tickets/{ticket.reference}/status/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/status/",
+            user,
+            token,
             {"status": "nonexistent"},
         )
         response = api.ticket_status(request, ticket.reference)
@@ -519,7 +537,10 @@ class TestApiTicketPriority:
         MockService.return_value = mock_svc
 
         request = _api_patch(
-            rf, f"/api/tickets/{ticket.reference}/priority/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/priority/",
+            user,
+            token,
             {"priority": "urgent"},
         )
         response = api.ticket_priority(request, ticket.reference)
@@ -537,7 +558,10 @@ class TestApiTicketPriority:
         ticket = TicketFactory()
 
         request = _api_patch(
-            rf, f"/api/tickets/{ticket.reference}/priority/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/priority/",
+            user,
+            token,
             {"priority": "super_duper"},
         )
         response = api.ticket_priority(request, ticket.reference)
@@ -566,7 +590,10 @@ class TestApiTicketAssign:
         MockService.return_value = mock_svc
 
         request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/assign/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/assign/",
+            user,
+            token,
             {"agent_id": agent.pk},
         )
         response = api.ticket_assign(request, ticket.reference)
@@ -583,9 +610,7 @@ class TestApiTicketAssign:
 
         ticket = TicketFactory()
 
-        request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/assign/", user, token, {}
-        )
+        request = _api_post(rf, f"/api/tickets/{ticket.reference}/assign/", user, token, {})
         response = api.ticket_assign(request, ticket.reference)
 
         assert response.status_code == 422
@@ -599,7 +624,10 @@ class TestApiTicketAssign:
         ticket = TicketFactory()
 
         request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/assign/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/assign/",
+            user,
+            token,
             {"agent_id": 99999},
         )
         response = api.ticket_assign(request, ticket.reference)
@@ -623,18 +651,14 @@ class TestApiTicketFollow:
         ticket = TicketFactory()
 
         # Follow
-        request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/follow/", user, token
-        )
+        request = _api_post(rf, f"/api/tickets/{ticket.reference}/follow/", user, token)
         response = api.ticket_follow(request, ticket.reference)
 
         data = json.loads(response.content)
         assert data["following"] is True
 
         # Unfollow
-        request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/follow/", user, token
-        )
+        request = _api_post(rf, f"/api/tickets/{ticket.reference}/follow/", user, token)
         response = api.ticket_follow(request, ticket.reference)
 
         data = json.loads(response.content)
@@ -663,7 +687,10 @@ class TestApiTicketTags:
         MockService.return_value = mock_svc
 
         request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/tags/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/tags/",
+            user,
+            token,
             {"tag_ids": [tag1.pk, tag2.pk]},
         )
         response = api.ticket_tags(request, ticket.reference)
@@ -680,9 +707,7 @@ class TestApiTicketTags:
 
         ticket = TicketFactory()
 
-        request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/tags/", user, token, {}
-        )
+        request = _api_post(rf, f"/api/tickets/{ticket.reference}/tags/", user, token, {})
         response = api.ticket_tags(request, ticket.reference)
 
         assert response.status_code == 422
@@ -704,7 +729,10 @@ class TestApiTicketMacro:
         ticket = TicketFactory()
 
         request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/macro/", user, token,
+            rf,
+            f"/api/tickets/{ticket.reference}/macro/",
+            user,
+            token,
             {"macro_id": 99999},
         )
         response = api.ticket_apply_macro(request, ticket.reference)
@@ -719,9 +747,7 @@ class TestApiTicketMacro:
 
         ticket = TicketFactory()
 
-        request = _api_post(
-            rf, f"/api/tickets/{ticket.reference}/macro/", user, token, {}
-        )
+        request = _api_post(rf, f"/api/tickets/{ticket.reference}/macro/", user, token, {})
         response = api.ticket_apply_macro(request, ticket.reference)
 
         assert response.status_code == 422
@@ -743,9 +769,7 @@ class TestApiTicketDelete:
         ticket = TicketFactory()
         ticket_pk = ticket.pk
 
-        request = _api_delete(
-            rf, f"/api/tickets/{ticket.reference}/delete/", user, token
-        )
+        request = _api_delete(rf, f"/api/tickets/{ticket.reference}/delete/", user, token)
         response = api.ticket_destroy(request, ticket.reference)
 
         assert response.status_code == 200
@@ -759,9 +783,7 @@ class TestApiTicketDelete:
         department.agents.add(user)
         token = ApiTokenFactory(user=user)
 
-        request = _api_delete(
-            rf, "/api/tickets/NONEXIST/delete/", user, token
-        )
+        request = _api_delete(rf, "/api/tickets/NONEXIST/delete/", user, token)
         response = api.ticket_destroy(request, "NONEXIST")
 
         assert response.status_code == 404

--- a/tests/integration/test_commands.py
+++ b/tests/integration/test_commands.py
@@ -1,12 +1,12 @@
-import pytest
 from datetime import timedelta
 from io import StringIO
 
+import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.utils import timezone
 
-from tests.factories import UserFactory, ApiTokenFactory, WebhookFactory
+from tests.factories import ApiTokenFactory, UserFactory, WebhookFactory
 
 
 @pytest.mark.django_db
@@ -59,9 +59,7 @@ class TestPurgeExpiredDataCommand:
 
         user = UserFactory()
         expired = ApiTokenFactory(user=user)
-        ApiToken.objects.filter(pk=expired.pk).update(
-            expires_at=timezone.now() - timedelta(days=1)
-        )
+        ApiToken.objects.filter(pk=expired.pk).update(expires_at=timezone.now() - timedelta(days=1))
 
         out = StringIO()
         call_command("purge_expired_data", stdout=out)
@@ -77,9 +75,7 @@ class TestPurgeExpiredDataCommand:
             payload={"test": True},
             response_code=200,
         )
-        WebhookDelivery.objects.filter(pk=old.pk).update(
-            created_at=timezone.now() - timedelta(days=60)
-        )
+        WebhookDelivery.objects.filter(pk=old.pk).update(created_at=timezone.now() - timedelta(days=60))
 
         out = StringIO()
         call_command("purge_expired_data", "--days", "30", stdout=out)

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -3,19 +3,19 @@ Full ticket lifecycle integration test.
 Tests the complete flow from creation through resolution and closing.
 """
 
-import pytest
 from datetime import timedelta
 
+import pytest
 from django.utils import timezone
 
-from escalated.models import Ticket, Reply, TicketActivity
-from escalated.services.ticket_service import TicketService
+from escalated.models import Reply, Ticket, TicketActivity
 from escalated.services.sla_service import SlaService
+from escalated.services.ticket_service import TicketService
 from tests.factories import (
-    UserFactory,
     DepartmentFactory,
     SlaPolicyFactory,
     TagFactory,
+    UserFactory,
 )
 
 
@@ -40,7 +40,7 @@ class TestTicketLifecycle:
         agent = UserFactory(username="lifecycle_agent")
         department = DepartmentFactory(name="Support")
         department.agents.add(agent)
-        sla = SlaPolicyFactory(
+        SlaPolicyFactory(
             is_default=True,
             first_response_hours={"medium": 8},
             resolution_hours={"medium": 24},
@@ -48,12 +48,15 @@ class TestTicketLifecycle:
         tag = TagFactory(name="Billing", slug="billing")
 
         # 1. Customer creates a ticket
-        ticket = service.create(customer, {
-            "subject": "Billing question",
-            "description": "I was charged twice for my subscription.",
-            "priority": "medium",
-            "department_id": department.pk,
-        })
+        ticket = service.create(
+            customer,
+            {
+                "subject": "Billing question",
+                "description": "I was charged twice for my subscription.",
+                "priority": "medium",
+                "department_id": department.pk,
+            },
+        )
 
         assert ticket.pk is not None
         assert ticket.status == Ticket.Status.OPEN
@@ -88,9 +91,9 @@ class TestTicketLifecycle:
         assert note.type == Reply.Type.NOTE
 
         # 5. Agent replies to customer
-        reply = service.reply(ticket, agent, {
-            "body": "I can see the duplicate charge. Let me process a refund for you."
-        })
+        reply = service.reply(
+            ticket, agent, {"body": "I can see the duplicate charge. Let me process a refund for you."}
+        )
         assert reply.pk is not None
         assert reply.is_internal_note is False
 
@@ -99,9 +102,7 @@ class TestTicketLifecycle:
         assert ticket.status == Ticket.Status.WAITING_ON_CUSTOMER
 
         # 6. Customer replies
-        customer_reply = service.reply(ticket, customer, {
-            "body": "Thank you! How long will the refund take?"
-        })
+        service.reply(ticket, customer, {"body": "Thank you! How long will the refund take?"})
 
         ticket.refresh_from_db()
         # After customer replies, status should transition to WAITING_ON_AGENT
@@ -146,11 +147,14 @@ class TestTicketLifecycle:
         department = DepartmentFactory()
         department.agents.add(agent)
 
-        ticket = service.create(customer, {
-            "subject": "Minor UI issue",
-            "description": "Button color is slightly off.",
-            "priority": "low",
-        })
+        ticket = service.create(
+            customer,
+            {
+                "subject": "Minor UI issue",
+                "description": "Button color is slightly off.",
+                "priority": "low",
+            },
+        )
 
         assert ticket.priority == Ticket.Priority.LOW
 
@@ -182,11 +186,14 @@ class TestTicketLifecycle:
         dept1.agents.add(agent)
         dept2.agents.add(agent)
 
-        ticket = service.create(customer, {
-            "subject": "Technical question about API",
-            "description": "How do I authenticate?",
-            "department_id": dept1.pk,
-        })
+        ticket = service.create(
+            customer,
+            {
+                "subject": "Technical question about API",
+                "description": "How do I authenticate?",
+                "department_id": dept1.pk,
+            },
+        )
 
         assert ticket.department == dept1
 
@@ -211,10 +218,13 @@ class TestTicketLifecycle:
         )
 
         service = TicketService()
-        ticket = service.create(customer, {
-            "subject": "SLA test ticket",
-            "description": "Testing SLA enforcement",
-        })
+        ticket = service.create(
+            customer,
+            {
+                "subject": "SLA test ticket",
+                "description": "Testing SLA enforcement",
+            },
+        )
 
         # Manually set SLA policy and deadline in the past
         ticket.sla_policy = policy

--- a/tests/integration/test_phase1_admin_views.py
+++ b/tests/integration/test_phase1_admin_views.py
@@ -1,18 +1,25 @@
 import json
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import patch, MagicMock
-
 from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory
 
 from escalated.models import (
-    TicketStatus, BusinessSchedule, Holiday, Role, Permission, AuditLog,
+    BusinessSchedule,
+    Role,
+    TicketStatus,
 )
 from escalated.views import admin
 from tests.factories import (
-    UserFactory, TicketFactory, TicketStatusFactory, BusinessScheduleFactory,
-    HolidayFactory, PermissionFactory, RoleFactory, AuditLogFactory,
+    AuditLogFactory,
+    BusinessScheduleFactory,
+    HolidayFactory,
+    PermissionFactory,
+    RoleFactory,
+    TicketFactory,
+    TicketStatusFactory,
+    UserFactory,
 )
 
 
@@ -30,6 +37,7 @@ def _make_admin_request(rf, method, path, data=None, user=None):
         request = rf.post(path, data=data or {})
     request.user = user
     from django.contrib.sessions.backends.db import SessionStore
+
     request.session = SessionStore()
     return request
 
@@ -66,12 +74,17 @@ class TestStatusesAdminViews:
         mock_render.assert_called_once()
 
     def test_create_post_creates_status(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/statuses/create/", data={
-            "label": "Awaiting Response",
-            "category": "pending",
-            "color": "#ff0000",
-            "position": "0",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/statuses/create/",
+            data={
+                "label": "Awaiting Response",
+                "category": "pending",
+                "color": "#ff0000",
+                "position": "0",
+            },
+        )
 
         response = admin.statuses_create(request)
         assert response.status_code == 302
@@ -79,12 +92,17 @@ class TestStatusesAdminViews:
 
     def test_create_sets_default_clears_others(self, rf):
         existing = TicketStatusFactory(category="open", is_default=True, slug="default-existing")
-        request = _make_admin_request(rf, "POST", "/admin/statuses/create/", data={
-            "label": "New Default",
-            "category": "open",
-            "color": "#00ff00",
-            "is_default": "true",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/statuses/create/",
+            data={
+                "label": "New Default",
+                "category": "open",
+                "color": "#00ff00",
+                "is_default": "true",
+            },
+        )
 
         admin.statuses_create(request)
 
@@ -95,11 +113,16 @@ class TestStatusesAdminViews:
 
     def test_edit_post_updates_status(self, rf):
         status = TicketStatusFactory(label="Old Label", slug="old-label")
-        request = _make_admin_request(rf, "POST", f"/admin/statuses/{status.pk}/edit/", data={
-            "label": "New Label",
-            "category": "pending",
-            "color": "#00ff00",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/statuses/{status.pk}/edit/",
+            data={
+                "label": "New Label",
+                "category": "pending",
+                "color": "#00ff00",
+            },
+        )
 
         response = admin.statuses_edit(request, status.pk)
         assert response.status_code == 302
@@ -146,14 +169,21 @@ class TestBusinessHoursAdminViews:
         assert "schedules" in props
 
     def test_create_post_with_holidays(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/business-hours/create/", data={
-            "name": "Test Schedule",
-            "timezone": "UTC",
-            "schedule": json.dumps({"monday": {"start": "09:00", "end": "17:00"}}),
-            "holidays": json.dumps([
-                {"name": "Christmas", "date": "2026-12-25", "recurring": True},
-            ]),
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/business-hours/create/",
+            data={
+                "name": "Test Schedule",
+                "timezone": "UTC",
+                "schedule": json.dumps({"monday": {"start": "09:00", "end": "17:00"}}),
+                "holidays": json.dumps(
+                    [
+                        {"name": "Christmas", "date": "2026-12-25", "recurring": True},
+                    ]
+                ),
+            },
+        )
 
         response = admin.business_hours_create(request)
         assert response.status_code == 302
@@ -167,14 +197,21 @@ class TestBusinessHoursAdminViews:
         sched = BusinessScheduleFactory()
         HolidayFactory(schedule=sched, name="Old Holiday")
 
-        request = _make_admin_request(rf, "POST", f"/admin/business-hours/{sched.pk}/edit/", data={
-            "name": sched.name,
-            "timezone": "UTC",
-            "schedule": json.dumps(sched.schedule),
-            "holidays": json.dumps([
-                {"name": "New Holiday", "date": "2026-07-04", "recurring": False},
-            ]),
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/business-hours/{sched.pk}/edit/",
+            data={
+                "name": sched.name,
+                "timezone": "UTC",
+                "schedule": json.dumps(sched.schedule),
+                "holidays": json.dumps(
+                    [
+                        {"name": "New Holiday", "date": "2026-07-04", "recurring": False},
+                    ]
+                ),
+            },
+        )
 
         response = admin.business_hours_edit(request, sched.pk)
         assert response.status_code == 302
@@ -192,12 +229,17 @@ class TestBusinessHoursAdminViews:
 
     def test_default_clears_others(self, rf):
         existing = BusinessScheduleFactory(is_default=True)
-        request = _make_admin_request(rf, "POST", "/admin/business-hours/create/", data={
-            "name": "New Default",
-            "timezone": "UTC",
-            "is_default": "true",
-            "schedule": json.dumps({"monday": {"start": "09:00", "end": "17:00"}}),
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/business-hours/create/",
+            data={
+                "name": "New Default",
+                "timezone": "UTC",
+                "is_default": "true",
+                "schedule": json.dumps({"monday": {"start": "09:00", "end": "17:00"}}),
+            },
+        )
 
         admin.business_hours_create(request)
 
@@ -229,11 +271,16 @@ class TestRolesAdminViews:
 
     def test_create_post_with_permissions(self, rf):
         perm = PermissionFactory(slug="test-perm-create")
-        request = _make_admin_request(rf, "POST", "/admin/roles/create/", data={
-            "name": "Support Lead",
-            "description": "Leads the support team",
-            "permissions": [str(perm.pk)],
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/roles/create/",
+            data={
+                "name": "Support Lead",
+                "description": "Leads the support team",
+                "permissions": [str(perm.pk)],
+            },
+        )
 
         response = admin.roles_create(request)
         assert response.status_code == 302
@@ -244,10 +291,15 @@ class TestRolesAdminViews:
 
     def test_edit_updates_role(self, rf):
         role = RoleFactory(name="Old Role", slug="old-role")
-        request = _make_admin_request(rf, "POST", f"/admin/roles/{role.pk}/edit/", data={
-            "name": "Updated Role",
-            "description": "Updated description",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/roles/{role.pk}/edit/",
+            data={
+                "name": "Updated Role",
+                "description": "Updated description",
+            },
+        )
 
         response = admin.roles_edit(request, role.pk)
         assert response.status_code == 302
@@ -277,10 +329,15 @@ class TestRolesAdminViews:
         p2 = PermissionFactory(slug="perm-b")
         role.permissions.add(p1)
 
-        request = _make_admin_request(rf, "POST", f"/admin/roles/{role.pk}/edit/", data={
-            "name": role.name,
-            "permissions": [str(p2.pk)],
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/roles/{role.pk}/edit/",
+            data={
+                "name": role.name,
+                "permissions": [str(p2.pk)],
+            },
+        )
 
         admin.roles_edit(request, role.pk)
 
@@ -328,6 +385,7 @@ class TestAuditLogsAdminViews:
         request = rf.get("/admin/audit-logs/", {"action": "created", "user_id": str(user.pk)})
         request.user = user
         from django.contrib.sessions.backends.db import SessionStore
+
         request.session = SessionStore()
 
         admin.audit_logs_index(request)

--- a/tests/integration/test_phase2_admin_views.py
+++ b/tests/integration/test_phase2_admin_views.py
@@ -1,19 +1,26 @@
 import json
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import patch, MagicMock
-
 from django.test import RequestFactory
 
 from escalated.models import (
-    CustomField, TicketLink, SideConversation, SideConversationReply,
-    Article, ArticleCategory, Ticket,
+    Article,
+    ArticleCategory,
+    CustomField,
+    SideConversation,
+    Ticket,
+    TicketLink,
 )
 from escalated.views import admin
 from tests.factories import (
-    UserFactory, TicketFactory, CustomFieldFactory,
-    SideConversationFactory, SideConversationReplyFactory,
-    ArticleCategoryFactory, ArticleFactory, TicketLinkFactory,
+    ArticleCategoryFactory,
+    ArticleFactory,
+    CustomFieldFactory,
+    SideConversationFactory,
+    TicketFactory,
+    TicketLinkFactory,
+    UserFactory,
 )
 
 
@@ -37,6 +44,7 @@ def _make_admin_request(rf, method, path, data=None, user=None, content_type=Non
         request = rf.post(path, data=data or {})
     request.user = user
     from django.contrib.sessions.backends.db import SessionStore
+
     request.session = SessionStore()
     return request
 
@@ -63,13 +71,18 @@ class TestCustomFieldsAdminViews:
         assert "custom_fields" in props
 
     def test_create_post_creates_field(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/custom-fields/create/", data={
-            "name": "Priority Level",
-            "type": "select",
-            "context": "ticket",
-            "options": json.dumps(["Low", "Medium", "High"]),
-            "position": "0",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/custom-fields/create/",
+            data={
+                "name": "Priority Level",
+                "type": "select",
+                "context": "ticket",
+                "options": json.dumps(["Low", "Medium", "High"]),
+                "position": "0",
+            },
+        )
 
         response = admin.custom_fields_create(request)
         assert response.status_code == 302
@@ -79,11 +92,16 @@ class TestCustomFieldsAdminViews:
 
     def test_edit_post_updates_field(self, rf):
         field = CustomFieldFactory(name="Old Name", slug="old-cf")
-        request = _make_admin_request(rf, "POST", f"/admin/custom-fields/{field.pk}/edit/", data={
-            "name": "New Name",
-            "type": "textarea",
-            "context": "user",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/custom-fields/{field.pk}/edit/",
+            data={
+                "name": "New Name",
+                "type": "textarea",
+                "context": "user",
+            },
+        )
 
         response = admin.custom_fields_edit(request, field.pk)
         assert response.status_code == 302
@@ -106,11 +124,15 @@ class TestCustomFieldsAdminViews:
         f2 = CustomFieldFactory(position=1, slug="cf-reorder2")
 
         request = _make_admin_request(
-            rf, "POST", "/admin/custom-fields/reorder/",
-            data={"positions": [
-                {"id": f1.pk, "position": 5},
-                {"id": f2.pk, "position": 3},
-            ]},
+            rf,
+            "POST",
+            "/admin/custom-fields/reorder/",
+            data={
+                "positions": [
+                    {"id": f1.pk, "position": 5},
+                    {"id": f2.pk, "position": 3},
+                ]
+            },
             content_type="application/json",
         )
 
@@ -155,7 +177,9 @@ class TestTicketLinksAdminViews:
         t2 = TicketFactory()
 
         request = _make_admin_request(
-            rf, "POST", f"/admin/tickets/{t1.pk}/links/store/",
+            rf,
+            "POST",
+            f"/admin/tickets/{t1.pk}/links/store/",
             data={
                 "target_reference": t2.reference,
                 "link_type": "related",
@@ -167,15 +191,15 @@ class TestTicketLinksAdminViews:
         assert response.status_code == 200
         data = json.loads(response.content)
         assert "link" in data
-        assert TicketLink.objects.filter(
-            parent_ticket=t1, child_ticket=t2
-        ).exists()
+        assert TicketLink.objects.filter(parent_ticket=t1, child_ticket=t2).exists()
 
     def test_store_prevents_self_linking(self, rf):
         t1 = TicketFactory()
 
         request = _make_admin_request(
-            rf, "POST", f"/admin/tickets/{t1.pk}/links/store/",
+            rf,
+            "POST",
+            f"/admin/tickets/{t1.pk}/links/store/",
             data={
                 "target_reference": t1.reference,
                 "link_type": "related",
@@ -192,7 +216,9 @@ class TestTicketLinksAdminViews:
         TicketLinkFactory(parent_ticket=t1, child_ticket=t2, link_type="related")
 
         request = _make_admin_request(
-            rf, "POST", f"/admin/tickets/{t1.pk}/links/store/",
+            rf,
+            "POST",
+            f"/admin/tickets/{t1.pk}/links/store/",
             data={
                 "target_reference": t2.reference,
                 "link_type": "related",
@@ -209,7 +235,9 @@ class TestTicketLinksAdminViews:
         link = TicketLinkFactory(parent_ticket=t1, child_ticket=t2)
 
         request = _make_admin_request(
-            rf, "POST", f"/admin/tickets/{t1.pk}/links/{link.pk}/delete/",
+            rf,
+            "POST",
+            f"/admin/tickets/{t1.pk}/links/{link.pk}/delete/",
         )
 
         response = admin.ticket_links_destroy(request, t1.pk, link.pk)
@@ -225,13 +253,14 @@ class TestTicketLinksAdminViews:
 @pytest.mark.django_db
 class TestTicketMergeAdminViews:
     def test_merge_search_returns_tickets(self, rf):
-        t1 = TicketFactory(subject="Login issue")
+        TicketFactory(subject="Login issue")
 
         request = _make_admin_request(rf, "GET", "/admin/tickets/merge-search/")
         request = rf.get("/admin/tickets/merge-search/", {"q": "Login"})
         user = UserFactory(username="merge_admin", is_staff=True, is_superuser=True)
         request.user = user
         from django.contrib.sessions.backends.db import SessionStore
+
         request.session = SessionStore()
 
         response = admin.ticket_merge_search(request)
@@ -253,7 +282,9 @@ class TestTicketMergeAdminViews:
         target = TicketFactory()
 
         request = _make_admin_request(
-            rf, "POST", f"/admin/tickets/{source.pk}/merge/",
+            rf,
+            "POST",
+            f"/admin/tickets/{source.pk}/merge/",
             data={"target_reference": target.reference},
             content_type="application/json",
         )
@@ -271,7 +302,9 @@ class TestTicketMergeAdminViews:
         source = TicketFactory()
 
         request = _make_admin_request(
-            rf, "POST", f"/admin/tickets/{source.pk}/merge/",
+            rf,
+            "POST",
+            f"/admin/tickets/{source.pk}/merge/",
             data={"target_reference": source.reference},
             content_type="application/json",
         )
@@ -303,7 +336,9 @@ class TestSideConversationsAdminViews:
         ticket = TicketFactory()
 
         request = _make_admin_request(
-            rf, "POST", f"/admin/tickets/{ticket.pk}/side-conversations/store/",
+            rf,
+            "POST",
+            f"/admin/tickets/{ticket.pk}/side-conversations/store/",
             data={
                 "subject": "Check with billing",
                 "body": "Need to verify the charge",
@@ -325,7 +360,9 @@ class TestSideConversationsAdminViews:
         ticket = TicketFactory()
 
         request = _make_admin_request(
-            rf, "POST", f"/admin/tickets/{ticket.pk}/side-conversations/store/",
+            rf,
+            "POST",
+            f"/admin/tickets/{ticket.pk}/side-conversations/store/",
             data={"body": "Missing subject"},
             content_type="application/json",
         )
@@ -338,7 +375,8 @@ class TestSideConversationsAdminViews:
         sc = SideConversationFactory(ticket=ticket)
 
         request = _make_admin_request(
-            rf, "POST",
+            rf,
+            "POST",
             f"/admin/tickets/{ticket.pk}/side-conversations/{sc.pk}/reply/",
             data={"body": "Here is my reply"},
             content_type="application/json",
@@ -355,7 +393,8 @@ class TestSideConversationsAdminViews:
         sc = SideConversationFactory(ticket=ticket)
 
         request = _make_admin_request(
-            rf, "POST",
+            rf,
+            "POST",
             f"/admin/tickets/{ticket.pk}/side-conversations/{sc.pk}/reply/",
             data={"body": ""},
             content_type="application/json",
@@ -369,7 +408,8 @@ class TestSideConversationsAdminViews:
         sc = SideConversationFactory(ticket=ticket, status="open")
 
         request = _make_admin_request(
-            rf, "POST",
+            rf,
+            "POST",
             f"/admin/tickets/{ticket.pk}/side-conversations/{sc.pk}/close/",
         )
 
@@ -405,23 +445,33 @@ class TestArticlesAdminViews:
 
     def test_create_post_creates_article(self, rf):
         cat = ArticleCategoryFactory(slug="art-create-cat")
-        request = _make_admin_request(rf, "POST", "/admin/kb/articles/create/", data={
-            "title": "Getting Started Guide",
-            "body": "Welcome to Escalated...",
-            "status": "draft",
-            "category_id": str(cat.pk),
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/kb/articles/create/",
+            data={
+                "title": "Getting Started Guide",
+                "body": "Welcome to Escalated...",
+                "status": "draft",
+                "category_id": str(cat.pk),
+            },
+        )
 
         response = admin.articles_create(request)
         assert response.status_code == 302
         assert Article.objects.filter(title="Getting Started Guide").exists()
 
     def test_create_published_sets_published_at(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/kb/articles/create/", data={
-            "title": "Published Article",
-            "body": "Content here",
-            "status": "published",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/kb/articles/create/",
+            data={
+                "title": "Published Article",
+                "body": "Content here",
+                "status": "published",
+            },
+        )
 
         admin.articles_create(request)
         article = Article.objects.get(title="Published Article")
@@ -429,11 +479,16 @@ class TestArticlesAdminViews:
 
     def test_edit_post_updates_article(self, rf):
         article = ArticleFactory(title="Old Title", slug="art-edit-old")
-        request = _make_admin_request(rf, "POST", f"/admin/kb/articles/{article.pk}/edit/", data={
-            "title": "New Title",
-            "body": "Updated body",
-            "status": "draft",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/kb/articles/{article.pk}/edit/",
+            data={
+                "title": "New Title",
+                "body": "Updated body",
+                "status": "draft",
+            },
+        )
 
         response = admin.articles_edit(request, article.pk)
         assert response.status_code == 302
@@ -480,29 +535,44 @@ class TestKBCategoriesAdminViews:
         assert "categories" in props
 
     def test_store_creates_category(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/kb/categories/store/", data={
-            "name": "Troubleshooting",
-            "position": "0",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/kb/categories/store/",
+            data={
+                "name": "Troubleshooting",
+                "position": "0",
+            },
+        )
 
         response = admin.kb_categories_store(request)
         assert response.status_code == 302
         assert ArticleCategory.objects.filter(name="Troubleshooting").exists()
 
     def test_store_requires_name(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/kb/categories/store/", data={
-            "name": "",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/kb/categories/store/",
+            data={
+                "name": "",
+            },
+        )
 
         response = admin.kb_categories_store(request)
         assert response.status_code == 400
 
     def test_update_updates_category(self, rf):
         cat = ArticleCategoryFactory(name="Old Name", slug="kbcat-edit-old")
-        request = _make_admin_request(rf, "POST", f"/admin/kb/categories/{cat.pk}/update/", data={
-            "name": "New Name",
-            "description": "Updated desc",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/kb/categories/{cat.pk}/update/",
+            data={
+                "name": "New Name",
+                "description": "Updated desc",
+            },
+        )
 
         response = admin.kb_categories_update(request, cat.pk)
         assert response.status_code == 302

--- a/tests/integration/test_phase3_5_admin_views.py
+++ b/tests/integration/test_phase3_5_admin_views.py
@@ -1,20 +1,28 @@
 import json
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import patch, MagicMock
-
 from django.test import RequestFactory
 
 from escalated.models import (
-    Skill, AgentCapacity, Webhook, WebhookDelivery,
-    Automation, TwoFactor, CustomObject, CustomObjectRecord,
+    Automation,
+    CustomObject,
+    CustomObjectRecord,
+    Skill,
+    TwoFactor,
+    Webhook,
 )
 from escalated.views import admin
 from tests.factories import (
-    UserFactory, SkillFactory, AgentCapacityFactory,
-    WebhookFactory, WebhookDeliveryFactory,
-    AutomationFactory, TwoFactorFactory,
-    CustomObjectFactory, CustomObjectRecordFactory,
+    AgentCapacityFactory,
+    AutomationFactory,
+    CustomObjectFactory,
+    CustomObjectRecordFactory,
+    SkillFactory,
+    TwoFactorFactory,
+    UserFactory,
+    WebhookDeliveryFactory,
+    WebhookFactory,
 )
 
 
@@ -38,6 +46,7 @@ def _make_admin_request(rf, method, path, data=None, user=None, content_type=Non
         request = rf.post(path, data=data or {})
     request.user = user
     from django.contrib.sessions.backends.db import SessionStore
+
     request.session = SessionStore()
     return request
 
@@ -64,18 +73,28 @@ class TestSkillsAdminViews:
         assert "skills" in props
 
     def test_create_post(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/skills/create/", data={
-            "name": "Networking",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/skills/create/",
+            data={
+                "name": "Networking",
+            },
+        )
         response = admin.skills_create(request)
         assert response.status_code == 302
         assert Skill.objects.filter(name="Networking").exists()
 
     def test_edit_post(self, rf):
         skill = SkillFactory(name="Old Skill", slug="old-skill")
-        request = _make_admin_request(rf, "POST", f"/admin/skills/{skill.pk}/edit/", data={
-            "name": "New Skill",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/skills/{skill.pk}/edit/",
+            data={
+                "name": "New Skill",
+            },
+        )
         response = admin.skills_edit(request, skill.pk)
         assert response.status_code == 302
         skill.refresh_from_db()
@@ -105,14 +124,21 @@ class TestCapacityAdminViews:
         admin.capacity_index(request)
 
         mock_render.assert_called_once()
-        props = mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        props = (
+            mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        )
         assert "capacities" in props
 
     def test_update(self, rf):
         cap = AgentCapacityFactory(max_concurrent=5)
-        request = _make_admin_request(rf, "POST", f"/admin/capacity/{cap.pk}/update/", data={
-            "max_concurrent": "20",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/capacity/{cap.pk}/update/",
+            data={
+                "max_concurrent": "20",
+            },
+        )
         response = admin.capacity_update(request, cap.pk)
         assert response.status_code == 302
         cap.refresh_from_db()
@@ -135,27 +161,39 @@ class TestWebhooksAdminViews:
         admin.webhooks_index(request)
 
         mock_render.assert_called_once()
-        props = mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        props = (
+            mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        )
         assert "webhooks" in props
         assert "available_events" in props
 
     def test_create_post(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/webhooks/create/", data={
-            "url": "https://example.com/hook",
-            "events": json.dumps(["ticket.created"]),
-            "active": "true",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/webhooks/create/",
+            data={
+                "url": "https://example.com/hook",
+                "events": json.dumps(["ticket.created"]),
+                "active": "true",
+            },
+        )
         response = admin.webhooks_create(request)
         assert response.status_code == 302
         assert Webhook.objects.filter(url="https://example.com/hook").exists()
 
     def test_edit_post(self, rf):
         wh = WebhookFactory(url="https://old.com/hook")
-        request = _make_admin_request(rf, "POST", f"/admin/webhooks/{wh.pk}/edit/", data={
-            "url": "https://new.com/hook",
-            "events": json.dumps(["ticket.updated"]),
-            "active": "true",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/webhooks/{wh.pk}/edit/",
+            data={
+                "url": "https://new.com/hook",
+                "events": json.dumps(["ticket.updated"]),
+                "active": "true",
+            },
+        )
         response = admin.webhooks_edit(request, wh.pk)
         assert response.status_code == 302
         wh.refresh_from_db()
@@ -178,7 +216,9 @@ class TestWebhooksAdminViews:
         admin.webhooks_deliveries(request, wh.pk)
 
         mock_render.assert_called_once()
-        props = mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        props = (
+            mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        )
         assert "webhook" in props
         assert "deliveries" in props
         assert "pagination" in props
@@ -200,28 +240,40 @@ class TestAutomationsAdminViews:
         admin.automations_index(request)
 
         mock_render.assert_called_once()
-        props = mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        props = (
+            mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        )
         assert "automations" in props
 
     def test_create_post(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/automations/create/", data={
-            "name": "Auto-close",
-            "conditions": json.dumps([{"field": "status", "value": "open"}]),
-            "actions": json.dumps([{"type": "change_status", "value": "closed"}]),
-            "active": "true",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/automations/create/",
+            data={
+                "name": "Auto-close",
+                "conditions": json.dumps([{"field": "status", "value": "open"}]),
+                "actions": json.dumps([{"type": "change_status", "value": "closed"}]),
+                "active": "true",
+            },
+        )
         response = admin.automations_create(request)
         assert response.status_code == 302
         assert Automation.objects.filter(name="Auto-close").exists()
 
     def test_edit_post(self, rf):
         auto = AutomationFactory(name="Old Name")
-        request = _make_admin_request(rf, "POST", f"/admin/automations/{auto.pk}/edit/", data={
-            "name": "New Name",
-            "conditions": json.dumps(auto.conditions),
-            "actions": json.dumps(auto.actions),
-            "active": "true",
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/automations/{auto.pk}/edit/",
+            data={
+                "name": "New Name",
+                "conditions": json.dumps(auto.conditions),
+                "actions": json.dumps(auto.actions),
+                "active": "true",
+            },
+        )
         response = admin.automations_edit(request, auto.pk)
         assert response.status_code == 302
         auto.refresh_from_db()
@@ -261,7 +313,9 @@ class TestTwoFactorAdminViews:
 
         # Try invalid code
         confirm_request = _make_admin_request(
-            rf, "POST", "/admin/settings/two-factor/confirm/",
+            rf,
+            "POST",
+            "/admin/settings/two-factor/confirm/",
             data={"code": "000000"},
             user=user,
             content_type="application/json",
@@ -295,25 +349,37 @@ class TestCustomObjectsAdminViews:
         admin.custom_objects_index(request)
 
         mock_render.assert_called_once()
-        props = mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        props = (
+            mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        )
         assert "custom_objects" in props
 
     def test_create_post(self, rf):
-        request = _make_admin_request(rf, "POST", "/admin/custom-objects/create/", data={
-            "name": "Company",
-            "slug": "company",
-            "fields_schema": json.dumps([{"name": "name", "type": "text"}]),
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            "/admin/custom-objects/create/",
+            data={
+                "name": "Company",
+                "slug": "company",
+                "fields_schema": json.dumps([{"name": "name", "type": "text"}]),
+            },
+        )
         response = admin.custom_objects_create(request)
         assert response.status_code == 302
         assert CustomObject.objects.filter(name="Company").exists()
 
     def test_edit_post(self, rf):
         obj = CustomObjectFactory(name="Old Obj", slug="old-obj")
-        request = _make_admin_request(rf, "POST", f"/admin/custom-objects/{obj.pk}/edit/", data={
-            "name": "New Obj",
-            "fields_schema": json.dumps([{"name": "updated", "type": "text"}]),
-        })
+        request = _make_admin_request(
+            rf,
+            "POST",
+            f"/admin/custom-objects/{obj.pk}/edit/",
+            data={
+                "name": "New Obj",
+                "fields_schema": json.dumps([{"name": "updated", "type": "text"}]),
+            },
+        )
         response = admin.custom_objects_edit(request, obj.pk)
         assert response.status_code == 302
         obj.refresh_from_db()
@@ -336,14 +402,18 @@ class TestCustomObjectsAdminViews:
         admin.custom_object_records(request, obj.pk)
 
         mock_render.assert_called_once()
-        props = mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        props = (
+            mock_render.call_args[1]["props"] if "props" in mock_render.call_args[1] else mock_render.call_args[0][2]
+        )
         assert "records" in props
         assert "custom_object" in props
 
     def test_records_store(self, rf):
         obj = CustomObjectFactory()
         request = _make_admin_request(
-            rf, "POST", f"/admin/custom-objects/{obj.pk}/records/store/",
+            rf,
+            "POST",
+            f"/admin/custom-objects/{obj.pk}/records/store/",
             data={"data": {"field1": "value1"}},
             content_type="application/json",
         )
@@ -355,7 +425,8 @@ class TestCustomObjectsAdminViews:
         obj = CustomObjectFactory()
         record = CustomObjectRecordFactory(object=obj, data={"field1": "old"})
         request = _make_admin_request(
-            rf, "POST",
+            rf,
+            "POST",
             f"/admin/custom-objects/{obj.pk}/records/{record.pk}/update/",
             data={"data": {"field1": "new"}},
             content_type="application/json",
@@ -369,7 +440,8 @@ class TestCustomObjectsAdminViews:
         obj = CustomObjectFactory()
         record = CustomObjectRecordFactory(object=obj)
         request = _make_admin_request(
-            rf, "POST",
+            rf,
+            "POST",
             f"/admin/custom-objects/{obj.pk}/records/{record.pk}/delete/",
         )
         response = admin.custom_object_records_delete(request, obj.pk, record.pk)

--- a/tests/integration/test_translations.py
+++ b/tests/integration/test_translations.py
@@ -1,12 +1,10 @@
 import os
+
 import pytest
 from django.utils import translation
 
-
 LOCALES = ["en", "de", "es", "fr"]
-LOCALE_DIR = os.path.join(
-    os.path.dirname(__file__), "..", "..", "escalated", "locale"
-)
+LOCALE_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "escalated", "locale")
 
 
 class TestTranslations:
@@ -29,7 +27,7 @@ class TestTranslations:
         if locale == "en":
             return
         po_path = os.path.join(LOCALE_DIR, locale, "LC_MESSAGES", "django.po")
-        with open(po_path, "r", encoding="utf-8") as f:
+        with open(po_path, encoding="utf-8") as f:
             content = f.read()
         lines = content.split("\n")
         in_header = True

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -1,17 +1,15 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-
 from django.test import RequestFactory
-from django.contrib.auth.models import AnonymousUser
 
-from escalated.models import Ticket, Department, Tag
-from escalated.views import customer, agent, admin
+from escalated.models import Department, Tag, Ticket
+from escalated.views import admin, agent, customer
 from tests.factories import (
-    UserFactory,
-    TicketFactory,
     DepartmentFactory,
     TagFactory,
-    SlaPolicyFactory,
+    TicketFactory,
+    UserFactory,
 )
 
 
@@ -23,6 +21,7 @@ def rf():
 def _attach_session(request):
     """Attach a mock session to the request for middleware compat."""
     from django.contrib.sessions.backends.db import SessionStore
+
     request.session = SessionStore()
 
 
@@ -30,12 +29,13 @@ def _attach_session(request):
 # Customer views
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestCustomerViews:
     @patch("escalated.views.customer.render_page")
     def test_ticket_list_returns_user_tickets(self, mock_render, rf):
         user = UserFactory(username="cust_list")
-        ticket = TicketFactory(requester=user)
+        TicketFactory(requester=user)
 
         request = rf.get("/tickets/")
         request.user = user
@@ -106,11 +106,14 @@ class TestCustomerViews:
     def test_ticket_store_creates_ticket(self, rf):
         user = UserFactory(username="cust_store")
 
-        request = rf.post("/tickets/store/", {
-            "subject": "New Issue",
-            "description": "I need help with something",
-            "priority": "high",
-        })
+        request = rf.post(
+            "/tickets/store/",
+            {
+                "subject": "New Issue",
+                "description": "I need help with something",
+                "priority": "high",
+            },
+        )
         request.user = user
         _attach_session(request)
 
@@ -136,6 +139,7 @@ class TestCustomerViews:
 # ---------------------------------------------------------------------------
 # Agent views
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.django_db
 class TestAgentViews:
@@ -192,9 +196,12 @@ class TestAgentViews:
 
         ticket = TicketFactory(status=Ticket.Status.OPEN)
 
-        request = rf.post(f"/agent/tickets/{ticket.pk}/assign/", {
-            "agent_id": target_agent.pk,
-        })
+        request = rf.post(
+            f"/agent/tickets/{ticket.pk}/assign/",
+            {
+                "agent_id": target_agent.pk,
+            },
+        )
         request.user = agent_user
         _attach_session(request)
 
@@ -210,9 +217,12 @@ class TestAgentViews:
         department.agents.add(agent_user)
         ticket = TicketFactory(status=Ticket.Status.OPEN)
 
-        request = rf.post(f"/agent/tickets/{ticket.pk}/status/", {
-            "status": "in_progress",
-        })
+        request = rf.post(
+            f"/agent/tickets/{ticket.pk}/status/",
+            {
+                "status": "in_progress",
+            },
+        )
         request.user = agent_user
         _attach_session(request)
 
@@ -228,9 +238,12 @@ class TestAgentViews:
         department.agents.add(agent_user)
         ticket = TicketFactory(priority=Ticket.Priority.MEDIUM)
 
-        request = rf.post(f"/agent/tickets/{ticket.pk}/priority/", {
-            "priority": "urgent",
-        })
+        request = rf.post(
+            f"/agent/tickets/{ticket.pk}/priority/",
+            {
+                "priority": "urgent",
+            },
+        )
         request.user = agent_user
         _attach_session(request)
 
@@ -245,13 +258,12 @@ class TestAgentViews:
 # Admin views
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 class TestAdminViews:
     @patch("escalated.views.admin.render_page")
     def test_reports_returns_stats(self, mock_render, rf):
-        admin_user = UserFactory(
-            username="admin_reports", is_staff=True, is_superuser=True
-        )
+        admin_user = UserFactory(username="admin_reports", is_staff=True, is_superuser=True)
 
         request = rf.get("/admin/reports/")
         request.user = admin_user
@@ -275,16 +287,17 @@ class TestAdminViews:
         assert response.status_code == 403
 
     def test_departments_create(self, rf):
-        admin_user = UserFactory(
-            username="admin_dept", is_staff=True, is_superuser=True
-        )
+        admin_user = UserFactory(username="admin_dept", is_staff=True, is_superuser=True)
 
-        request = rf.post("/admin/departments/create/", {
-            "name": "Engineering",
-            "slug": "engineering",
-            "description": "Engineering team",
-            "is_active": "true",
-        })
+        request = rf.post(
+            "/admin/departments/create/",
+            {
+                "name": "Engineering",
+                "slug": "engineering",
+                "description": "Engineering team",
+                "is_active": "true",
+            },
+        )
         request.user = admin_user
         _attach_session(request)
 
@@ -293,15 +306,16 @@ class TestAdminViews:
         assert Department.objects.filter(slug="engineering").exists()
 
     def test_tags_create(self, rf):
-        admin_user = UserFactory(
-            username="admin_tag", is_staff=True, is_superuser=True
-        )
+        admin_user = UserFactory(username="admin_tag", is_staff=True, is_superuser=True)
 
-        request = rf.post("/admin/tags/create/", {
-            "name": "Bug",
-            "slug": "bug",
-            "color": "#ef4444",
-        })
+        request = rf.post(
+            "/admin/tags/create/",
+            {
+                "name": "Bug",
+                "slug": "bug",
+                "color": "#ef4444",
+            },
+        )
         request.user = admin_user
         _attach_session(request)
 
@@ -310,9 +324,7 @@ class TestAdminViews:
         assert Tag.objects.filter(slug="bug").exists()
 
     def test_tags_delete(self, rf):
-        admin_user = UserFactory(
-            username="admin_tag_del", is_staff=True, is_superuser=True
-        )
+        admin_user = UserFactory(username="admin_tag_del", is_staff=True, is_superuser=True)
         tag = TagFactory(name="ToDelete", slug="to-delete")
 
         request = rf.post(f"/admin/tags/{tag.pk}/delete/")

--- a/tests/unit/test_api_middleware.py
+++ b/tests/unit/test_api_middleware.py
@@ -10,9 +10,9 @@ import pytest
 from django.test import RequestFactory
 from django.utils import timezone
 
-from escalated.api_middleware import AuthenticateApiToken, ApiRateLimit
+from escalated.api_middleware import ApiRateLimit, AuthenticateApiToken
 from escalated.models import ApiToken
-from tests.factories import UserFactory, DepartmentFactory, ApiTokenFactory
+from tests.factories import ApiTokenFactory, DepartmentFactory, UserFactory
 
 
 @pytest.fixture
@@ -74,7 +74,8 @@ class TestAuthenticateApiToken:
         department.agents.add(user)
 
         result = ApiToken.create_token(
-            user, "Expired",
+            user,
+            "Expired",
             expires_at=timezone.now() - timedelta(days=1),
         )
 
@@ -170,6 +171,7 @@ class TestApiRateLimit:
         token = ApiTokenFactory(user=user)
 
         from django.core.cache import cache
+
         cache.clear()
 
         # Set cache to already have 2 hits
@@ -191,6 +193,7 @@ class TestApiRateLimit:
         token = ApiTokenFactory(user=user)
 
         from django.core.cache import cache
+
         cache.clear()
 
         request = rf.get("/api/test/")
@@ -200,7 +203,7 @@ class TestApiRateLimit:
         mock_response.__setitem__ = MagicMock()
         mock_response.__getitem__ = MagicMock()
 
-        result = rate.process_response(request, mock_response)
+        rate.process_response(request, mock_response)
         # Should have set X-RateLimit-Limit and X-RateLimit-Remaining
         calls = {c[0][0] for c in mock_response.__setitem__.call_args_list}
         assert "X-RateLimit-Limit" in calls

--- a/tests/unit/test_api_token_model.py
+++ b/tests/unit/test_api_token_model.py
@@ -3,14 +3,13 @@ Unit tests for the ApiToken model.
 """
 
 import hashlib
-import secrets
 from datetime import timedelta
 
 import pytest
 from django.utils import timezone
 
 from escalated.models import ApiToken
-from tests.factories import UserFactory, ApiTokenFactory
+from tests.factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -109,7 +108,8 @@ class TestApiTokenModel:
         user = UserFactory(username="qs_active")
         result_active = ApiToken.create_token(user, "Active")
         result_expired = ApiToken.create_token(
-            user, "Expired",
+            user,
+            "Expired",
             expires_at=timezone.now() - timedelta(days=1),
         )
 
@@ -121,7 +121,8 @@ class TestApiTokenModel:
         user = UserFactory(username="qs_expired")
         result_active = ApiToken.create_token(user, "Active")
         result_expired = ApiToken.create_token(
-            user, "Expired",
+            user,
+            "Expired",
             expires_at=timezone.now() - timedelta(days=1),
         )
 

--- a/tests/unit/test_auditable_mixin.py
+++ b/tests/unit/test_auditable_mixin.py
@@ -1,19 +1,17 @@
-import pytest
-
 from escalated.mixins import AuditableMixin
 
 
 class TestAuditableMixin:
     def test_mixin_has_expected_methods(self):
-        assert hasattr(AuditableMixin, 'save')
-        assert hasattr(AuditableMixin, 'delete')
+        assert hasattr(AuditableMixin, "save")
+        assert hasattr(AuditableMixin, "delete")
 
     def test_mixin_audit_exclude_attribute(self):
-        assert hasattr(AuditableMixin, 'audit_exclude')
-        assert 'created_at' in AuditableMixin.audit_exclude
-        assert 'updated_at' in AuditableMixin.audit_exclude
+        assert hasattr(AuditableMixin, "audit_exclude")
+        assert "created_at" in AuditableMixin.audit_exclude
+        assert "updated_at" in AuditableMixin.audit_exclude
 
     def test_mixin_has_request_getter(self):
-        assert hasattr(AuditableMixin, '_get_current_request')
+        assert hasattr(AuditableMixin, "_get_current_request")
         # Should return None when no request thread-local is set
         assert AuditableMixin._get_current_request() is None

--- a/tests/unit/test_business_hours_service.py
+++ b/tests/unit/test_business_hours_service.py
@@ -1,6 +1,7 @@
-import pytest
-from datetime import datetime, date
+from datetime import date, datetime
 from zoneinfo import ZoneInfo
+
+import pytest
 
 from escalated.services.business_hours_service import BusinessHoursCalculator
 from tests.factories import BusinessScheduleFactory, HolidayFactory
@@ -38,8 +39,10 @@ class TestBusinessHoursCalculator:
     def test_is_not_within_business_hours_holiday(self):
         schedule = BusinessScheduleFactory(timezone="UTC")
         HolidayFactory(
-            schedule=schedule, name="Test Holiday",
-            date=date(2026, 3, 2), recurring=False,
+            schedule=schedule,
+            name="Test Holiday",
+            date=date(2026, 3, 2),
+            recurring=False,
         )
         dt = datetime(2026, 3, 2, 10, 0, tzinfo=ZoneInfo("UTC"))
         assert self.calculator.is_within_business_hours(dt, schedule) is False
@@ -79,8 +82,10 @@ class TestBusinessHoursCalculator:
     def test_recurring_holiday_matches_any_year(self):
         schedule = BusinessScheduleFactory(timezone="UTC")
         HolidayFactory(
-            schedule=schedule, name="Christmas",
-            date=date(2025, 12, 25), recurring=True,
+            schedule=schedule,
+            name="Christmas",
+            date=date(2025, 12, 25),
+            recurring=True,
         )
         # Christmas 2026 should also be a holiday
         dt = datetime(2026, 12, 25, 10, 0, tzinfo=ZoneInfo("UTC"))
@@ -89,8 +94,10 @@ class TestBusinessHoursCalculator:
     def test_non_recurring_holiday_only_matches_exact_date(self):
         schedule = BusinessScheduleFactory(timezone="UTC")
         HolidayFactory(
-            schedule=schedule, name="Company Event",
-            date=date(2026, 3, 2), recurring=False,
+            schedule=schedule,
+            name="Company Event",
+            date=date(2026, 3, 2),
+            recurring=False,
         )
         # Same date = holiday
         dt1 = datetime(2026, 3, 2, 10, 0, tzinfo=ZoneInfo("UTC"))
@@ -99,8 +106,10 @@ class TestBusinessHoursCalculator:
         # Different year = not a holiday (need fresh schedule to clear cache)
         schedule2 = BusinessScheduleFactory(timezone="UTC")
         HolidayFactory(
-            schedule=schedule2, name="Company Event",
-            date=date(2026, 3, 2), recurring=False,
+            schedule=schedule2,
+            name="Company Event",
+            date=date(2026, 3, 2),
+            recurring=False,
         )
         dt2 = datetime(2027, 3, 2, 10, 0, tzinfo=ZoneInfo("UTC"))
         assert self.calculator.is_within_business_hours(dt2, schedule2) is True

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,16 +1,16 @@
-import pytest
 from datetime import timedelta
 
+import pytest
 from django.utils import timezone
 
-from escalated.models import Ticket, Reply, SlaPolicy, Tag, Department
+from escalated.models import Reply, Ticket
 from tests.factories import (
-    UserFactory,
-    TicketFactory,
+    DepartmentFactory,
     ReplyFactory,
     SlaPolicyFactory,
     TagFactory,
-    DepartmentFactory,
+    TicketFactory,
+    UserFactory,
 )
 
 

--- a/tests/unit/test_phase1_models.py
+++ b/tests/unit/test_phase1_models.py
@@ -1,12 +1,21 @@
-import pytest
 from datetime import date
 
+import pytest
+
 from escalated.models import (
-    AuditLog, TicketStatus, BusinessSchedule, Holiday, Role, Permission,
+    AuditLog,
+    Holiday,
+    Permission,
+    TicketStatus,
 )
 from tests.factories import (
-    UserFactory, TicketStatusFactory, BusinessScheduleFactory,
-    HolidayFactory, PermissionFactory, RoleFactory, AuditLogFactory,
+    AuditLogFactory,
+    BusinessScheduleFactory,
+    HolidayFactory,
+    PermissionFactory,
+    RoleFactory,
+    TicketStatusFactory,
+    UserFactory,
 )
 
 

--- a/tests/unit/test_phase2_models.py
+++ b/tests/unit/test_phase2_models.py
@@ -2,15 +2,25 @@ import pytest
 from django.db import IntegrityError
 
 from escalated.models import (
-    CustomField, CustomFieldValue, TicketLink, SideConversation,
-    SideConversationReply, ArticleCategory, Article, Ticket,
+    Article,
+    ArticleCategory,
+    CustomField,
+    CustomFieldValue,
+    SideConversation,
+    SideConversationReply,
+    Ticket,
+    TicketLink,
 )
 from tests.factories import (
-    UserFactory, TicketFactory, CustomFieldFactory, CustomFieldValueFactory,
-    TicketLinkFactory, SideConversationFactory, SideConversationReplyFactory,
-    ArticleCategoryFactory, ArticleFactory,
+    ArticleCategoryFactory,
+    ArticleFactory,
+    CustomFieldFactory,
+    CustomFieldValueFactory,
+    SideConversationFactory,
+    SideConversationReplyFactory,
+    TicketFactory,
+    TicketLinkFactory,
 )
-
 
 # ---------------------------------------------------------------------------
 # Custom Fields
@@ -69,6 +79,7 @@ class TestCustomFieldValueModel:
     def test_str_representation(self):
         field = CustomFieldFactory(name="Region")
         from django.contrib.contenttypes.models import ContentType
+
         ct = ContentType.objects.get_for_model(Ticket)
         val = CustomFieldValueFactory(
             custom_field=field,
@@ -82,6 +93,7 @@ class TestCustomFieldValueModel:
     def test_cascade_delete_on_field(self):
         field = CustomFieldFactory()
         from django.contrib.contenttypes.models import ContentType
+
         ct = ContentType.objects.get_for_model(Ticket)
         CustomFieldValueFactory(
             custom_field=field,
@@ -193,9 +205,7 @@ class TestSideConversationReplyModel:
         SideConversationReplyFactory(side_conversation=sc)
         sc_pk = sc.pk
         sc.delete()
-        assert not SideConversationReply.objects.filter(
-            side_conversation_id=sc_pk
-        ).exists()
+        assert not SideConversationReply.objects.filter(side_conversation_id=sc_pk).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_phase3_5_models.py
+++ b/tests/unit/test_phase3_5_models.py
@@ -2,17 +2,25 @@ import pytest
 from django.db import IntegrityError
 
 from escalated.models import (
-    AgentProfile, Skill, AgentSkill, AgentCapacity,
-    Webhook, WebhookDelivery, Automation,
-    TwoFactor, CustomObject, CustomObjectRecord,
+    AgentProfile,
+    AgentSkill,
+    Automation,
+    CustomObjectRecord,
+    Webhook,
+    WebhookDelivery,
 )
 from tests.factories import (
-    UserFactory, AgentProfileFactory, SkillFactory,
-    AgentCapacityFactory, WebhookFactory, WebhookDeliveryFactory,
-    AutomationFactory, TwoFactorFactory, CustomObjectFactory,
+    AgentCapacityFactory,
+    AgentProfileFactory,
+    AutomationFactory,
+    CustomObjectFactory,
     CustomObjectRecordFactory,
+    SkillFactory,
+    TwoFactorFactory,
+    UserFactory,
+    WebhookDeliveryFactory,
+    WebhookFactory,
 )
-
 
 # ---------------------------------------------------------------------------
 # Phase 3: Agent & Routing
@@ -143,7 +151,7 @@ class TestWebhookModel:
     def test_deliveries_relationship(self):
         wh = WebhookFactory()
         d1 = WebhookDeliveryFactory(webhook=wh)
-        d2 = WebhookDeliveryFactory(webhook=wh)
+        WebhookDeliveryFactory(webhook=wh)
 
         assert wh.deliveries.count() == 2
         assert d1 in wh.deliveries.all()
@@ -224,6 +232,7 @@ class TestTwoFactorModel:
 
     def test_is_confirmed_true(self):
         from django.utils import timezone
+
         tf = TwoFactorFactory(confirmed_at=timezone.now())
         assert tf.is_confirmed() is True
 
@@ -257,7 +266,7 @@ class TestCustomObjectModel:
     def test_records_relationship(self):
         obj = CustomObjectFactory()
         r1 = CustomObjectRecordFactory(object=obj)
-        r2 = CustomObjectRecordFactory(object=obj)
+        CustomObjectRecordFactory(object=obj)
 
         assert obj.records.count() == 2
         assert r1 in obj.records.all()

--- a/tests/unit/test_phase3_5_services.py
+++ b/tests/unit/test_phase3_5_services.py
@@ -1,16 +1,17 @@
 import pytest
-from unittest.mock import patch, MagicMock
 
-from escalated.services.capacity_service import CapacityService
-from escalated.services.two_factor_service import TwoFactorService
-from escalated.services.sso_service import SsoService
+from escalated.models import AgentCapacity, Automation, Reply
 from escalated.services.automation_runner import AutomationRunner
-from escalated.models import AgentCapacity, Ticket, Reply, Tag, Automation
+from escalated.services.capacity_service import CapacityService
+from escalated.services.sso_service import SsoService
+from escalated.services.two_factor_service import TwoFactorService
 from tests.factories import (
-    UserFactory, TicketFactory, TagFactory, AgentCapacityFactory,
-    AutomationFactory, SkillFactory,
+    AgentCapacityFactory,
+    AutomationFactory,
+    TagFactory,
+    TicketFactory,
+    UserFactory,
 )
-
 
 # ---------------------------------------------------------------------------
 # Capacity Service
@@ -92,6 +93,7 @@ class TestTwoFactorService:
         secret = self.service.generate_secret()
         # Generate a code for the current time step
         import time
+
         time_step = int(time.time()) // 30
         code = self.service._generate_totp(secret, time_step)
         assert self.service.verify(secret, code) is True

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1,16 +1,15 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
 
-from escalated.policies import check_policy, PolicyDenied
-from escalated.policies.ticket_policy import TicketPolicy
-from escalated.policies.department_policy import DepartmentPolicy
-from escalated.policies.tag_policy import TagPolicy
+from escalated.policies.article_policy import ArticlePolicy
 from escalated.policies.canned_response_policy import CannedResponsePolicy
-from escalated.policies.sla_policy_policy import SlaPolicyPolicy
+from escalated.policies.department_policy import DepartmentPolicy
 from escalated.policies.escalation_rule_policy import EscalationRulePolicy
 from escalated.policies.macro_policy import MacroPolicy
-from escalated.policies.article_policy import ArticlePolicy
-from tests.factories import UserFactory, DepartmentFactory, CannedResponseFactory, MacroFactory
+from escalated.policies.sla_policy_policy import SlaPolicyPolicy
+from escalated.policies.tag_policy import TagPolicy
+from escalated.policies.ticket_policy import TicketPolicy
+from tests.factories import CannedResponseFactory, DepartmentFactory, MacroFactory, UserFactory
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,19 +1,17 @@
-import pytest
 from datetime import timedelta
-from unittest.mock import patch
 
+import pytest
 from django.utils import timezone
 
-from escalated.models import Ticket, SlaPolicy, EscalationRule
-from escalated.services.sla_service import SlaService
+from escalated.models import EscalationRule, Ticket
 from escalated.services.escalation_service import EscalationService
+from escalated.services.sla_service import SlaService
 from escalated.services.ticket_service import TicketService
 from tests.factories import (
-    UserFactory,
-    TicketFactory,
-    SlaPolicyFactory,
-    DepartmentFactory,
     EscalationRuleFactory,
+    SlaPolicyFactory,
+    TicketFactory,
+    UserFactory,
 )
 
 
@@ -33,9 +31,7 @@ class TestSlaService:
 
         # Verify the deadline is approximately 8 hours from now
         expected_first_response = timezone.now() + timedelta(hours=8)
-        delta = abs(
-            (ticket.first_response_due_at - expected_first_response).total_seconds()
-        )
+        delta = abs((ticket.first_response_due_at - expected_first_response).total_seconds())
         assert delta < 5  # Within 5 seconds
 
     def test_apply_sla_deadlines_no_policy(self):
@@ -122,7 +118,7 @@ class TestSlaService:
 
     def test_get_default_policy(self):
         SlaPolicyFactory(is_default=False, name="Non-default")
-        default = SlaPolicyFactory(is_default=True, name="Default")
+        SlaPolicyFactory(is_default=True, name="Default")
 
         result = SlaService.get_default_policy()
         assert result is not None
@@ -156,7 +152,7 @@ class TestSlaService:
 @pytest.mark.django_db
 class TestEscalationService:
     def test_evaluate_sla_breach_rule(self):
-        rule = EscalationRuleFactory(
+        EscalationRuleFactory(
             trigger_type=EscalationRule.TriggerType.SLA_BREACH,
             conditions={},
             actions={"escalate": True},
@@ -173,7 +169,7 @@ class TestEscalationService:
         assert ticket.status == Ticket.Status.ESCALATED
 
     def test_evaluate_no_response_rule(self):
-        rule = EscalationRuleFactory(
+        EscalationRuleFactory(
             trigger_type=EscalationRule.TriggerType.NO_RESPONSE,
             conditions={"no_response_hours": 1},
             actions={"set_priority": "high"},
@@ -183,9 +179,7 @@ class TestEscalationService:
             priority=Ticket.Priority.MEDIUM,
         )
         # Make the ticket old enough
-        Ticket.objects.filter(pk=ticket.pk).update(
-            created_at=timezone.now() - timedelta(hours=2)
-        )
+        Ticket.objects.filter(pk=ticket.pk).update(created_at=timezone.now() - timedelta(hours=2))
         ticket.refresh_from_db()
 
         actions = EscalationService.evaluate_ticket(ticket)
@@ -195,7 +189,7 @@ class TestEscalationService:
         assert ticket.priority == Ticket.Priority.HIGH
 
     def test_evaluate_rule_with_status_condition(self):
-        rule = EscalationRuleFactory(
+        EscalationRuleFactory(
             trigger_type=EscalationRule.TriggerType.SLA_BREACH,
             conditions={"status": ["open"]},
             actions={"escalate": True},
@@ -210,7 +204,7 @@ class TestEscalationService:
         assert actions == 0
 
     def test_evaluate_rule_inactive_is_skipped(self):
-        rule = EscalationRuleFactory(
+        EscalationRuleFactory(
             trigger_type=EscalationRule.TriggerType.SLA_BREACH,
             conditions={},
             actions={"escalate": True},
@@ -226,7 +220,7 @@ class TestEscalationService:
 
     def test_evaluate_assigns_to_agent(self):
         agent = UserFactory(username="escalation_agent")
-        rule = EscalationRuleFactory(
+        EscalationRuleFactory(
             trigger_type=EscalationRule.TriggerType.SLA_BREACH,
             conditions={},
             actions={"assign_to_id": agent.pk},
@@ -241,7 +235,7 @@ class TestEscalationService:
         assert ticket.assigned_to == agent
 
     def test_evaluate_all(self):
-        rule = EscalationRuleFactory(
+        EscalationRuleFactory(
             trigger_type=EscalationRule.TriggerType.SLA_BREACH,
             conditions={},
             actions={"escalate": True},
@@ -265,10 +259,13 @@ class TestTicketService:
         user = UserFactory(username="ticket_svc_user")
         service = TicketService()
 
-        ticket = service.create(user, {
-            "subject": "Test ticket",
-            "description": "Test description",
-        })
+        ticket = service.create(
+            user,
+            {
+                "subject": "Test ticket",
+                "description": "Test description",
+            },
+        )
 
         assert ticket.pk is not None
         assert ticket.subject == "Test ticket"
@@ -279,11 +276,14 @@ class TestTicketService:
         user = UserFactory(username="priority_user")
         service = TicketService()
 
-        ticket = service.create(user, {
-            "subject": "Urgent issue",
-            "description": "Needs attention",
-            "priority": "urgent",
-        })
+        ticket = service.create(
+            user,
+            {
+                "subject": "Urgent issue",
+                "description": "Needs attention",
+                "priority": "urgent",
+            },
+        )
 
         assert ticket.priority == Ticket.Priority.URGENT
 

--- a/tests/unit/test_ticket_merge_service.py
+++ b/tests/unit/test_ticket_merge_service.py
@@ -1,8 +1,8 @@
 import pytest
 
-from escalated.models import Ticket, Reply
+from escalated.models import Reply, Ticket
 from escalated.services.ticket_merge_service import TicketMergeService
-from tests.factories import UserFactory, TicketFactory, ReplyFactory
+from tests.factories import ReplyFactory, TicketFactory, UserFactory
 
 
 @pytest.mark.django_db
@@ -74,7 +74,8 @@ class TestTicketMergeService:
         self.service.merge(source, target, merged_by_user_id=user.pk)
 
         target_note = Reply.objects.filter(
-            ticket=target, is_internal_note=True,
+            ticket=target,
+            is_internal_note=True,
             body__contains="merged into this ticket",
         ).first()
 

--- a/tests/unit/test_two_factor_service.py
+++ b/tests/unit/test_two_factor_service.py
@@ -1,5 +1,3 @@
-import pytest
-
 from escalated.services.two_factor_service import TwoFactorService
 
 
@@ -23,6 +21,7 @@ class TestTwoFactorService:
         secret = service.generate_secret()
         # Generate a current code
         import time
+
         time_step = int(time.time()) // service.PERIOD
         code = service._generate_totp(secret, time_step)
         assert service.verify(secret, code) is True

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -1,22 +1,23 @@
 import json
+
 import pytest
 from django.test import RequestFactory
 
 from escalated.validators import (
-    CreateTicketValidator,
-    UpdateTicketValidator,
-    ReplyToTicketValidator,
     AssignTicketValidator,
-    ChangeStatusValidator,
-    ChangePriorityValidator,
-    UpdateTagsValidator,
     BulkActionValidator,
-    StoreDepartmentValidator,
-    StoreTagValidator,
+    ChangePriorityValidator,
+    ChangeStatusValidator,
+    CreateTicketValidator,
+    ReplyToTicketValidator,
     StoreCannedResponseValidator,
+    StoreDepartmentValidator,
+    StoreEscalationRuleValidator,
     StoreMacroValidator,
     StoreSlaPolicyValidator,
-    StoreEscalationRuleValidator,
+    StoreTagValidator,
+    UpdateTagsValidator,
+    UpdateTicketValidator,
 )
 
 
@@ -52,17 +53,13 @@ class TestCreateTicketValidator:
         assert error.status_code == 422
 
     def test_invalid_priority(self, rf):
-        request = _make_request(rf, {
-            "subject": "Help", "description": "I need help", "priority": "INVALID"
-        })
+        request = _make_request(rf, {"subject": "Help", "description": "I need help", "priority": "INVALID"})
         data, error = CreateTicketValidator.validate_request(request)
         assert data is None
         assert error.status_code == 422
 
     def test_valid_priority(self, rf):
-        request = _make_request(rf, {
-            "subject": "Help", "description": "I need help", "priority": "high"
-        })
+        request = _make_request(rf, {"subject": "Help", "description": "I need help", "priority": "high"})
         data, error = CreateTicketValidator.validate_request(request)
         assert error is None
         assert data["priority"] == "high"
@@ -225,10 +222,13 @@ class TestStoreCannedResponseValidator:
 
 class TestStoreMacroValidator:
     def test_valid(self, rf):
-        request = _make_request(rf, {
-            "name": "Close and Tag",
-            "actions": [{"type": "change_status", "value": "closed"}],
-        })
+        request = _make_request(
+            rf,
+            {
+                "name": "Close and Tag",
+                "actions": [{"type": "change_status", "value": "closed"}],
+            },
+        )
         data, error = StoreMacroValidator.validate_request(request)
         assert error is None
 
@@ -241,19 +241,25 @@ class TestStoreMacroValidator:
 
 class TestStoreSlaPolicyValidator:
     def test_valid(self, rf):
-        request = _make_request(rf, {
-            "name": "Default SLA",
-            "first_response_hours": {"low": 24, "medium": 8, "high": 4, "urgent": 1, "critical": 0.5},
-            "resolution_hours": {"low": 72, "medium": 24, "high": 8, "urgent": 4, "critical": 2},
-        })
+        request = _make_request(
+            rf,
+            {
+                "name": "Default SLA",
+                "first_response_hours": {"low": 24, "medium": 8, "high": 4, "urgent": 1, "critical": 0.5},
+                "resolution_hours": {"low": 72, "medium": 24, "high": 8, "urgent": 4, "critical": 2},
+            },
+        )
         data, error = StoreSlaPolicyValidator.validate_request(request)
         assert error is None
 
     def test_missing_name(self, rf):
-        request = _make_request(rf, {
-            "first_response_hours": {"low": 24},
-            "resolution_hours": {"low": 72},
-        })
+        request = _make_request(
+            rf,
+            {
+                "first_response_hours": {"low": 24},
+                "resolution_hours": {"low": 72},
+            },
+        )
         data, error = StoreSlaPolicyValidator.validate_request(request)
         assert data is None
         assert error.status_code == 422
@@ -261,20 +267,26 @@ class TestStoreSlaPolicyValidator:
 
 class TestStoreEscalationRuleValidator:
     def test_valid(self, rf):
-        request = _make_request(rf, {
-            "trigger_type": "time_based",
-            "conditions": [{"field": "priority", "operator": "eq", "value": "critical"}],
-            "actions": [{"type": "assign", "value": 1}],
-        })
+        request = _make_request(
+            rf,
+            {
+                "trigger_type": "time_based",
+                "conditions": [{"field": "priority", "operator": "eq", "value": "critical"}],
+                "actions": [{"type": "assign", "value": 1}],
+            },
+        )
         data, error = StoreEscalationRuleValidator.validate_request(request)
         assert error is None
 
     def test_invalid_trigger_type(self, rf):
-        request = _make_request(rf, {
-            "trigger_type": "invalid",
-            "conditions": [],
-            "actions": [],
-        })
+        request = _make_request(
+            rf,
+            {
+                "trigger_type": "invalid",
+                "conditions": [],
+                "actions": [],
+            },
+        )
         data, error = StoreEscalationRuleValidator.validate_request(request)
         assert data is None
         assert error.status_code == 422
@@ -282,11 +294,14 @@ class TestStoreEscalationRuleValidator:
 
 class TestBulkActionValidator:
     def test_valid(self, rf):
-        request = _make_request(rf, {
-            "ticket_ids": [1, 2, 3],
-            "action": "change_status",
-            "value": "closed",
-        })
+        request = _make_request(
+            rf,
+            {
+                "ticket_ids": [1, 2, 3],
+                "action": "change_status",
+                "value": "closed",
+            },
+        )
         data, error = BulkActionValidator.validate_request(request)
         assert error is None
 

--- a/tests/unit/test_webhook_dispatcher.py
+++ b/tests/unit/test_webhook_dispatcher.py
@@ -1,7 +1,8 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-from escalated.models import Webhook, WebhookDelivery
+import pytest
+
+from escalated.models import WebhookDelivery
 from escalated.services.webhook_dispatcher import WebhookDispatcher
 from tests.factories import WebhookFactory
 


### PR DESCRIPTION
## Summary
- Add Ruff as a dev dependency and configure it in `pyproject.toml` with Django-appropriate rules (`E`, `F`, `I`, `W`, `UP`, `DJ`)
- Add `.github/workflows/lint.yml` that runs `ruff check` and `ruff format --check` on pushes and PRs to main
- Auto-fix all existing lint violations across the codebase (formatting, unused variables, import sorting, modern Python syntax upgrades)

## Test plan
- [ ] Verify the `lint` workflow runs and passes on this PR
- [ ] Confirm `ruff check .` and `ruff format --check .` pass locally
- [ ] Ensure no behavioral changes to application code (all fixes are style/lint only)