### PR TITLE
feat: add knowledge base toggle settings

### DIFF
--- a/escalated/kb_guards.py
+++ b/escalated/kb_guards.py
@@ -1,0 +1,40 @@
+"""
+Knowledge base toggle guards.
+
+Provides settings and a decorator to conditionally enable/disable KB views
+based on EscalatedSetting values.
+"""
+
+from functools import wraps
+
+from django.http import HttpResponseNotFound
+from django.utils.translation import gettext as _
+
+from escalated.models import EscalatedSetting
+
+
+def kb_enabled():
+    """Check if the knowledge base is enabled."""
+    return EscalatedSetting.get_bool("knowledge_base_enabled", default=True)
+
+
+def kb_public():
+    """Check if the knowledge base is publicly accessible (no login required)."""
+    return EscalatedSetting.get_bool("knowledge_base_public", default=False)
+
+
+def kb_feedback_enabled():
+    """Check if the helpful/not-helpful feedback is enabled on articles."""
+    return EscalatedSetting.get_bool("knowledge_base_feedback_enabled", default=True)
+
+
+def require_kb_enabled(view_func):
+    """Decorator that returns 404 if the knowledge base is disabled."""
+
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        if not kb_enabled():
+            return HttpResponseNotFound(_("Knowledge base is not available."))
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
 
+from escalated.kb_guards import require_kb_enabled
 from escalated.models import (
     AgentCapacity,
     Article,
@@ -2513,6 +2514,7 @@ def side_conversations_close(request, ticket_id, conversation_id):
 # ---------------------------------------------------------------------------
 
 
+@require_kb_enabled
 @login_required
 def articles_index(request):
     """List all KB articles with filters."""
@@ -2559,6 +2561,7 @@ def articles_index(request):
     )
 
 
+@require_kb_enabled
 @login_required
 def articles_create(request):
     """Create a new KB article."""
@@ -2605,6 +2608,7 @@ def articles_create(request):
     )
 
 
+@require_kb_enabled
 @login_required
 def articles_edit(request, article_id):
     """Edit a KB article."""
@@ -2643,6 +2647,7 @@ def articles_edit(request, article_id):
     )
 
 
+@require_kb_enabled
 @login_required
 def articles_delete(request, article_id):
     """Delete a KB article."""
@@ -2667,6 +2672,7 @@ def articles_delete(request, article_id):
 # ---------------------------------------------------------------------------
 
 
+@require_kb_enabled
 @login_required
 def kb_categories_index(request):
     """List all KB categories with article counts."""
@@ -2685,6 +2691,7 @@ def kb_categories_index(request):
     )
 
 
+@require_kb_enabled
 @login_required
 def kb_categories_store(request):
     """Create a new KB category."""
@@ -2712,6 +2719,7 @@ def kb_categories_store(request):
     return redirect("escalated:admin_kb_categories_index")
 
 
+@require_kb_enabled
 @login_required
 def kb_categories_update(request, category_id):
     """Update a KB category."""
@@ -2740,6 +2748,7 @@ def kb_categories_update(request, category_id):
     return redirect("escalated:admin_kb_categories_index")
 
 
+@require_kb_enabled
 @login_required
 def kb_categories_delete(request, category_id):
     """Delete a KB category."""

--- a/tests/unit/test_kb_toggle.py
+++ b/tests/unit/test_kb_toggle.py
@@ -1,0 +1,80 @@
+import pytest
+from django.http import HttpResponseNotFound
+from django.test import RequestFactory
+
+from escalated.kb_guards import (
+    kb_enabled,
+    kb_feedback_enabled,
+    kb_public,
+    require_kb_enabled,
+)
+from escalated.models import EscalatedSetting
+
+
+@pytest.mark.django_db
+class TestKbSettings:
+    def test_kb_enabled_default_true(self):
+        assert kb_enabled() is True
+
+    def test_kb_enabled_set_false(self):
+        EscalatedSetting.set("knowledge_base_enabled", "false")
+        assert kb_enabled() is False
+
+    def test_kb_enabled_set_true(self):
+        EscalatedSetting.set("knowledge_base_enabled", "true")
+        assert kb_enabled() is True
+
+    def test_kb_public_default_false(self):
+        assert kb_public() is False
+
+    def test_kb_public_set_true(self):
+        EscalatedSetting.set("knowledge_base_public", "true")
+        assert kb_public() is True
+
+    def test_kb_feedback_enabled_default_true(self):
+        assert kb_feedback_enabled() is True
+
+    def test_kb_feedback_enabled_set_false(self):
+        EscalatedSetting.set("knowledge_base_feedback_enabled", "false")
+        assert kb_feedback_enabled() is False
+
+
+@pytest.mark.django_db
+class TestRequireKbEnabledDecorator:
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    def _make_view(self):
+        @require_kb_enabled
+        def my_view(request):
+            from django.http import JsonResponse
+
+            return JsonResponse({"ok": True})
+
+        return my_view
+
+    def test_allows_when_enabled(self):
+        EscalatedSetting.set("knowledge_base_enabled", "true")
+        view = self._make_view()
+        request = self.factory.get("/test/")
+        response = view(request)
+        assert response.status_code == 200
+
+    def test_blocks_when_disabled(self):
+        EscalatedSetting.set("knowledge_base_enabled", "false")
+        view = self._make_view()
+        request = self.factory.get("/test/")
+        response = view(request)
+        assert response.status_code == 404
+        assert isinstance(response, HttpResponseNotFound)
+
+    def test_allows_by_default(self):
+        # No setting set, should default to enabled
+        view = self._make_view()
+        request = self.factory.get("/test/")
+        response = view(request)
+        assert response.status_code == 200
+
+    def test_preserves_function_name(self):
+        view = self._make_view()
+        assert view.__name__ == "my_view"


### PR DESCRIPTION
## Summary
- Add `escalated.kb_guards` module with `kb_enabled()`, `kb_public()`, `kb_feedback_enabled()` helpers reading from EscalatedSetting
- Add `@require_kb_enabled` decorator that returns 404 when the KB is disabled
- Apply the guard to all 8 KB admin views: articles index/create/edit/delete, categories index/store/update/delete

## Test plan
- [x] 11 pytest tests covering: default setting values, toggling each setting, decorator allowing/blocking requests, default behavior without settings, and function name preservation via `@wraps`
- [x] ruff check and format pass