### PR TITLE
feat: add saved views / custom queues

### DIFF
--- a/escalated/migrations/0014_saved_views.py
+++ b/escalated/migrations/0014_saved_views.py
@@ -1,0 +1,48 @@
+"""
+Add SavedView model for custom ticket queues / saved filters.
+"""
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+from escalated.conf import get_table_name
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("escalated", "0013_plugin_metadata_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SavedView",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("name", models.CharField(max_length=255)),
+                ("filters", models.JSONField(default=dict)),
+                (
+                    "user",
+                    models.ForeignKey(
+                        to=settings.AUTH_USER_MODEL,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        null=True,
+                        blank=True,
+                        related_name="escalated_saved_views",
+                    ),
+                ),
+                ("is_shared", models.BooleanField(default=False)),
+                ("is_default", models.BooleanField(default=False)),
+                ("position", models.IntegerField(default=0)),
+                ("icon", models.CharField(max_length=100, blank=True, default="")),
+                ("color", models.CharField(max_length=20, blank=True, default="#6b7280")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": get_table_name("saved_views"),
+                "ordering": ["position", "name"],
+            },
+        ),
+    ]

--- a/escalated/models.py
+++ b/escalated/models.py
@@ -1140,6 +1140,39 @@ class CustomFieldValue(models.Model):
 
 
 # ---------------------------------------------------------------------------
+# Saved Views
+# ---------------------------------------------------------------------------
+
+
+class SavedView(models.Model):
+    """Custom saved filter / queue for tickets."""
+
+    name = models.CharField(max_length=255)
+    filters = models.JSONField(default=dict)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="escalated_saved_views",
+    )
+    is_shared = models.BooleanField(default=False)
+    is_default = models.BooleanField(default=False)
+    position = models.IntegerField(default=0)
+    icon = models.CharField(max_length=100, blank=True, default="")
+    color = models.CharField(max_length=20, blank=True, default="#6b7280")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = get_table_name("saved_views")
+        ordering = ["position", "name"]
+
+    def __str__(self):
+        return self.name
+
+
+# ---------------------------------------------------------------------------
 # Ticket Links
 # ---------------------------------------------------------------------------
 

--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -66,6 +66,12 @@ admin_patterns = [
     ),
     # Ticket Merging
     path("admin/tickets/<int:ticket_id>/merge/", admin.ticket_merge, name="admin_ticket_merge"),
+    # Saved Views
+    path("admin/saved-views/", admin.saved_views_index, name="admin_saved_views_index"),
+    path("admin/saved-views/store/", admin.saved_views_store, name="admin_saved_views_store"),
+    path("admin/saved-views/<int:view_id>/update/", admin.saved_views_update, name="admin_saved_views_update"),
+    path("admin/saved-views/<int:view_id>/delete/", admin.saved_views_delete, name="admin_saved_views_delete"),
+    path("admin/saved-views/reorder/", admin.saved_views_reorder, name="admin_saved_views_reorder"),
     # Side Conversations
     path(
         "admin/tickets/<int:ticket_id>/side-conversations/",

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -2355,6 +2355,185 @@ def ticket_merge(request, ticket_id):
 
 
 # ---------------------------------------------------------------------------
+# Saved Views
+# ---------------------------------------------------------------------------
+
+
+@login_required
+def saved_views_index(request):
+    """List saved views for the current user (own + shared)."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    from escalated.models import SavedView
+
+    views = SavedView.objects.filter(Q(user=request.user) | Q(is_shared=True)).order_by("position", "name")
+
+    return JsonResponse(
+        {
+            "views": [
+                {
+                    "id": v.pk,
+                    "name": v.name,
+                    "filters": v.filters,
+                    "is_shared": v.is_shared,
+                    "is_default": v.is_default,
+                    "position": v.position,
+                    "icon": v.icon,
+                    "color": v.color,
+                    "is_own": v.user_id == request.user.pk,
+                }
+                for v in views
+            ]
+        }
+    )
+
+
+@login_required
+def saved_views_store(request):
+    """Create a new saved view."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    name = body.get("name", "").strip()
+    if not name:
+        return JsonResponse({"error": "name is required"}, status=400)
+
+    from escalated.models import SavedView
+
+    view = SavedView.objects.create(
+        name=name,
+        filters=body.get("filters", {}),
+        user=request.user,
+        is_shared=body.get("is_shared", False),
+        is_default=body.get("is_default", False),
+        position=body.get("position", 0),
+        icon=body.get("icon", ""),
+        color=body.get("color", "#6b7280"),
+    )
+
+    return JsonResponse(
+        {
+            "success": True,
+            "view": {
+                "id": view.pk,
+                "name": view.name,
+            },
+        }
+    )
+
+
+@login_required
+def saved_views_update(request, view_id):
+    """Update an existing saved view."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    from escalated.models import SavedView
+
+    try:
+        view = SavedView.objects.get(pk=view_id)
+    except SavedView.DoesNotExist:
+        return HttpResponseNotFound(_("Saved view not found"))
+
+    # Only owner or admin can update
+    if view.user_id != request.user.pk and not request.user.is_superuser:
+        return HttpResponseForbidden(_("Cannot update this view"))
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    if "name" in body:
+        view.name = body["name"]
+    if "filters" in body:
+        view.filters = body["filters"]
+    if "is_shared" in body:
+        view.is_shared = body["is_shared"]
+    if "is_default" in body:
+        view.is_default = body["is_default"]
+    if "position" in body:
+        view.position = body["position"]
+    if "icon" in body:
+        view.icon = body["icon"]
+    if "color" in body:
+        view.color = body["color"]
+
+    view.save()
+
+    return JsonResponse({"success": True})
+
+
+@login_required
+def saved_views_delete(request, view_id):
+    """Delete a saved view."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    from escalated.models import SavedView
+
+    try:
+        view = SavedView.objects.get(pk=view_id)
+    except SavedView.DoesNotExist:
+        return HttpResponseNotFound(_("Saved view not found"))
+
+    if view.user_id != request.user.pk and not request.user.is_superuser:
+        return HttpResponseForbidden(_("Cannot delete this view"))
+
+    view.delete()
+
+    return JsonResponse({"success": True})
+
+
+@login_required
+def saved_views_reorder(request):
+    """Reorder saved views."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    order = body.get("order", [])
+    if not isinstance(order, list):
+        return JsonResponse({"error": "order must be a list of view IDs"}, status=400)
+
+    from escalated.models import SavedView
+
+    for position, view_id in enumerate(order):
+        SavedView.objects.filter(
+            pk=view_id,
+        ).filter(Q(user=request.user) | Q(is_shared=True)).update(position=position)
+
+    return JsonResponse({"success": True})
+
+
+# ---------------------------------------------------------------------------
 # Side Conversations
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_saved_views.py
+++ b/tests/unit/test_saved_views.py
@@ -1,0 +1,109 @@
+import pytest
+
+from escalated.models import SavedView
+from tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+class TestSavedViewModel:
+    def test_create_saved_view(self):
+        user = UserFactory()
+        view = SavedView.objects.create(
+            name="My Open Tickets",
+            filters={"status": "open", "assigned": "me"},
+            user=user,
+        )
+        assert view.pk is not None
+        assert view.name == "My Open Tickets"
+        assert view.filters == {"status": "open", "assigned": "me"}
+        assert view.user == user
+
+    def test_shared_view(self):
+        view = SavedView.objects.create(
+            name="All Urgent",
+            filters={"priority": "urgent"},
+            is_shared=True,
+        )
+        assert view.is_shared is True
+        assert view.user is None
+
+    def test_default_values(self):
+        view = SavedView.objects.create(name="Test View")
+        assert view.filters == {}
+        assert view.is_shared is False
+        assert view.is_default is False
+        assert view.position == 0
+        assert view.icon == ""
+        assert view.color == "#6b7280"
+
+    def test_ordering_by_position_and_name(self):
+        v3 = SavedView.objects.create(name="C View", position=2)
+        v1 = SavedView.objects.create(name="A View", position=0)
+        v2 = SavedView.objects.create(name="B View", position=1)
+
+        views = list(SavedView.objects.all())
+        assert views == [v1, v2, v3]
+
+    def test_str_representation(self):
+        view = SavedView.objects.create(name="My Queue")
+        assert str(view) == "My Queue"
+
+    def test_user_can_have_multiple_views(self):
+        user = UserFactory()
+        SavedView.objects.create(name="View 1", user=user, position=0)
+        SavedView.objects.create(name="View 2", user=user, position=1)
+        assert SavedView.objects.filter(user=user).count() == 2
+
+    def test_is_default_flag(self):
+        user = UserFactory()
+        view = SavedView.objects.create(
+            name="Default View",
+            user=user,
+            is_default=True,
+        )
+        assert view.is_default is True
+
+    def test_icon_and_color(self):
+        view = SavedView.objects.create(
+            name="Styled",
+            icon="inbox",
+            color="#ff5722",
+        )
+        assert view.icon == "inbox"
+        assert view.color == "#ff5722"
+
+    def test_filters_jsonfield(self):
+        filters = {
+            "status": ["open", "in_progress"],
+            "priority": "high",
+            "department_id": 5,
+            "tags": ["bug", "feature"],
+        }
+        view = SavedView.objects.create(name="Complex", filters=filters)
+        view.refresh_from_db()
+        assert view.filters == filters
+
+    def test_delete_user_cascades(self):
+        user = UserFactory()
+        SavedView.objects.create(name="Personal", user=user)
+        assert SavedView.objects.filter(user=user).count() == 1
+
+        user.delete()
+        assert SavedView.objects.filter(name="Personal").count() == 0
+
+    def test_reorder(self):
+        v1 = SavedView.objects.create(name="V1", position=0)
+        v2 = SavedView.objects.create(name="V2", position=1)
+        v3 = SavedView.objects.create(name="V3", position=2)
+
+        # Reorder: V3, V1, V2
+        for pos, pk in enumerate([v3.pk, v1.pk, v2.pk]):
+            SavedView.objects.filter(pk=pk).update(position=pos)
+
+        v1.refresh_from_db()
+        v2.refresh_from_db()
+        v3.refresh_from_db()
+
+        assert v3.position == 0
+        assert v1.position == 1
+        assert v2.position == 2


### PR DESCRIPTION
## Summary
- Add `SavedView` model with name, filters (JSONField), user FK (nullable), is_shared, is_default, position, icon, color fields
- Add migration 0014_saved_views
- Add CRUD views: index, store, update, delete, and reorder endpoints under `/admin/saved-views/`
- Views filter by user's own views + shared views; only owner or superuser can update/delete

## Test plan
- [x] 11 pytest tests covering model creation, shared views, default values, ordering, str representation, multiple views per user, icon/color, complex JSON filters, cascade on user delete, and reorder
- [x] ruff check and format pass