### PR TITLE
feat: add real-time broadcasting support

### DIFF
--- a/escalated/broadcasting.py
+++ b/escalated/broadcasting.py
@@ -1,0 +1,216 @@
+"""
+Real-time broadcasting support for Escalated.
+
+Emits events that can be consumed by Django Channels or other real-time
+backends.  Broadcasting is opt-in via the ESCALATED_BROADCASTING_ENABLED
+setting (defaults to ``False``).
+
+When enabled, signal handlers for ticket lifecycle events will call
+``broadcast_event()`` which dispatches to the configured backend.
+The default backend writes to the Django cache for polling; when Django
+Channels is installed, it sends to a channel layer group.
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+
+logger = logging.getLogger("escalated.broadcasting")
+
+
+def broadcasting_enabled():
+    """Check if broadcasting is enabled."""
+    return getattr(settings, "ESCALATED_BROADCASTING_ENABLED", False)
+
+
+def get_channel_layer():
+    """
+    Attempt to import and return the Django Channels default channel layer.
+    Returns ``None`` if channels is not installed or not configured.
+    """
+    try:
+        from channels.layers import get_channel_layer as _get_layer
+
+        layer = _get_layer()
+        return layer
+    except (ImportError, Exception):
+        return None
+
+
+def broadcast_event(event_type, channel, payload):
+    """
+    Broadcast an event to a named channel.
+
+    If Django Channels is available and configured, the event is sent to a
+    channel-layer group.  Otherwise it is pushed to a cache-backed list
+    that can be polled via ``get_pending_events()``.
+
+    Args:
+        event_type: Short string identifying the event (e.g. "ticket.created").
+        channel: The channel/group name (e.g. "ticket.42").
+        payload: JSON-serializable dict of event data.
+    """
+    if not broadcasting_enabled():
+        return
+
+    event = {
+        "type": "escalated.event",
+        "event_type": event_type,
+        "channel": channel,
+        "payload": payload,
+    }
+
+    layer = get_channel_layer()
+    if layer is not None:
+        from asgiref.sync import async_to_sync
+
+        try:
+            async_to_sync(layer.group_send)(channel, event)
+            logger.debug("Broadcast %s to channel layer group %s", event_type, channel)
+            return
+        except Exception as exc:
+            logger.warning("Channel layer send failed: %s", exc)
+
+    # Fallback: cache-backed event list (for polling or testing)
+    cache_key = f"escalated.broadcast.{channel}"
+    events = cache.get(cache_key, [])
+    events.append(event)
+    # Keep a bounded list and 5-minute TTL
+    cache.set(cache_key, events[-100:], 300)
+    logger.debug("Broadcast %s to cache key %s", event_type, cache_key)
+
+
+def get_pending_events(channel):
+    """
+    Retrieve and clear pending events for a channel (cache backend only).
+
+    Useful for testing and for simple polling endpoints.
+    """
+    cache_key = f"escalated.broadcast.{channel}"
+    events = cache.get(cache_key, [])
+    cache.delete(cache_key)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Signal handlers
+# ---------------------------------------------------------------------------
+
+
+def on_ticket_created(sender, **kwargs):
+    ticket = kwargs.get("ticket")
+    if ticket is None:
+        return
+    broadcast_event(
+        "ticket.created",
+        f"ticket.{ticket.pk}",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "subject": ticket.subject,
+            "status": ticket.status,
+        },
+    )
+
+
+def on_ticket_updated(sender, **kwargs):
+    ticket = kwargs.get("ticket")
+    changes = kwargs.get("changes", {})
+    if ticket is None:
+        return
+    broadcast_event(
+        "ticket.updated",
+        f"ticket.{ticket.pk}",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "changes": changes,
+        },
+    )
+
+
+def on_ticket_status_changed(sender, **kwargs):
+    ticket = kwargs.get("ticket")
+    if ticket is None:
+        return
+    broadcast_event(
+        "ticket.status_changed",
+        f"ticket.{ticket.pk}",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "old_status": kwargs.get("old_status"),
+            "new_status": kwargs.get("new_status"),
+        },
+    )
+
+
+def on_ticket_assigned(sender, **kwargs):
+    ticket = kwargs.get("ticket")
+    agent = kwargs.get("agent")
+    if ticket is None:
+        return
+    broadcast_event(
+        "ticket.assigned",
+        f"ticket.{ticket.pk}",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "agent_id": agent.pk if agent else None,
+        },
+    )
+
+
+def on_reply_created(sender, **kwargs):
+    reply = kwargs.get("reply")
+    ticket = kwargs.get("ticket")
+    if ticket is None:
+        return
+    broadcast_event(
+        "reply.created",
+        f"ticket.{ticket.pk}",
+        {
+            "ticket_id": ticket.pk,
+            "reply_id": reply.pk if reply else None,
+            "is_internal": reply.is_internal_note if reply else False,
+        },
+    )
+
+
+def connect_signals():
+    """
+    Connect broadcasting signal handlers.
+
+    Should be called from AppConfig.ready() when broadcasting is enabled.
+    """
+    from escalated.signals import (
+        reply_created,
+        ticket_assigned,
+        ticket_created,
+        ticket_status_changed,
+        ticket_updated,
+    )
+
+    ticket_created.connect(on_ticket_created)
+    ticket_updated.connect(on_ticket_updated)
+    ticket_status_changed.connect(on_ticket_status_changed)
+    ticket_assigned.connect(on_ticket_assigned)
+    reply_created.connect(on_reply_created)
+
+
+def disconnect_signals():
+    """Disconnect broadcasting signal handlers (useful in tests)."""
+    from escalated.signals import (
+        reply_created,
+        ticket_assigned,
+        ticket_created,
+        ticket_status_changed,
+        ticket_updated,
+    )
+
+    ticket_created.disconnect(on_ticket_created)
+    ticket_updated.disconnect(on_ticket_updated)
+    ticket_status_changed.disconnect(on_ticket_status_changed)
+    ticket_assigned.disconnect(on_ticket_assigned)
+    reply_created.disconnect(on_reply_created)

--- a/escalated/channel_routing.py
+++ b/escalated/channel_routing.py
@@ -1,0 +1,68 @@
+"""
+Django Channels routing for Escalated real-time events.
+
+Usage (in your project's routing.py):
+
+    from channels.routing import ProtocolTypeRouter, URLRouter
+    from escalated.channel_routing import websocket_urlpatterns
+
+    application = ProtocolTypeRouter({
+        "websocket": URLRouter(websocket_urlpatterns),
+    })
+
+This module only defines the URL patterns; the consumer implementation
+follows.  If Django Channels is not installed, this module is a no-op.
+"""
+
+websocket_urlpatterns = []
+
+try:
+    from channels.generic.websocket import JsonWebsocketConsumer
+
+    class EscalatedEventConsumer(JsonWebsocketConsumer):
+        """
+        WebSocket consumer for Escalated real-time events.
+
+        Clients connect and join a group for a specific ticket
+        (e.g. ``/ws/escalated/ticket/42/``).
+        """
+
+        def connect(self):
+            self.ticket_id = self.scope["url_route"]["kwargs"]["ticket_id"]
+            self.group_name = f"ticket.{self.ticket_id}"
+
+            # Authorization: user must be authenticated
+            user = self.scope.get("user")
+            if user is None or not user.is_authenticated:
+                self.close()
+                return
+
+            from asgiref.sync import async_to_sync
+
+            async_to_sync(self.channel_layer.group_add)(self.group_name, self.channel_name)
+            self.accept()
+
+        def disconnect(self, close_code):
+            if hasattr(self, "group_name"):
+                from asgiref.sync import async_to_sync
+
+                async_to_sync(self.channel_layer.group_discard)(self.group_name, self.channel_name)
+
+        def escalated_event(self, event):
+            """Handle an event broadcast to this group."""
+            self.send_json(
+                {
+                    "event_type": event.get("event_type"),
+                    "payload": event.get("payload"),
+                }
+            )
+
+    from django.urls import re_path
+
+    websocket_urlpatterns = [
+        re_path(r"ws/escalated/ticket/(?P<ticket_id>\d+)/$", EscalatedEventConsumer.as_asgi()),
+    ]
+
+except ImportError:
+    # Django Channels not installed — routing is empty, which is fine.
+    pass

--- a/tests/unit/test_broadcasting.py
+++ b/tests/unit/test_broadcasting.py
@@ -1,0 +1,162 @@
+import pytest
+from django.core.cache import cache
+
+from escalated.broadcasting import (
+    broadcast_event,
+    broadcasting_enabled,
+    connect_signals,
+    disconnect_signals,
+    get_pending_events,
+    on_reply_created,
+    on_ticket_assigned,
+    on_ticket_created,
+    on_ticket_status_changed,
+    on_ticket_updated,
+)
+from tests.factories import ReplyFactory, TicketFactory, UserFactory
+
+
+class TestBroadcastingEnabled:
+    def test_disabled_by_default(self, settings):
+        if hasattr(settings, "ESCALATED_BROADCASTING_ENABLED"):
+            del settings.ESCALATED_BROADCASTING_ENABLED
+        assert broadcasting_enabled() is False
+
+    def test_enabled_when_set(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        assert broadcasting_enabled() is True
+
+    def test_disabled_when_false(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = False
+        assert broadcasting_enabled() is False
+
+
+class TestBroadcastEvent:
+    def setup_method(self):
+        cache.clear()
+
+    def test_no_op_when_disabled(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = False
+        broadcast_event("test.event", "test_channel", {"key": "value"})
+        events = get_pending_events("test_channel")
+        assert len(events) == 0
+
+    def test_caches_event_when_enabled(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        broadcast_event("test.event", "test_channel", {"key": "value"})
+        events = get_pending_events("test_channel")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "test.event"
+        assert events[0]["payload"] == {"key": "value"}
+
+    def test_get_pending_clears_events(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        broadcast_event("test.event", "channel1", {"key": "val"})
+        events = get_pending_events("channel1")
+        assert len(events) == 1
+
+        # Second call should be empty
+        events2 = get_pending_events("channel1")
+        assert len(events2) == 0
+
+    def test_multiple_events_on_same_channel(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        broadcast_event("e1", "ch", {"a": 1})
+        broadcast_event("e2", "ch", {"b": 2})
+        events = get_pending_events("ch")
+        assert len(events) == 2
+        assert events[0]["event_type"] == "e1"
+        assert events[1]["event_type"] == "e2"
+
+    def test_different_channels_isolated(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        broadcast_event("e1", "ch1", {"a": 1})
+        broadcast_event("e2", "ch2", {"b": 2})
+        assert len(get_pending_events("ch1")) == 1
+        assert len(get_pending_events("ch2")) == 1
+
+    def test_bounded_list(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        for i in range(150):
+            broadcast_event(f"e{i}", "bounded", {"i": i})
+        events = get_pending_events("bounded")
+        assert len(events) == 100  # Bounded to 100
+
+
+@pytest.mark.django_db
+class TestSignalHandlers:
+    def setup_method(self):
+        cache.clear()
+
+    def test_on_ticket_created(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        ticket = TicketFactory()
+        on_ticket_created(sender=None, ticket=ticket)
+
+        events = get_pending_events(f"ticket.{ticket.pk}")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "ticket.created"
+        assert events[0]["payload"]["ticket_id"] == ticket.pk
+
+    def test_on_ticket_updated(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        ticket = TicketFactory()
+        on_ticket_updated(sender=None, ticket=ticket, changes={"subject": "New"})
+
+        events = get_pending_events(f"ticket.{ticket.pk}")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "ticket.updated"
+        assert events[0]["payload"]["changes"] == {"subject": "New"}
+
+    def test_on_ticket_status_changed(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        ticket = TicketFactory()
+        on_ticket_status_changed(sender=None, ticket=ticket, old_status="open", new_status="closed")
+
+        events = get_pending_events(f"ticket.{ticket.pk}")
+        assert len(events) == 1
+        assert events[0]["payload"]["old_status"] == "open"
+        assert events[0]["payload"]["new_status"] == "closed"
+
+    def test_on_ticket_assigned(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        ticket = TicketFactory()
+        agent = UserFactory()
+        on_ticket_assigned(sender=None, ticket=ticket, agent=agent)
+
+        events = get_pending_events(f"ticket.{ticket.pk}")
+        assert len(events) == 1
+        assert events[0]["payload"]["agent_id"] == agent.pk
+
+    def test_on_reply_created(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        ticket = TicketFactory()
+        reply = ReplyFactory(ticket=ticket, is_internal_note=False)
+        on_reply_created(sender=None, reply=reply, ticket=ticket)
+
+        events = get_pending_events(f"ticket.{ticket.pk}")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "reply.created"
+        assert events[0]["payload"]["reply_id"] == reply.pk
+
+    def test_handler_ignores_none_ticket(self, settings):
+        settings.ESCALATED_BROADCASTING_ENABLED = True
+        # Should not raise
+        on_ticket_created(sender=None, ticket=None)
+        on_ticket_updated(sender=None, ticket=None)
+        on_ticket_status_changed(sender=None, ticket=None)
+        on_ticket_assigned(sender=None, ticket=None)
+        on_reply_created(sender=None, reply=None, ticket=None)
+
+
+@pytest.mark.django_db
+class TestConnectDisconnect:
+    def test_connect_and_disconnect(self):
+        # Should not raise
+        connect_signals()
+        disconnect_signals()
+
+    def test_connect_idempotent(self):
+        connect_signals()
+        connect_signals()
+        disconnect_signals()


### PR DESCRIPTION
## Summary
- Add `escalated.broadcasting` module with `broadcast_event()`, `get_pending_events()`, and signal handlers for ticket lifecycle events
- Config: `ESCALATED_BROADCASTING_ENABLED` (default `False`) -- opt-in
- Dual backend: sends to Django Channels channel layer group when available, falls back to cache-backed event list for polling/testing
- Signal handlers: `on_ticket_created`, `on_ticket_updated`, `on_ticket_status_changed`, `on_ticket_assigned`, `on_reply_created`
- `connect_signals()` / `disconnect_signals()` for wiring into AppConfig.ready()
- Add `escalated.channel_routing` with `EscalatedEventConsumer` WebSocket consumer and URL patterns for Django Channels integration (gracefully no-ops if Channels not installed)

## Test plan
- [x] 17 pytest tests covering: broadcasting enabled/disabled flag, event caching when enabled, no-op when disabled, pending events clear after read, multiple events on same channel, channel isolation, bounded list (100 max), all 5 signal handlers, None ticket handling, connect/disconnect idempotency
- [x] ruff check and format pass