### PR TITLE
Fix Python 3.10 compatibility: revert datetime.UTC to timezone.utc

### DIFF
--- a/escalated/services/business_hours_service.py
+++ b/escalated/services/business_hours_service.py
@@ -1,4 +1,4 @@
-from datetime import UTC, timedelta
+from datetime import timedelta, timezone
 from zoneinfo import ZoneInfo
 
 
@@ -70,7 +70,7 @@ class BusinessHoursCalculator:
                 remaining_minutes -= available_minutes
                 current = (current + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
 
-        return current.astimezone(UTC)
+        return current.astimezone(timezone.utc)
 
     def _get_day_schedule(self, dt_local, schedule):
         """Get the schedule for a specific day of the week."""

--- a/escalated/services/webhook_dispatcher.py
+++ b/escalated/services/webhook_dispatcher.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import requests
 
@@ -29,7 +29,7 @@ class WebhookDispatcher:
             {
                 "event": event,
                 "payload": payload,
-                "timestamp": datetime.now(UTC).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
         )
 
@@ -53,7 +53,7 @@ class WebhookDispatcher:
             response = requests.post(webhook.url, data=body, headers=headers, timeout=10)
             delivery.response_code = response.status_code
             delivery.response_body = response.text[:2000]
-            delivery.delivered_at = datetime.now(UTC)
+            delivery.delivered_at = datetime.now(timezone.utc)
             delivery.attempts = attempt
             delivery.save()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ Homepage = "https://github.com/escalated-dev/escalated-django"
 
 [tool.ruff]
 line-length = 120
-target-version = "py311"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP", "DJ"]
-ignore = ["DJ001"]
+ignore = ["DJ001", "UP017"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
- Reverted `from datetime import UTC` to `from datetime import timezone` and replaced `UTC` with `timezone.utc` in `business_hours_service.py` and `webhook_dispatcher.py`
- Added `UP017` to Ruff ignore list to prevent re-upgrading `timezone.utc` to `datetime.UTC`
- Fixed Ruff `target-version` from `py311` to `py310` to match `requires-python = ">=3.10"`

## Context
Ruff's `UP017` rule auto-upgraded `datetime.timezone.utc` to `datetime.UTC`, but `datetime.UTC` was only added in Python 3.11. This caused `ImportError: cannot import name 'UTC' from 'datetime'` on Python 3.10.

## Test plan
- [ ] Verify `ruff check .` passes
- [ ] Verify tests pass on Python 3.10