### PR TITLE
feat: add ticket splitting

### DIFF
--- a/escalated/services/ticket_service.py
+++ b/escalated/services/ticket_service.py
@@ -105,3 +105,19 @@ class TicketService:
         from escalated.models import Ticket
 
         return self.driver.transition_status(ticket, user, Ticket.Status.ESCALATED)
+
+    def split_ticket(self, source, reply, data):
+        """
+        Split a reply out of a ticket into a new ticket.
+
+        Args:
+            source: The source ticket.
+            reply: The reply whose body becomes the new ticket description.
+            data: dict with optional subject, priority, department_id, assigned_to_id.
+        Returns:
+            The newly created Ticket.
+        """
+        from escalated.services.ticket_split_service import TicketSplitService
+
+        service = TicketSplitService()
+        return service.split_ticket(source, reply, data)

--- a/escalated/services/ticket_split_service.py
+++ b/escalated/services/ticket_split_service.py
@@ -1,0 +1,129 @@
+from django.db import transaction
+
+
+class TicketSplitService:
+    """Service for splitting a reply out of a ticket into a new ticket."""
+
+    def split_ticket(self, source, reply, data, split_by_user_id=None):
+        """
+        Split a reply from the source ticket into a new ticket.
+
+        Creates a new ticket using the reply body as description, copies
+        relevant metadata from the source ticket, links the two tickets,
+        and logs activity on both.
+
+        Args:
+            source: The original Ticket the reply belongs to.
+            reply: The Reply to split out (its body becomes the new ticket description).
+            data: dict with optional overrides — subject, priority, department_id, assigned_to_id.
+            split_by_user_id: ID of the user performing the split.
+
+        Returns:
+            The newly created Ticket.
+        """
+        with transaction.atomic():
+            from django.contrib.contenttypes.models import ContentType
+
+            from escalated.models import Reply, Ticket, TicketActivity, TicketLink
+
+            subject = data.get("subject") or f"Split from {source.reference}: {source.subject}"
+            if len(subject) > 500:
+                subject = subject[:497] + "..."
+
+            new_ticket = Ticket(
+                subject=subject,
+                description=reply.body,
+                priority=data.get("priority", source.priority),
+                channel=source.channel,
+                ticket_type=source.ticket_type,
+                status=Ticket.Status.OPEN,
+            )
+
+            # Copy requester from source
+            new_ticket.requester_content_type = source.requester_content_type
+            new_ticket.requester_object_id = source.requester_object_id
+            new_ticket.guest_name = source.guest_name
+            new_ticket.guest_email = source.guest_email
+
+            # Apply optional overrides
+            if data.get("department_id"):
+                new_ticket.department_id = data["department_id"]
+            elif source.department_id:
+                new_ticket.department_id = source.department_id
+
+            if data.get("assigned_to_id"):
+                new_ticket.assigned_to_id = data["assigned_to_id"]
+
+            new_ticket.save()
+
+            # Copy tags from source
+            if source.tags.exists():
+                new_ticket.tags.set(source.tags.all())
+
+            # Link source and new ticket
+            TicketLink.objects.create(
+                parent_ticket=source,
+                child_ticket=new_ticket,
+                link_type=TicketLink.LinkType.RELATED,
+            )
+
+            # System note on source
+            Reply.objects.create(
+                ticket=source,
+                body=f"Reply was split into new ticket {new_ticket.reference}.",
+                is_internal_note=True,
+                is_pinned=False,
+                metadata={
+                    "system_note": True,
+                    "split_target": new_ticket.reference,
+                    "split_by": split_by_user_id,
+                },
+            )
+
+            # System note on new ticket
+            Reply.objects.create(
+                ticket=new_ticket,
+                body=f"This ticket was split from {source.reference}.",
+                is_internal_note=True,
+                is_pinned=False,
+                metadata={
+                    "system_note": True,
+                    "split_source": source.reference,
+                    "split_by": split_by_user_id,
+                },
+            )
+
+            # Activity on source
+            causer_ct = None
+            causer_oid = None
+            if split_by_user_id:
+                from django.contrib.auth import get_user_model
+
+                User = get_user_model()
+                causer_ct = ContentType.objects.get_for_model(User)
+                causer_oid = split_by_user_id
+
+            TicketActivity.objects.create(
+                ticket=source,
+                causer_content_type=causer_ct,
+                causer_object_id=causer_oid,
+                type=TicketActivity.ActivityType.CREATED,
+                properties={
+                    "action": "split",
+                    "new_ticket_reference": new_ticket.reference,
+                },
+            )
+
+            # Activity on new ticket
+            TicketActivity.objects.create(
+                ticket=new_ticket,
+                causer_content_type=causer_ct,
+                causer_object_id=causer_oid,
+                type=TicketActivity.ActivityType.CREATED,
+                properties={
+                    "action": "split_from",
+                    "source_ticket_reference": source.reference,
+                },
+            )
+
+            return new_ticket

--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -66,6 +66,8 @@ admin_patterns = [
     ),
     # Ticket Merging
     path("admin/tickets/<int:ticket_id>/merge/", admin.ticket_merge, name="admin_ticket_merge"),
+    # Ticket Splitting
+    path("admin/tickets/<int:ticket_id>/split/", admin.ticket_split, name="admin_ticket_split"),
     # Side Conversations
     path(
         "admin/tickets/<int:ticket_id>/side-conversations/",

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -2355,6 +2355,64 @@ def ticket_merge(request, ticket_id):
 
 
 # ---------------------------------------------------------------------------
+# Ticket Splitting
+# ---------------------------------------------------------------------------
+
+
+@login_required
+def ticket_split(request, ticket_id):
+    """Split a reply from a ticket into a new ticket."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        source = Ticket.objects.get(pk=ticket_id)
+    except Ticket.DoesNotExist:
+        return HttpResponseNotFound(_("Ticket not found"))
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    reply_id = body.get("reply_id")
+    if not reply_id:
+        return JsonResponse({"error": "reply_id is required"}, status=400)
+
+    try:
+        reply = Reply.objects.get(pk=reply_id, ticket=source)
+    except Reply.DoesNotExist:
+        return JsonResponse({"error": "Reply not found on this ticket"}, status=404)
+
+    data = {
+        "subject": body.get("subject"),
+        "priority": body.get("priority"),
+        "department_id": body.get("department_id"),
+        "assigned_to_id": body.get("assigned_to_id"),
+    }
+
+    from escalated.services.ticket_split_service import TicketSplitService
+
+    service = TicketSplitService()
+    new_ticket = service.split_ticket(source, reply, data, split_by_user_id=request.user.pk)
+
+    return JsonResponse(
+        {
+            "success": True,
+            "new_ticket": {
+                "id": new_ticket.pk,
+                "reference": new_ticket.reference,
+                "subject": new_ticket.subject,
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Side Conversations
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_ticket_split_service.py
+++ b/tests/unit/test_ticket_split_service.py
@@ -1,0 +1,183 @@
+import pytest
+
+from escalated.models import Reply, Ticket, TicketActivity, TicketLink
+from escalated.services.ticket_split_service import TicketSplitService
+from tests.factories import ReplyFactory, TicketFactory, UserFactory
+
+
+@pytest.mark.django_db
+class TestTicketSplitService:
+    def setup_method(self):
+        self.service = TicketSplitService()
+
+    def test_creates_new_ticket_from_reply(self):
+        source = TicketFactory()
+        user = UserFactory()
+        reply = ReplyFactory(ticket=source, author=user, body="Split this content")
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        assert new_ticket.pk is not None
+        assert new_ticket.pk != source.pk
+        assert new_ticket.description == "Split this content"
+        assert new_ticket.status == Ticket.Status.OPEN
+
+    def test_copies_metadata_from_source(self):
+        source = TicketFactory(priority=Ticket.Priority.HIGH, channel="email")
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        assert new_ticket.priority == Ticket.Priority.HIGH
+        assert new_ticket.channel == "email"
+        assert new_ticket.ticket_type == source.ticket_type
+
+    def test_copies_requester_from_source(self):
+        user = UserFactory()
+        source = TicketFactory(requester=user)
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        assert new_ticket.requester_content_type == source.requester_content_type
+        assert new_ticket.requester_object_id == source.requester_object_id
+
+    def test_uses_subject_override(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {"subject": "Custom subject"})
+
+        assert new_ticket.subject == "Custom subject"
+
+    def test_default_subject_includes_source_reference(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        assert source.reference in new_ticket.subject
+
+    def test_uses_priority_override(self):
+        source = TicketFactory(priority=Ticket.Priority.LOW)
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {"priority": Ticket.Priority.URGENT})
+
+        assert new_ticket.priority == Ticket.Priority.URGENT
+
+    def test_links_tickets(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        link = TicketLink.objects.get(parent_ticket=source, child_ticket=new_ticket)
+        assert link.link_type == TicketLink.LinkType.RELATED
+
+    def test_creates_system_note_on_source(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        notes = Reply.objects.filter(ticket=source, is_internal_note=True)
+        note = notes.filter(body__contains="split into new ticket").first()
+        assert note is not None
+        assert new_ticket.reference in note.body
+
+    def test_creates_system_note_on_new_ticket(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        notes = Reply.objects.filter(ticket=new_ticket, is_internal_note=True)
+        note = notes.filter(body__contains="split from").first()
+        assert note is not None
+        assert source.reference in note.body
+
+    def test_system_notes_have_metadata(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+        user = UserFactory()
+
+        new_ticket = self.service.split_ticket(source, reply, {}, split_by_user_id=user.pk)
+
+        source_note = Reply.objects.filter(
+            ticket=source,
+            is_internal_note=True,
+            body__contains="split into new ticket",
+        ).first()
+
+        assert source_note.metadata is not None
+        assert source_note.metadata.get("system_note") is True
+        assert source_note.metadata.get("split_by") == user.pk
+        assert source_note.metadata.get("split_target") == new_ticket.reference
+
+    def test_logs_activity_on_source(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        activity = TicketActivity.objects.filter(ticket=source).first()
+        assert activity is not None
+        assert activity.properties.get("action") == "split"
+        assert activity.properties.get("new_ticket_reference") == new_ticket.reference
+
+    def test_logs_activity_on_new_ticket(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        activity = TicketActivity.objects.filter(ticket=new_ticket).first()
+        assert activity is not None
+        assert activity.properties.get("action") == "split_from"
+        assert activity.properties.get("source_ticket_reference") == source.reference
+
+    def test_copies_tags_from_source(self):
+        from tests.factories import TagFactory
+
+        source = TicketFactory()
+        tag1 = TagFactory()
+        tag2 = TagFactory()
+        source.tags.add(tag1, tag2)
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        assert set(new_ticket.tags.values_list("pk", flat=True)) == {tag1.pk, tag2.pk}
+
+    def test_copies_department_from_source(self):
+        from tests.factories import DepartmentFactory
+
+        dept = DepartmentFactory()
+        source = TicketFactory(department=dept)
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        assert new_ticket.department_id == dept.pk
+
+    def test_department_override(self):
+        from tests.factories import DepartmentFactory
+
+        dept1 = DepartmentFactory()
+        dept2 = DepartmentFactory()
+        source = TicketFactory(department=dept1)
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {"department_id": dept2.pk})
+
+        assert new_ticket.department_id == dept2.pk
+
+    def test_new_ticket_has_unique_reference(self):
+        source = TicketFactory()
+        reply = ReplyFactory(ticket=source)
+
+        new_ticket = self.service.split_ticket(source, reply, {})
+
+        assert new_ticket.reference != source.reference
+        assert new_ticket.reference is not None


### PR DESCRIPTION
## Summary
- Add `TicketSplitService` with `split_ticket(source, reply, data)` method that creates a new ticket from a reply body, copies metadata (requester, priority, tags, department, channel), links the tickets via `TicketLink`, and logs activity on both tickets
- Add admin view at `POST /tickets/<id>/split/` with URL routing
- Add `split_ticket` convenience method to `TicketService`

## Test plan
- [x] 16 pytest unit tests covering: new ticket creation, metadata copying, requester copying, subject/priority/department overrides, ticket linking, system notes with metadata, activity logging, tag copying, and unique reference generation
- [x] ruff check and format pass