### PR TITLE
feat: add ticket snooze/schedule

### DIFF
--- a/escalated/management/commands/wake_snoozed_tickets.py
+++ b/escalated/management/commands/wake_snoozed_tickets.py
@@ -1,0 +1,38 @@
+from django.core.management.base import BaseCommand
+from django.utils.translation import gettext as _
+
+from escalated.models import Ticket
+
+
+class Command(BaseCommand):
+    help = "Unsnooze tickets whose snooze period has expired."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=_("Show what would be unsnoozed without making changes"),
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        expired = Ticket.objects.snooze_expired()
+        count = expired.count()
+
+        if dry_run:
+            self.stdout.write(_("[DRY RUN] Would unsnooze %(count)d tickets.") % {"count": count})
+            for ticket in expired[:20]:
+                self.stdout.write(f"  - {ticket.reference}: snoozed_until={ticket.snoozed_until}")
+            return
+
+        if count == 0:
+            self.stdout.write(_("No snoozed tickets to wake."))
+            return
+
+        woken = 0
+        for ticket in expired:
+            ticket.unsnooze()
+            woken += 1
+
+        self.stdout.write(self.style.SUCCESS(_("Unsnoozed %(count)d tickets.") % {"count": woken}))

--- a/escalated/migrations/0014_ticket_snooze_fields.py
+++ b/escalated/migrations/0014_ticket_snooze_fields.py
@@ -1,0 +1,38 @@
+"""
+Add snooze fields to the Ticket model: snoozed_until, snoozed_by, status_before_snooze.
+"""
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("escalated", "0013_plugin_metadata_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="ticket",
+            name="snoozed_until",
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name="ticket",
+            name="snoozed_by",
+            field=models.ForeignKey(
+                to=settings.AUTH_USER_MODEL,
+                on_delete=django.db.models.deletion.SET_NULL,
+                null=True,
+                blank=True,
+                related_name="escalated_snoozed_tickets",
+            ),
+        ),
+        migrations.AddField(
+            model_name="ticket",
+            name="status_before_snooze",
+            field=models.CharField(max_length=30, null=True, blank=True),
+        ),
+    ]

--- a/escalated/models.py
+++ b/escalated/models.py
@@ -61,6 +61,18 @@ class TicketQuerySet(models.QuerySet):
         """Filter tickets that are followed by a specific user."""
         return self.filter(ticket_followers__user_id=user_id)
 
+    def snoozed(self):
+        """Return tickets that are currently snoozed."""
+        return self.filter(snoozed_until__isnull=False, snoozed_until__gt=timezone.now())
+
+    def not_snoozed(self):
+        """Exclude currently snoozed tickets."""
+        return self.exclude(snoozed_until__isnull=False, snoozed_until__gt=timezone.now())
+
+    def snooze_expired(self):
+        """Return tickets whose snooze period has expired."""
+        return self.filter(snoozed_until__isnull=False, snoozed_until__lte=timezone.now())
+
 
 class TicketManager(models.Manager):
     def get_queryset(self):
@@ -83,6 +95,15 @@ class TicketManager(models.Manager):
 
     def search(self, term):
         return self.get_queryset().search(term)
+
+    def snoozed(self):
+        return self.get_queryset().snoozed()
+
+    def not_snoozed(self):
+        return self.get_queryset().not_snoozed()
+
+    def snooze_expired(self):
+        return self.get_queryset().snooze_expired()
 
 
 # ---------------------------------------------------------------------------
@@ -241,6 +262,17 @@ class Ticket(models.Model):
         related_name="merged_tickets",
     )
 
+    # Snooze fields
+    snoozed_until = models.DateTimeField(null=True, blank=True)
+    snoozed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="escalated_snoozed_tickets",
+    )
+    status_before_snooze = models.CharField(max_length=30, null=True, blank=True)
+
     # SLA tracking fields
     first_response_at = models.DateTimeField(null=True, blank=True)
     first_response_due_at = models.DateTimeField(null=True, blank=True)
@@ -383,6 +415,36 @@ class Ticket(models.Model):
         if not self.resolution_due_at or self.resolved_at:
             return None
         return self.resolution_due_at - timezone.now()
+
+    # ----- Snooze helpers -----
+
+    @property
+    def is_snoozed(self):
+        """Check if the ticket is currently snoozed."""
+        return self.snoozed_until is not None and self.snoozed_until > timezone.now()
+
+    def snooze(self, until, user=None):
+        """
+        Snooze this ticket until the given datetime.
+
+        Saves the current status so it can be restored on unsnooze.
+        """
+        self.status_before_snooze = self.status
+        self.snoozed_until = until
+        self.snoozed_by = user
+        self.status = self.Status.CLOSED
+        self.save(update_fields=["status", "snoozed_until", "snoozed_by", "status_before_snooze", "updated_at"])
+
+    def unsnooze(self):
+        """
+        Unsnooze this ticket, restoring its previous status.
+        """
+        restored_status = self.status_before_snooze or self.Status.OPEN
+        self.status = restored_status
+        self.snoozed_until = None
+        self.snoozed_by = None
+        self.status_before_snooze = None
+        self.save(update_fields=["status", "snoozed_until", "snoozed_by", "status_before_snooze", "updated_at"])
 
 
 class Reply(models.Model):

--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -66,6 +66,9 @@ admin_patterns = [
     ),
     # Ticket Merging
     path("admin/tickets/<int:ticket_id>/merge/", admin.ticket_merge, name="admin_ticket_merge"),
+    # Ticket Snooze
+    path("admin/tickets/<int:ticket_id>/snooze/", admin.ticket_snooze, name="admin_ticket_snooze"),
+    path("admin/tickets/<int:ticket_id>/unsnooze/", admin.ticket_unsnooze, name="admin_ticket_unsnooze"),
     # Side Conversations
     path(
         "admin/tickets/<int:ticket_id>/side-conversations/",

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -2355,6 +2355,72 @@ def ticket_merge(request, ticket_id):
 
 
 # ---------------------------------------------------------------------------
+# Ticket Snooze / Unsnooze
+# ---------------------------------------------------------------------------
+
+
+@login_required
+def ticket_snooze(request, ticket_id):
+    """Snooze a ticket until a specified datetime."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        ticket = Ticket.objects.get(pk=ticket_id)
+    except Ticket.DoesNotExist:
+        return HttpResponseNotFound(_("Ticket not found"))
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    snoozed_until = body.get("snoozed_until")
+    if not snoozed_until:
+        return JsonResponse({"error": "snoozed_until is required"}, status=400)
+
+    from django.utils.dateparse import parse_datetime
+
+    dt = parse_datetime(snoozed_until)
+    if dt is None:
+        return JsonResponse({"error": "Invalid datetime format"}, status=400)
+
+    if timezone.is_naive(dt):
+        dt = timezone.make_aware(dt)
+
+    ticket.snooze(until=dt, user=request.user)
+
+    return JsonResponse({"success": True, "snoozed_until": dt.isoformat()})
+
+
+@login_required
+def ticket_unsnooze(request, ticket_id):
+    """Unsnooze a ticket, restoring its previous status."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        ticket = Ticket.objects.get(pk=ticket_id)
+    except Ticket.DoesNotExist:
+        return HttpResponseNotFound(_("Ticket not found"))
+
+    if not ticket.is_snoozed:
+        return JsonResponse({"error": "Ticket is not snoozed"}, status=400)
+
+    ticket.unsnooze()
+
+    return JsonResponse({"success": True, "status": ticket.status})
+
+
+# ---------------------------------------------------------------------------
 # Side Conversations
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_ticket_snooze.py
+++ b/tests/unit/test_ticket_snooze.py
@@ -1,0 +1,172 @@
+from datetime import timedelta
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from escalated.models import Ticket
+from tests.factories import TicketFactory, UserFactory
+
+
+@pytest.mark.django_db
+class TestTicketSnoozeModel:
+    def test_snooze_sets_fields(self):
+        ticket = TicketFactory(status=Ticket.Status.OPEN)
+        user = UserFactory()
+        future = timezone.now() + timedelta(hours=24)
+
+        ticket.snooze(until=future, user=user)
+        ticket.refresh_from_db()
+
+        assert ticket.snoozed_until == future
+        assert ticket.snoozed_by == user
+        assert ticket.status_before_snooze == Ticket.Status.OPEN
+        assert ticket.status == Ticket.Status.CLOSED
+
+    def test_is_snoozed_true_when_future(self):
+        ticket = TicketFactory()
+        user = UserFactory()
+        future = timezone.now() + timedelta(hours=24)
+        ticket.snooze(until=future, user=user)
+        ticket.refresh_from_db()
+
+        assert ticket.is_snoozed is True
+
+    def test_is_snoozed_false_when_past(self):
+        ticket = TicketFactory()
+        past = timezone.now() - timedelta(hours=1)
+        ticket.snoozed_until = past
+        ticket.save()
+
+        assert ticket.is_snoozed is False
+
+    def test_is_snoozed_false_when_none(self):
+        ticket = TicketFactory()
+
+        assert ticket.is_snoozed is False
+
+    def test_unsnooze_restores_status(self):
+        ticket = TicketFactory(status=Ticket.Status.IN_PROGRESS)
+        user = UserFactory()
+        future = timezone.now() + timedelta(hours=24)
+        ticket.snooze(until=future, user=user)
+        ticket.refresh_from_db()
+
+        ticket.unsnooze()
+        ticket.refresh_from_db()
+
+        assert ticket.status == Ticket.Status.IN_PROGRESS
+        assert ticket.snoozed_until is None
+        assert ticket.snoozed_by is None
+        assert ticket.status_before_snooze is None
+
+    def test_unsnooze_defaults_to_open(self):
+        ticket = TicketFactory(status=Ticket.Status.OPEN)
+        ticket.snoozed_until = timezone.now() + timedelta(hours=1)
+        ticket.status = Ticket.Status.CLOSED
+        ticket.status_before_snooze = None  # Edge case: missing
+        ticket.save()
+
+        ticket.unsnooze()
+        ticket.refresh_from_db()
+
+        assert ticket.status == Ticket.Status.OPEN
+
+
+@pytest.mark.django_db
+class TestTicketSnoozeQuerySet:
+    def test_snoozed_returns_snoozed_tickets(self):
+        user = UserFactory()
+        t1 = TicketFactory()
+        t1.snooze(until=timezone.now() + timedelta(hours=24), user=user)
+
+        t2 = TicketFactory()  # not snoozed
+
+        snoozed = Ticket.objects.snoozed()
+        assert t1 in snoozed
+        assert t2 not in snoozed
+
+    def test_not_snoozed_excludes_snoozed(self):
+        user = UserFactory()
+        t1 = TicketFactory()
+        t1.snooze(until=timezone.now() + timedelta(hours=24), user=user)
+
+        t2 = TicketFactory()
+
+        not_snoozed = Ticket.objects.not_snoozed()
+        assert t1 not in not_snoozed
+        assert t2 in not_snoozed
+
+    def test_snooze_expired_returns_expired(self):
+        user = UserFactory()
+        t1 = TicketFactory()
+        # Manually set snooze to past
+        t1.snoozed_until = timezone.now() - timedelta(hours=1)
+        t1.status_before_snooze = Ticket.Status.OPEN
+        t1.snoozed_by = user
+        t1.save()
+
+        t2 = TicketFactory()
+        t2.snooze(until=timezone.now() + timedelta(hours=24), user=user)
+
+        expired = Ticket.objects.snooze_expired()
+        assert t1 in expired
+        assert t2 not in expired
+
+
+@pytest.mark.django_db
+class TestWakeSnoozedTicketsCommand:
+    def test_wakes_expired_tickets(self):
+        user = UserFactory()
+        ticket = TicketFactory(status=Ticket.Status.IN_PROGRESS)
+        ticket.snooze(until=timezone.now() + timedelta(hours=24), user=user)
+        ticket.refresh_from_db()
+
+        # Manually move snooze to past
+        ticket.snoozed_until = timezone.now() - timedelta(hours=1)
+        ticket.save(update_fields=["snoozed_until"])
+
+        out = StringIO()
+        call_command("wake_snoozed_tickets", stdout=out)
+
+        ticket.refresh_from_db()
+        assert ticket.status == Ticket.Status.IN_PROGRESS
+        assert ticket.snoozed_until is None
+        assert "Unsnoozed 1 tickets" in out.getvalue()
+
+    def test_no_tickets_to_wake(self):
+        out = StringIO()
+        call_command("wake_snoozed_tickets", stdout=out)
+        assert "No snoozed tickets to wake" in out.getvalue()
+
+    def test_dry_run(self):
+        user = UserFactory()
+        ticket = TicketFactory(status=Ticket.Status.OPEN)
+        ticket.snooze(until=timezone.now() + timedelta(hours=24), user=user)
+        ticket.refresh_from_db()
+
+        ticket.snoozed_until = timezone.now() - timedelta(hours=1)
+        ticket.save(update_fields=["snoozed_until"])
+
+        out = StringIO()
+        call_command("wake_snoozed_tickets", "--dry-run", stdout=out)
+
+        ticket.refresh_from_db()
+        # Should still be snoozed (dry run)
+        assert ticket.snoozed_until is not None
+        assert "DRY RUN" in out.getvalue()
+
+    def test_does_not_wake_future_snoozed(self):
+        user = UserFactory()
+        ticket = TicketFactory(status=Ticket.Status.OPEN)
+        future = timezone.now() + timedelta(hours=24)
+        ticket.snooze(until=future, user=user)
+        ticket.refresh_from_db()
+
+        out = StringIO()
+        call_command("wake_snoozed_tickets", stdout=out)
+
+        ticket.refresh_from_db()
+        assert ticket.is_snoozed is True
+        assert "No snoozed tickets to wake" in out.getvalue()


### PR DESCRIPTION
## Summary
- Add `snoozed_until`, `snoozed_by`, `status_before_snooze` fields to Ticket model with migration 0014
- Add `snooze()`, `unsnooze()` methods and `is_snoozed` property on Ticket
- Add `snoozed()`, `not_snoozed()`, `snooze_expired()` queryset/manager methods
- Add `wake_snoozed_tickets` management command with `--dry-run` support
- Add admin `POST /tickets/<id>/snooze/` and `POST /tickets/<id>/unsnooze/` endpoints

## Test plan
- [x] 13 pytest tests covering model snooze/unsnooze, is_snoozed property, queryset filtering, and management command (wake, dry-run, no-op, future snooze)
- [x] ruff check and format pass