### PR TITLE
feat: add email threading and branded templates

### DIFF
--- a/escalated/mail/threading.py
+++ b/escalated/mail/threading.py
@@ -1,0 +1,76 @@
+"""
+Email threading support for outbound emails.
+
+Generates Message-ID, In-Reply-To, and References headers so that email
+clients can group ticket conversations into a single thread.
+"""
+
+from django.conf import settings
+
+from escalated.models import EscalatedSetting
+
+
+def get_email_domain():
+    """Return the domain used for Message-ID generation."""
+    domain = EscalatedSetting.get("email_domain")
+    if domain:
+        return domain
+    default_from = getattr(settings, "DEFAULT_FROM_EMAIL", "support@escalated.dev")
+    if "@" in default_from:
+        return default_from.split("@", 1)[1]
+    return "escalated.dev"
+
+
+def make_message_id(ticket):
+    """Generate a Message-ID for the initial ticket notification."""
+    domain = get_email_domain()
+    return f"<ticket-{ticket.pk}-{ticket.reference}@{domain}>"
+
+
+def make_reply_message_id(ticket, reply):
+    """Generate a Message-ID for a reply notification."""
+    domain = get_email_domain()
+    return f"<ticket-{ticket.pk}-reply-{reply.pk}@{domain}>"
+
+
+def get_threading_headers(ticket, reply=None):
+    """
+    Return a dict of email headers for threading.
+
+    For new ticket notifications:
+        - Message-ID is set (anchor for the thread)
+
+    For reply notifications:
+        - Message-ID for this specific reply
+        - In-Reply-To pointing to the ticket's Message-ID
+        - References listing the ticket's Message-ID
+    """
+    headers = {}
+    ticket_msg_id = make_message_id(ticket)
+
+    if reply is None:
+        # New ticket notification
+        headers["Message-ID"] = ticket_msg_id
+    else:
+        # Reply notification
+        headers["Message-ID"] = make_reply_message_id(ticket, reply)
+        headers["In-Reply-To"] = ticket_msg_id
+        headers["References"] = ticket_msg_id
+
+    return headers
+
+
+def get_branding_context():
+    """
+    Return branding settings for email templates.
+
+    Returns a dict with email_logo_url, email_accent_color, email_footer_text.
+    """
+    return {
+        "email_logo_url": EscalatedSetting.get("email_logo_url", ""),
+        "email_accent_color": EscalatedSetting.get("email_accent_color", "#4f46e5"),
+        "email_footer_text": EscalatedSetting.get(
+            "email_footer_text",
+            "This is an automated message from the support system.",
+        ),
+    }

--- a/escalated/services/notification_service.py
+++ b/escalated/services/notification_service.py
@@ -4,7 +4,6 @@ import json
 import logging
 
 from django.conf import settings
-from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
 
@@ -24,6 +23,9 @@ class NotificationService:
         channels = get_setting("NOTIFICATION_CHANNELS")
 
         if "email" in channels:
+            from escalated.mail.threading import get_threading_headers
+
+            headers = get_threading_headers(ticket, reply=None)
             NotificationService._send_email(
                 subject="[{}] {}".format(
                     ticket.reference,
@@ -32,6 +34,7 @@ class NotificationService:
                 template="escalated/emails/new_ticket.html",
                 context={"ticket": ticket},
                 recipient=NotificationService._get_requester_email(ticket),
+                extra_headers=headers,
             )
 
         NotificationService._fire_webhook(
@@ -50,6 +53,10 @@ class NotificationService:
         channels = get_setting("NOTIFICATION_CHANNELS")
 
         if "email" in channels:
+            from escalated.mail.threading import get_threading_headers
+
+            headers = get_threading_headers(ticket, reply=reply)
+
             # Notify the requester if an agent replied
             requester_email = NotificationService._get_requester_email(ticket)
             if requester_email and reply.author != ticket.requester:
@@ -61,6 +68,7 @@ class NotificationService:
                     template="escalated/emails/reply.html",
                     context={"ticket": ticket, "reply": reply},
                     recipient=requester_email,
+                    extra_headers=headers,
                 )
 
             # Notify assigned agent if customer replied
@@ -75,6 +83,7 @@ class NotificationService:
                         template="escalated/emails/reply.html",
                         context={"ticket": ticket, "reply": reply},
                         recipient=agent_email,
+                        extra_headers=headers,
                     )
 
             # Notify followers (except the author and assignee, already notified)
@@ -307,21 +316,31 @@ class NotificationService:
         return None
 
     @staticmethod
-    def _send_email(subject, template, context, recipient):
-        """Send an HTML email using Django's mail system."""
+    def _send_email(subject, template, context, recipient, extra_headers=None):
+        """Send an HTML email using Django's mail system with optional headers."""
         if not recipient:
             return
 
         try:
+            # Inject branding context for templates that use it
+            from escalated.mail.threading import get_branding_context
+
+            context.setdefault("branding", get_branding_context())
+
             html_body = render_to_string(template, context)
-            send_mail(
+            from_email = getattr(settings, "DEFAULT_FROM_EMAIL", "support@escalated.dev")
+
+            from django.core.mail import EmailMessage
+
+            msg = EmailMessage(
                 subject=subject,
-                message="",  # Plain text fallback
-                from_email=getattr(settings, "DEFAULT_FROM_EMAIL", "support@escalated.dev"),
-                recipient_list=[recipient],
-                html_message=html_body,
-                fail_silently=True,
+                body=html_body,
+                from_email=from_email,
+                to=[recipient],
+                headers=extra_headers or {},
             )
+            msg.content_subtype = "html"
+            msg.send(fail_silently=True)
         except Exception as e:
             logger.error(f"Failed to send email to {recipient}: {e}")
 

--- a/escalated/templates/escalated/emails/base_branded.html
+++ b/escalated/templates/escalated/emails/base_branded.html
@@ -1,0 +1,35 @@
+{% load i18n %}<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{% endblock %}</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: {{ branding.email_accent_color|default:"#4f46e5" }}; color: white; padding: 20px; border-radius: 8px 8px 0 0; }
+        .header-logo { margin-bottom: 10px; }
+        .header-logo img { max-height: 40px; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .footer { padding: 15px 20px; font-size: 12px; color: #6b7280; border-top: 1px solid #e5e7eb; }
+        .badge { display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; }
+        .badge-priority { background: #fef3c7; color: #92400e; }
+        .reference { font-family: monospace; font-weight: bold; color: {{ branding.email_accent_color|default:"#4f46e5" }}; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        {% if branding.email_logo_url %}
+        <div class="header-logo">
+            <img src="{{ branding.email_logo_url }}" alt="Logo">
+        </div>
+        {% endif %}
+        <h2 style="margin: 0;">{% block header_title %}{% endblock %}</h2>
+    </div>
+    <div class="content">
+        {% block content %}{% endblock %}
+    </div>
+    <div class="footer">
+        <p>{{ branding.email_footer_text|default:"This is an automated message from the support system." }}</p>
+    </div>
+</body>
+</html>

--- a/tests/unit/test_email_threading.py
+++ b/tests/unit/test_email_threading.py
@@ -1,0 +1,132 @@
+import pytest
+from django.core import mail
+
+from escalated.mail.threading import (
+    get_branding_context,
+    get_email_domain,
+    get_threading_headers,
+    make_message_id,
+    make_reply_message_id,
+)
+from escalated.models import EscalatedSetting
+from escalated.services.notification_service import NotificationService
+from tests.factories import ReplyFactory, TicketFactory, UserFactory
+
+
+@pytest.mark.django_db
+class TestEmailDomain:
+    def test_default_domain_from_settings(self):
+        domain = get_email_domain()
+        # Falls back to DEFAULT_FROM_EMAIL or "escalated.dev"
+        assert domain
+
+    def test_custom_domain_from_setting(self):
+        EscalatedSetting.set("email_domain", "custom.example.com")
+        assert get_email_domain() == "custom.example.com"
+
+
+@pytest.mark.django_db
+class TestMessageId:
+    def test_make_message_id_format(self):
+        ticket = TicketFactory()
+        msg_id = make_message_id(ticket)
+        assert msg_id.startswith("<ticket-")
+        assert ticket.reference in msg_id
+        assert msg_id.endswith(">")
+
+    def test_make_reply_message_id_format(self):
+        ticket = TicketFactory()
+        reply = ReplyFactory(ticket=ticket)
+        msg_id = make_reply_message_id(ticket, reply)
+        assert f"reply-{reply.pk}" in msg_id
+        assert msg_id.startswith("<ticket-")
+        assert msg_id.endswith(">")
+
+    def test_message_ids_are_unique(self):
+        ticket = TicketFactory()
+        reply1 = ReplyFactory(ticket=ticket)
+        reply2 = ReplyFactory(ticket=ticket)
+        assert make_reply_message_id(ticket, reply1) != make_reply_message_id(ticket, reply2)
+
+
+@pytest.mark.django_db
+class TestThreadingHeaders:
+    def test_new_ticket_headers(self):
+        ticket = TicketFactory()
+        headers = get_threading_headers(ticket, reply=None)
+        assert "Message-ID" in headers
+        assert "In-Reply-To" not in headers
+        assert "References" not in headers
+
+    def test_reply_headers(self):
+        ticket = TicketFactory()
+        reply = ReplyFactory(ticket=ticket)
+        headers = get_threading_headers(ticket, reply=reply)
+
+        assert "Message-ID" in headers
+        assert "In-Reply-To" in headers
+        assert "References" in headers
+
+        # In-Reply-To and References should point to the ticket's message ID
+        ticket_msg_id = make_message_id(ticket)
+        assert headers["In-Reply-To"] == ticket_msg_id
+        assert headers["References"] == ticket_msg_id
+
+    def test_reply_message_id_differs_from_ticket(self):
+        ticket = TicketFactory()
+        reply = ReplyFactory(ticket=ticket)
+        headers = get_threading_headers(ticket, reply=reply)
+        ticket_headers = get_threading_headers(ticket, reply=None)
+        assert headers["Message-ID"] != ticket_headers["Message-ID"]
+
+
+@pytest.mark.django_db
+class TestBrandingContext:
+    def test_default_branding(self):
+        ctx = get_branding_context()
+        assert ctx["email_accent_color"] == "#4f46e5"
+        assert ctx["email_footer_text"]  # Has a default
+        assert ctx["email_logo_url"] == ""
+
+    def test_custom_branding(self):
+        EscalatedSetting.set("email_logo_url", "https://example.com/logo.png")
+        EscalatedSetting.set("email_accent_color", "#ff0000")
+        EscalatedSetting.set("email_footer_text", "Custom footer")
+
+        ctx = get_branding_context()
+        assert ctx["email_logo_url"] == "https://example.com/logo.png"
+        assert ctx["email_accent_color"] == "#ff0000"
+        assert ctx["email_footer_text"] == "Custom footer"
+
+
+@pytest.mark.django_db
+class TestNotificationServiceThreading:
+    def test_ticket_created_has_message_id(self, settings):
+        settings.ESCALATED = {"NOTIFICATION_CHANNELS": ["email"], "WEBHOOK_URL": None}
+        user = UserFactory()
+        ticket = TicketFactory(requester=user)
+
+        NotificationService.notify_ticket_created(ticket)
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert "Message-ID" in msg.extra_headers
+        assert ticket.reference in msg.extra_headers["Message-ID"]
+
+    def test_reply_has_threading_headers(self, settings):
+        settings.ESCALATED = {"NOTIFICATION_CHANNELS": ["email"], "WEBHOOK_URL": None}
+        user = UserFactory()
+        ticket = TicketFactory(requester=user)
+        agent = UserFactory(username="agent_threading")
+        ticket.assigned_to = agent
+        ticket.save()
+
+        reply = ReplyFactory(ticket=ticket, author=agent)
+
+        NotificationService.notify_reply_added(ticket, reply)
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert "In-Reply-To" in msg.extra_headers
+        assert "References" in msg.extra_headers
+        assert ticket.reference in msg.extra_headers["In-Reply-To"]


### PR DESCRIPTION
## Summary
- Add `escalated.mail.threading` module with `get_threading_headers()`, `make_message_id()`, `make_reply_message_id()` for proper In-Reply-To/References/Message-ID headers
- Add branding settings (`email_logo_url`, `email_accent_color`, `email_footer_text`) via `EscalatedSetting`
- Add `base_branded.html` email template with logo, accent color, and footer customization
- Update `NotificationService._send_email()` to use `EmailMessage` with custom headers and inject branding context

## Test plan
- [x] 12 pytest tests covering domain resolution, message ID format/uniqueness, threading headers for new tickets vs replies, branding defaults/customization, and integration with NotificationService
- [x] ruff check and format pass