### PR TITLE
feat: add embeddable widget API

### DIFF
--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path
 
 from escalated.conf import get_setting
-from escalated.views import admin, admin_plugins, agent, customer, guest, import_views, inbound
+from escalated.views import admin, admin_plugins, agent, customer, guest, import_views, inbound, widget
 
 app_name = "escalated"
 
@@ -260,13 +260,22 @@ guest_patterns = [
     path("guest/<str:token>/rate/", guest.ticket_rate, name="guest_ticket_rate"),
 ]
 
+# Widget public API (no authentication)
+widget_patterns = [
+    path("widget/config/", widget.widget_config, name="widget_config"),
+    path("widget/articles/search/", widget.widget_article_search, name="widget_article_search"),
+    path("widget/articles/<int:article_id>/", widget.widget_article_detail, name="widget_article_detail"),
+    path("widget/tickets/create/", widget.widget_create_ticket, name="widget_create_ticket"),
+    path("widget/tickets/lookup/", widget.widget_lookup_ticket, name="widget_lookup_ticket"),
+]
+
 # Inbound email webhook (no authentication — external services POST here)
 inbound_patterns = [
     path("inbound/<str:adapter_name>/", inbound.inbound_webhook, name="inbound_webhook"),
 ]
 
 # Core routes (always registered)
-urlpatterns = list(inbound_patterns)
+urlpatterns = list(inbound_patterns) + list(widget_patterns)
 
 # UI routes (only when UI is enabled)
 if get_setting("UI_ENABLED"):

--- a/escalated/views/widget.py
+++ b/escalated/views/widget.py
@@ -1,0 +1,243 @@
+"""
+Public-facing embeddable widget API endpoints.
+
+All endpoints are unauthenticated and intended for use from a JavaScript
+widget embedded on a customer's website.  Rate limiting is applied via
+Django's cache framework to prevent abuse.
+"""
+
+import json
+import time
+
+from django.core.cache import cache
+from django.db.models import Q
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_GET, require_POST
+
+from escalated.conf import get_setting
+from escalated.models import Article, EscalatedSetting, Ticket
+
+# ---------------------------------------------------------------------------
+# Rate limiting helper
+# ---------------------------------------------------------------------------
+
+
+def _rate_limited(request, scope="widget", limit=None, window=60):
+    """
+    Simple per-IP rate limiter backed by the Django cache.
+
+    Returns ``True`` when the request should be rejected.
+    """
+    if limit is None:
+        limit = EscalatedSetting.get_int("widget_rate_limit", default=30)
+
+    ip = request.META.get("REMOTE_ADDR", "unknown")
+    key = f"escalated.ratelimit.{scope}.{ip}"
+    data = cache.get(key)
+
+    now = time.time()
+    if data is None:
+        cache.set(key, {"count": 1, "start": now}, window)
+        return False
+
+    if now - data["start"] > window:
+        cache.set(key, {"count": 1, "start": now}, window)
+        return False
+
+    data["count"] += 1
+    cache.set(key, data, window)
+    return data["count"] > limit
+
+
+def _reject():
+    return JsonResponse({"error": "Rate limit exceeded"}, status=429)
+
+
+def _widget_enabled():
+    return EscalatedSetting.get_bool("widget_enabled", default=True)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@require_GET
+def widget_config(request):
+    """Return public widget configuration."""
+    if not _widget_enabled():
+        return JsonResponse({"error": "Widget is disabled"}, status=403)
+
+    if _rate_limited(request, scope="widget_config"):
+        return _reject()
+
+    return JsonResponse(
+        {
+            "widget_enabled": True,
+            "widget_title": EscalatedSetting.get("widget_title", "Support"),
+            "widget_greeting": EscalatedSetting.get("widget_greeting", "How can we help?"),
+            "widget_accent_color": EscalatedSetting.get("widget_accent_color", "#4f46e5"),
+            "kb_search_enabled": EscalatedSetting.get_bool("widget_kb_search_enabled", default=True),
+            "ticket_creation_enabled": EscalatedSetting.get_bool("widget_ticket_creation_enabled", default=True),
+        }
+    )
+
+
+@require_GET
+def widget_article_search(request):
+    """Search published knowledge-base articles."""
+    if not _widget_enabled():
+        return JsonResponse({"error": "Widget is disabled"}, status=403)
+
+    if _rate_limited(request, scope="widget_search"):
+        return _reject()
+
+    q = request.GET.get("q", "").strip()
+    if not q or len(q) < 2:
+        return JsonResponse({"articles": []})
+
+    articles = (
+        Article.objects.published().filter(Q(title__icontains=q) | Q(body__icontains=q)).order_by("-view_count")[:10]
+    )
+
+    return JsonResponse(
+        {
+            "articles": [
+                {
+                    "id": a.pk,
+                    "title": a.title,
+                    "slug": a.slug,
+                    "excerpt": (a.body[:200] + "...") if len(a.body) > 200 else a.body,
+                }
+                for a in articles
+            ]
+        }
+    )
+
+
+@require_GET
+def widget_article_detail(request, article_id):
+    """Return a single published article."""
+    if not _widget_enabled():
+        return JsonResponse({"error": "Widget is disabled"}, status=403)
+
+    if _rate_limited(request, scope="widget_article"):
+        return _reject()
+
+    try:
+        article = Article.objects.published().get(pk=article_id)
+    except Article.DoesNotExist:
+        return JsonResponse({"error": "Article not found"}, status=404)
+
+    # Increment view count
+    Article.objects.filter(pk=article_id).update(view_count=article.view_count + 1)
+
+    return JsonResponse(
+        {
+            "article": {
+                "id": article.pk,
+                "title": article.title,
+                "slug": article.slug,
+                "body": article.body,
+                "category": article.category.name if article.category else None,
+            }
+        }
+    )
+
+
+@csrf_exempt
+@require_POST
+def widget_create_ticket(request):
+    """Create a ticket from the widget (guest mode)."""
+    if not _widget_enabled():
+        return JsonResponse({"error": "Widget is disabled"}, status=403)
+
+    if not EscalatedSetting.get_bool("widget_ticket_creation_enabled", default=True):
+        return JsonResponse({"error": "Ticket creation is disabled"}, status=403)
+
+    if _rate_limited(request, scope="widget_create", limit=10, window=60):
+        return _reject()
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    name = body.get("name", "").strip()
+    email = body.get("email", "").strip()
+    subject = body.get("subject", "").strip()
+    description = body.get("description", "").strip()
+
+    errors = {}
+    if not name:
+        errors["name"] = "Name is required"
+    if not email:
+        errors["email"] = "Email is required"
+    if not subject:
+        errors["subject"] = "Subject is required"
+    if not description:
+        errors["description"] = "Description is required"
+
+    if errors:
+        return JsonResponse({"errors": errors}, status=400)
+
+    import secrets
+
+    guest_token = secrets.token_hex(32)
+    priority = body.get("priority", get_setting("DEFAULT_PRIORITY"))
+
+    ticket = Ticket.objects.create(
+        requester_content_type=None,
+        requester_object_id=None,
+        guest_name=name,
+        guest_email=email,
+        guest_token=guest_token,
+        subject=subject,
+        description=description,
+        priority=priority,
+        channel="widget",
+    )
+
+    return JsonResponse(
+        {
+            "success": True,
+            "ticket": {
+                "reference": ticket.reference,
+                "guest_token": guest_token,
+            },
+        }
+    )
+
+
+@require_GET
+def widget_lookup_ticket(request):
+    """Look up a guest ticket by reference and email."""
+    if not _widget_enabled():
+        return JsonResponse({"error": "Widget is disabled"}, status=403)
+
+    if _rate_limited(request, scope="widget_lookup", limit=10, window=60):
+        return _reject()
+
+    reference = request.GET.get("reference", "").strip()
+    email = request.GET.get("email", "").strip()
+
+    if not reference or not email:
+        return JsonResponse({"error": "reference and email are required"}, status=400)
+
+    try:
+        ticket = Ticket.objects.get(reference=reference, guest_email=email)
+    except Ticket.DoesNotExist:
+        return JsonResponse({"error": "Ticket not found"}, status=404)
+
+    return JsonResponse(
+        {
+            "ticket": {
+                "reference": ticket.reference,
+                "subject": ticket.subject,
+                "status": ticket.status,
+                "guest_token": ticket.guest_token,
+                "created_at": ticket.created_at.isoformat(),
+            }
+        }
+    )

--- a/tests/unit/test_widget.py
+++ b/tests/unit/test_widget.py
@@ -1,0 +1,198 @@
+import json
+
+import pytest
+from django.core.cache import cache
+
+from escalated.models import EscalatedSetting, Ticket
+from escalated.views.widget import _rate_limited
+from tests.factories import ArticleCategoryFactory, ArticleFactory, TicketFactory
+
+
+class FakeRequest:
+    """Minimal request-like object for testing rate limiting."""
+
+    def __init__(self, ip="127.0.0.1"):
+        self.META = {"REMOTE_ADDR": ip}
+
+
+@pytest.mark.django_db
+class TestRateLimiter:
+    def setup_method(self):
+        cache.clear()
+
+    def test_allows_under_limit(self):
+        req = FakeRequest()
+        assert _rate_limited(req, scope="test", limit=5) is False
+
+    def test_blocks_over_limit(self):
+        req = FakeRequest()
+        for _ in range(5):
+            _rate_limited(req, scope="test_block", limit=5)
+        assert _rate_limited(req, scope="test_block", limit=5) is True
+
+    def test_different_ips_independent(self):
+        req1 = FakeRequest(ip="1.1.1.1")
+        req2 = FakeRequest(ip="2.2.2.2")
+        for _ in range(5):
+            _rate_limited(req1, scope="test_ip", limit=5)
+
+        # req1 should be rate limited, req2 should not
+        assert _rate_limited(req1, scope="test_ip", limit=5) is True
+        assert _rate_limited(req2, scope="test_ip", limit=5) is False
+
+
+@pytest.mark.django_db
+class TestWidgetConfig:
+    def test_returns_config(self, client):
+        response = client.get("/support/widget/config/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["widget_enabled"] is True
+        assert "widget_title" in data
+
+    def test_custom_settings(self, client):
+        EscalatedSetting.set("widget_title", "Help Center")
+        EscalatedSetting.set("widget_accent_color", "#ff0000")
+
+        response = client.get("/support/widget/config/")
+        data = response.json()
+        assert data["widget_title"] == "Help Center"
+        assert data["widget_accent_color"] == "#ff0000"
+
+    def test_disabled_widget(self, client):
+        EscalatedSetting.set("widget_enabled", "false")
+        response = client.get("/support/widget/config/")
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+class TestWidgetArticleSearch:
+    def test_search_articles(self, client):
+        cat = ArticleCategoryFactory()
+        ArticleFactory(category=cat, title="How to reset password", status="published")
+        ArticleFactory(category=cat, title="Billing FAQ", status="published")
+
+        response = client.get("/support/widget/articles/search/?q=reset")
+        data = response.json()
+        assert len(data["articles"]) == 1
+        assert data["articles"][0]["title"] == "How to reset password"
+
+    def test_empty_query(self, client):
+        response = client.get("/support/widget/articles/search/?q=")
+        data = response.json()
+        assert data["articles"] == []
+
+    def test_short_query(self, client):
+        response = client.get("/support/widget/articles/search/?q=a")
+        data = response.json()
+        assert data["articles"] == []
+
+    def test_excludes_draft_articles(self, client):
+        cat = ArticleCategoryFactory()
+        ArticleFactory(category=cat, title="Draft Article", status="draft")
+
+        response = client.get("/support/widget/articles/search/?q=Draft")
+        data = response.json()
+        assert len(data["articles"]) == 0
+
+
+@pytest.mark.django_db
+class TestWidgetArticleDetail:
+    def test_get_published_article(self, client):
+        cat = ArticleCategoryFactory()
+        article = ArticleFactory(category=cat, title="Test Article", status="published")
+
+        response = client.get(f"/support/widget/articles/{article.pk}/")
+        data = response.json()
+        assert data["article"]["title"] == "Test Article"
+
+    def test_increments_view_count(self, client):
+        cat = ArticleCategoryFactory()
+        article = ArticleFactory(category=cat, status="published", view_count=5)
+
+        client.get(f"/support/widget/articles/{article.pk}/")
+        article.refresh_from_db()
+        assert article.view_count == 6
+
+    def test_draft_returns_404(self, client):
+        cat = ArticleCategoryFactory()
+        article = ArticleFactory(category=cat, status="draft")
+
+        response = client.get(f"/support/widget/articles/{article.pk}/")
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestWidgetCreateTicket:
+    def test_create_ticket(self, client):
+        response = client.post(
+            "/support/widget/tickets/create/",
+            data=json.dumps(
+                {
+                    "name": "John Doe",
+                    "email": "john@example.com",
+                    "subject": "Help me",
+                    "description": "I need help with something",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert "reference" in data["ticket"]
+        assert "guest_token" in data["ticket"]
+
+        # Verify ticket created
+        ticket = Ticket.objects.get(reference=data["ticket"]["reference"])
+        assert ticket.guest_name == "John Doe"
+        assert ticket.guest_email == "john@example.com"
+        assert ticket.channel == "widget"
+
+    def test_validation_errors(self, client):
+        response = client.post(
+            "/support/widget/tickets/create/",
+            data=json.dumps({"name": "", "email": "", "subject": "", "description": ""}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert "errors" in data
+        assert "name" in data["errors"]
+
+    def test_disabled_ticket_creation(self, client):
+        EscalatedSetting.set("widget_ticket_creation_enabled", "false")
+        response = client.post(
+            "/support/widget/tickets/create/",
+            data=json.dumps(
+                {
+                    "name": "Test",
+                    "email": "test@example.com",
+                    "subject": "Test",
+                    "description": "Test",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+class TestWidgetLookupTicket:
+    def test_lookup_by_reference_and_email(self, client):
+        ticket = TicketFactory(guest_email="john@example.com")
+
+        response = client.get(f"/support/widget/tickets/lookup/?reference={ticket.reference}&email=john@example.com")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ticket"]["reference"] == ticket.reference
+
+    def test_wrong_email_returns_404(self, client):
+        ticket = TicketFactory(guest_email="john@example.com")
+
+        response = client.get(f"/support/widget/tickets/lookup/?reference={ticket.reference}&email=wrong@example.com")
+        assert response.status_code == 404
+
+    def test_missing_params(self, client):
+        response = client.get("/support/widget/tickets/lookup/")
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary
- Add `escalated.views.widget` with public endpoints: config, article search, article detail, create ticket, lookup ticket
- URLs registered under `/widget/` (always available, no auth required)
- Per-IP rate limiting via Django cache (configurable via `widget_rate_limit` setting)
- Widget settings: `widget_enabled`, `widget_title`, `widget_greeting`, `widget_accent_color`, `widget_kb_search_enabled`, `widget_ticket_creation_enabled`
- Ticket creation uses guest mode (no auth), sets channel to "widget"

## Test plan
- [x] 19 pytest tests covering: rate limiter (under/over limit, per-IP isolation), config endpoint with custom settings and disabled state, article search (results, empty query, draft exclusion), article detail with view count increment, ticket creation with validation and disabled state, lookup by reference+email with error cases
- [x] ruff check and format pass