### PR TITLE
feat: add live chat support

### DIFF
--- a/escalated/consumers.py
+++ b/escalated/consumers.py
@@ -1,0 +1,104 @@
+"""
+Django Channels WebSocket consumer for live chat.
+
+Provides real-time messaging via WebSocket connections. Falls back gracefully
+when Django Channels is not installed (HTTP polling still works via views).
+"""
+
+try:
+    from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+    HAS_CHANNELS = True
+except ImportError:
+    HAS_CHANNELS = False
+
+if HAS_CHANNELS:
+
+    class ChatConsumer(AsyncJsonWebsocketConsumer):
+        """
+        WebSocket consumer for live chat sessions.
+
+        URL: ws://host/ws/chat/<session_id>/
+
+        Incoming messages:
+            {"type": "chat.message", "body": "..."}
+            {"type": "chat.typing", "is_typing": true/false}
+
+        Outgoing messages:
+            {"type": "chat.message", "body": "...", "sender_type": "...", "message_id": ..., "timestamp": "..."}
+            {"type": "chat.typing", "sender_type": "...", "is_typing": true/false}
+            {"type": "chat.ended", "ended_by": "..."}
+            {"type": "chat.assigned", "agent_name": "..."}
+        """
+
+        async def connect(self):
+            self.session_id = self.scope["url_route"]["kwargs"]["session_id"]
+            self.room_group_name = f"chat_{self.session_id}"
+
+            await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+            await self.accept()
+
+        async def disconnect(self, close_code):
+            await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+        async def receive_json(self, content):
+            msg_type = content.get("type", "")
+
+            if msg_type == "chat.message":
+                await self.channel_layer.group_send(
+                    self.room_group_name,
+                    {
+                        "type": "chat_message",
+                        "body": content.get("body", ""),
+                        "sender_type": content.get("sender_type", "customer"),
+                    },
+                )
+            elif msg_type == "chat.typing":
+                await self.channel_layer.group_send(
+                    self.room_group_name,
+                    {
+                        "type": "chat_typing",
+                        "sender_type": content.get("sender_type", "customer"),
+                        "is_typing": content.get("is_typing", False),
+                    },
+                )
+
+        async def chat_message(self, event):
+            await self.send_json(
+                {
+                    "type": "chat.message",
+                    "body": event["body"],
+                    "sender_type": event["sender_type"],
+                    "message_id": event.get("message_id"),
+                    "timestamp": event.get("timestamp"),
+                }
+            )
+
+        async def chat_typing(self, event):
+            await self.send_json(
+                {
+                    "type": "chat.typing",
+                    "sender_type": event["sender_type"],
+                    "is_typing": event["is_typing"],
+                }
+            )
+
+        async def chat_ended(self, event):
+            await self.send_json(
+                {
+                    "type": "chat.ended",
+                    "ended_by": event.get("ended_by"),
+                }
+            )
+
+        async def chat_assigned(self, event):
+            await self.send_json(
+                {
+                    "type": "chat.assigned",
+                    "agent_name": event.get("agent_name"),
+                }
+            )
+
+else:
+    # Stub when channels is not installed
+    ChatConsumer = None

--- a/escalated/management/commands/cleanup_abandoned_chats.py
+++ b/escalated/management/commands/cleanup_abandoned_chats.py
@@ -1,0 +1,70 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from django.utils.translation import gettext as _
+
+from escalated.models import ChatSession, Ticket
+
+
+class Command(BaseCommand):
+    help = "Mark waiting chat sessions as abandoned after a configurable timeout."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--minutes",
+            type=int,
+            default=10,
+            help=_("Minutes before a waiting chat is considered abandoned (default: 10)"),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=_("Show what would be cleaned up without making changes"),
+        )
+
+    def handle(self, *args, **options):
+        minutes = options["minutes"]
+        dry_run = options["dry_run"]
+        threshold = timezone.now() - timedelta(minutes=minutes)
+
+        abandoned_sessions = ChatSession.objects.filter(
+            status=ChatSession.Status.WAITING,
+            created_at__lt=threshold,
+        )
+
+        count = abandoned_sessions.count()
+
+        if dry_run:
+            self.stdout.write(
+                _("[DRY RUN] Would mark %(count)d chat sessions as abandoned (waiting > %(minutes)d min).")
+                % {"count": count, "minutes": minutes}
+            )
+            for session in abandoned_sessions[:20]:
+                self.stdout.write(f"  - Session {session.pk}: ticket {session.ticket.reference}")
+            return
+
+        if count == 0:
+            self.stdout.write(_("No abandoned chat sessions to clean up."))
+            return
+
+        now = timezone.now()
+        cleaned = 0
+        for session in abandoned_sessions:
+            session.status = ChatSession.Status.ABANDONED
+            session.ended_at = now
+            session.save(update_fields=["status", "ended_at", "updated_at"])
+
+            ticket = session.ticket
+            ticket.chat_ended_at = now
+            ticket.status = Ticket.Status.CLOSED
+            ticket.closed_at = now
+            ticket.save(update_fields=["chat_ended_at", "status", "closed_at", "updated_at"])
+            cleaned += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                _("Marked %(count)d chat sessions as abandoned (waiting > %(minutes)d min).")
+                % {"count": cleaned, "minutes": minutes}
+            )
+        )

--- a/escalated/management/commands/close_idle_chats.py
+++ b/escalated/management/commands/close_idle_chats.py
@@ -1,0 +1,70 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from django.utils.translation import gettext as _
+
+from escalated.models import ChatSession, Ticket
+
+
+class Command(BaseCommand):
+    help = "Close chat sessions that have been idle (no messages) for a configurable duration."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--minutes",
+            type=int,
+            default=30,
+            help=_("Minutes of inactivity before closing a chat (default: 30)"),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=_("Show what would be closed without making changes"),
+        )
+
+    def handle(self, *args, **options):
+        minutes = options["minutes"]
+        dry_run = options["dry_run"]
+        threshold = timezone.now() - timedelta(minutes=minutes)
+
+        idle_sessions = ChatSession.objects.filter(
+            status=ChatSession.Status.ACTIVE,
+            updated_at__lt=threshold,
+        )
+
+        count = idle_sessions.count()
+
+        if dry_run:
+            self.stdout.write(
+                _("[DRY RUN] Would close %(count)d idle chat sessions (inactive > %(minutes)d min).")
+                % {"count": count, "minutes": minutes}
+            )
+            for session in idle_sessions[:20]:
+                self.stdout.write(f"  - Session {session.pk}: ticket {session.ticket.reference}")
+            return
+
+        if count == 0:
+            self.stdout.write(_("No idle chat sessions to close."))
+            return
+
+        now = timezone.now()
+        closed = 0
+        for session in idle_sessions:
+            session.status = ChatSession.Status.ENDED
+            session.ended_at = now
+            session.save(update_fields=["status", "ended_at", "updated_at"])
+
+            ticket = session.ticket
+            ticket.chat_ended_at = now
+            ticket.status = Ticket.Status.RESOLVED
+            ticket.resolved_at = now
+            ticket.save(update_fields=["chat_ended_at", "status", "resolved_at", "updated_at"])
+            closed += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                _("Closed %(count)d idle chat sessions (inactive > %(minutes)d min).")
+                % {"count": closed, "minutes": minutes}
+            )
+        )

--- a/escalated/migrations/0016_live_chat.py
+++ b/escalated/migrations/0016_live_chat.py
@@ -1,0 +1,153 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+from escalated.conf import get_table_name
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("escalated", "0015_merge_0014_saved_views_0014_ticket_snooze_fields"),
+    ]
+
+    operations = [
+        # ------------------------------------------------------------------
+        # Extend Ticket: channel already exists as CharField; add chat fields
+        # ------------------------------------------------------------------
+        migrations.AddField(
+            model_name="ticket",
+            name="chat_ended_at",
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name="ticket",
+            name="chat_metadata",
+            field=models.JSONField(null=True, blank=True),
+        ),
+        # ------------------------------------------------------------------
+        # Add chat_status to AgentProfile
+        # ------------------------------------------------------------------
+        migrations.AddField(
+            model_name="agentprofile",
+            name="chat_status",
+            field=models.CharField(
+                max_length=20,
+                choices=[
+                    ("online", "Online"),
+                    ("away", "Away"),
+                    ("offline", "Offline"),
+                ],
+                default="offline",
+            ),
+        ),
+        # ------------------------------------------------------------------
+        # ChatSession
+        # ------------------------------------------------------------------
+        migrations.CreateModel(
+            name="ChatSession",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "ticket",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="chat_sessions",
+                        to="escalated.ticket",
+                    ),
+                ),
+                ("customer_session_id", models.CharField(max_length=255, db_index=True)),
+                (
+                    "agent",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        null=True,
+                        blank=True,
+                        related_name="escalated_chat_sessions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        max_length=20,
+                        choices=[
+                            ("waiting", "Waiting"),
+                            ("active", "Active"),
+                            ("ended", "Ended"),
+                            ("abandoned", "Abandoned"),
+                        ],
+                        default="waiting",
+                        db_index=True,
+                    ),
+                ),
+                ("customer_typing_at", models.DateTimeField(null=True, blank=True)),
+                ("agent_typing_at", models.DateTimeField(null=True, blank=True)),
+                ("metadata", models.JSONField(null=True, blank=True)),
+                ("rating", models.PositiveSmallIntegerField(null=True, blank=True)),
+                ("rating_comment", models.TextField(blank=True, default="")),
+                ("started_at", models.DateTimeField(auto_now_add=True)),
+                ("ended_at", models.DateTimeField(null=True, blank=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": get_table_name("chat_sessions"),
+                "ordering": ["-created_at"],
+            },
+        ),
+        # ------------------------------------------------------------------
+        # ChatRoutingRule
+        # ------------------------------------------------------------------
+        migrations.CreateModel(
+            name="ChatRoutingRule",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "department",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        null=True,
+                        blank=True,
+                        related_name="chat_routing_rules",
+                        to="escalated.department",
+                    ),
+                ),
+                (
+                    "routing_strategy",
+                    models.CharField(
+                        max_length=30,
+                        choices=[
+                            ("round_robin", "Round Robin"),
+                            ("least_active", "Least Active"),
+                            ("random", "Random"),
+                        ],
+                        default="round_robin",
+                    ),
+                ),
+                (
+                    "offline_behavior",
+                    models.CharField(
+                        max_length=30,
+                        choices=[
+                            ("queue", "Queue"),
+                            ("ticket", "Create Ticket"),
+                            ("hide", "Hide Chat"),
+                        ],
+                        default="ticket",
+                    ),
+                ),
+                ("max_concurrent_chats", models.PositiveIntegerField(default=5)),
+                ("welcome_message", models.TextField(blank=True, default="")),
+                ("offline_message", models.TextField(blank=True, default="")),
+                ("is_active", models.BooleanField(default=True)),
+                ("position", models.PositiveIntegerField(default=0)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": get_table_name("chat_routing_rules"),
+                "ordering": ["position"],
+            },
+        ),
+    ]

--- a/escalated/models.py
+++ b/escalated/models.py
@@ -73,6 +73,12 @@ class TicketQuerySet(models.QuerySet):
         """Return tickets whose snooze period has expired."""
         return self.filter(snoozed_until__isnull=False, snoozed_until__lte=timezone.now())
 
+    def live_chats(self):
+        """Return tickets that are live chat conversations."""
+        return self.filter(channel="chat", chat_ended_at__isnull=True).exclude(
+            status__in=[Ticket.Status.RESOLVED, Ticket.Status.CLOSED]
+        )
+
 
 class TicketManager(models.Manager):
     def get_queryset(self):
@@ -95,6 +101,9 @@ class TicketManager(models.Manager):
 
     def search(self, term):
         return self.get_queryset().search(term)
+
+    def live_chats(self):
+        return self.get_queryset().live_chats()
 
     def snoozed(self):
         return self.get_queryset().snoozed()
@@ -262,6 +271,10 @@ class Ticket(models.Model):
         related_name="merged_tickets",
     )
 
+    # Live chat fields
+    chat_ended_at = models.DateTimeField(null=True, blank=True)
+    chat_metadata = models.JSONField(null=True, blank=True)
+
     # Snooze fields
     snoozed_until = models.DateTimeField(null=True, blank=True)
     snoozed_by = models.ForeignKey(
@@ -354,6 +367,11 @@ class Ticket(models.Model):
     @property
     def is_closed(self):
         return self.status == self.Status.CLOSED
+
+    @property
+    def is_live_chat(self):
+        """Check if this ticket is a live chat conversation."""
+        return self.channel == "chat"
 
     @property
     def is_guest(self):
@@ -1485,8 +1503,15 @@ class AgentProfile(models.Model):
         on_delete=models.CASCADE,
         related_name="escalated_agent_profile",
     )
+
+    class ChatStatus(models.TextChoices):
+        ONLINE = "online", _("Online")
+        AWAY = "away", _("Away")
+        OFFLINE = "offline", _("Offline")
+
     agent_type = models.CharField(max_length=20, default="full")
     max_tickets = models.PositiveIntegerField(null=True, blank=True)
+    chat_status = models.CharField(max_length=20, choices=ChatStatus.choices, default=ChatStatus.OFFLINE)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -1495,6 +1520,9 @@ class AgentProfile(models.Model):
 
     def __str__(self):
         return f"Agent profile for {self.user}"
+
+    def is_chat_online(self) -> bool:
+        return self.chat_status == self.ChatStatus.ONLINE
 
     def is_light_agent(self) -> bool:
         return self.agent_type == "light"
@@ -2013,3 +2041,159 @@ class ImportSourceMap(models.Model):
     def has_been_imported(cls, job_id, entity_type: str, source_id: str) -> bool:
         """Return True if this source record has already been imported."""
         return cls.resolve(job_id, entity_type, source_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Live Chat Models
+# ---------------------------------------------------------------------------
+
+
+class ChatSessionQuerySet(models.QuerySet):
+    def waiting(self):
+        return self.filter(status=ChatSession.Status.WAITING)
+
+    def active(self):
+        return self.filter(status=ChatSession.Status.ACTIVE)
+
+    def ended(self):
+        return self.filter(status=ChatSession.Status.ENDED)
+
+    def abandoned(self):
+        return self.filter(status=ChatSession.Status.ABANDONED)
+
+    def for_agent(self, user_id):
+        return self.filter(agent_id=user_id)
+
+    def for_customer(self, session_id):
+        return self.filter(customer_session_id=session_id)
+
+
+class ChatSessionManager(models.Manager):
+    def get_queryset(self):
+        return ChatSessionQuerySet(self.model, using=self._db)
+
+    def waiting(self):
+        return self.get_queryset().waiting()
+
+    def active(self):
+        return self.get_queryset().active()
+
+    def ended(self):
+        return self.get_queryset().ended()
+
+    def for_agent(self, user_id):
+        return self.get_queryset().for_agent(user_id)
+
+    def for_customer(self, session_id):
+        return self.get_queryset().for_customer(session_id)
+
+
+class ChatSession(models.Model):
+    class Status(models.TextChoices):
+        WAITING = "waiting", _("Waiting")
+        ACTIVE = "active", _("Active")
+        ENDED = "ended", _("Ended")
+        ABANDONED = "abandoned", _("Abandoned")
+
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, related_name="chat_sessions")
+    customer_session_id = models.CharField(max_length=255, db_index=True)
+    agent = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="escalated_chat_sessions",
+    )
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.WAITING, db_index=True)
+    customer_typing_at = models.DateTimeField(null=True, blank=True)
+    agent_typing_at = models.DateTimeField(null=True, blank=True)
+    metadata = models.JSONField(null=True, blank=True)
+    rating = models.PositiveSmallIntegerField(null=True, blank=True)
+    rating_comment = models.TextField(blank=True, default="")
+    started_at = models.DateTimeField(auto_now_add=True)
+    ended_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    objects = ChatSessionManager()
+
+    class Meta:
+        db_table = get_table_name("chat_sessions")
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"ChatSession {self.pk} ({self.status})"
+
+    @property
+    def is_active(self):
+        return self.status == self.Status.ACTIVE
+
+    @property
+    def is_waiting(self):
+        return self.status == self.Status.WAITING
+
+
+class ChatRoutingRuleQuerySet(models.QuerySet):
+    def active(self):
+        return self.filter(is_active=True)
+
+    def for_department(self, department_id):
+        return self.filter(Q(department_id=department_id) | Q(department__isnull=True))
+
+
+class ChatRoutingRuleManager(models.Manager):
+    def get_queryset(self):
+        return ChatRoutingRuleQuerySet(self.model, using=self._db)
+
+    def active(self):
+        return self.get_queryset().active()
+
+    def for_department(self, department_id):
+        return self.get_queryset().for_department(department_id)
+
+
+class ChatRoutingRule(models.Model):
+    class RoutingStrategy(models.TextChoices):
+        ROUND_ROBIN = "round_robin", _("Round Robin")
+        LEAST_ACTIVE = "least_active", _("Least Active")
+        RANDOM = "random", _("Random")
+
+    class OfflineBehavior(models.TextChoices):
+        QUEUE = "queue", _("Queue")
+        TICKET = "ticket", _("Create Ticket")
+        HIDE = "hide", _("Hide Chat")
+
+    department = models.ForeignKey(
+        Department,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="chat_routing_rules",
+    )
+    routing_strategy = models.CharField(
+        max_length=30,
+        choices=RoutingStrategy.choices,
+        default=RoutingStrategy.ROUND_ROBIN,
+    )
+    offline_behavior = models.CharField(
+        max_length=30,
+        choices=OfflineBehavior.choices,
+        default=OfflineBehavior.TICKET,
+    )
+    max_concurrent_chats = models.PositiveIntegerField(default=5)
+    welcome_message = models.TextField(blank=True, default="")
+    offline_message = models.TextField(blank=True, default="")
+    is_active = models.BooleanField(default=True)
+    position = models.PositiveIntegerField(default=0)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    objects = ChatRoutingRuleManager()
+
+    class Meta:
+        db_table = get_table_name("chat_routing_rules")
+        ordering = ["position"]
+
+    def __str__(self):
+        dept = self.department.name if self.department else "Global"
+        return f"ChatRoutingRule: {dept} ({self.routing_strategy})"

--- a/escalated/services/chat_availability_service.py
+++ b/escalated/services/chat_availability_service.py
@@ -1,0 +1,65 @@
+from escalated.models import AgentProfile, ChatSession
+
+
+class ChatAvailabilityService:
+    """Service for checking chat availability."""
+
+    def is_available(self, department=None):
+        """
+        Check if live chat is currently available (any agents online).
+
+        Args:
+            department: Optional Department to check availability for.
+
+        Returns:
+            bool: True if at least one agent is online and available.
+        """
+        agents = self.get_online_agents(department)
+        return len(agents) > 0
+
+    def get_online_agents(self, department=None):
+        """
+        Get a list of agents currently online for chat.
+
+        Args:
+            department: Optional Department to filter by.
+
+        Returns:
+            list: List of User objects for online agents.
+        """
+        profiles = AgentProfile.objects.filter(chat_status=AgentProfile.ChatStatus.ONLINE)
+
+        if department:
+            agent_ids = department.agents.values_list("pk", flat=True)
+            profiles = profiles.filter(user_id__in=agent_ids)
+
+        return [p.user for p in profiles.select_related("user")]
+
+    def get_queue_position(self, session):
+        """
+        Get the queue position of a waiting chat session.
+
+        Returns:
+            int: Position in the queue (1-based), or 0 if not waiting.
+        """
+        if session.status != ChatSession.Status.WAITING:
+            return 0
+
+        ahead = ChatSession.objects.filter(
+            status=ChatSession.Status.WAITING,
+            created_at__lt=session.created_at,
+        ).count()
+
+        return ahead + 1
+
+    def get_agent_chat_count(self, agent):
+        """
+        Get the number of active chats for an agent.
+
+        Returns:
+            int: Number of active chat sessions.
+        """
+        return ChatSession.objects.filter(
+            agent=agent,
+            status=ChatSession.Status.ACTIVE,
+        ).count()

--- a/escalated/services/chat_routing_service.py
+++ b/escalated/services/chat_routing_service.py
@@ -1,0 +1,98 @@
+import random
+
+from escalated.models import AgentProfile, ChatRoutingRule, ChatSession
+
+
+class ChatRoutingService:
+    """Service for routing chats to available agents."""
+
+    def find_available_agent(self, department=None):
+        """
+        Find an available agent based on routing rules.
+
+        Args:
+            department: Optional Department to filter agents by.
+
+        Returns:
+            User or None: The selected agent, or None if nobody is available.
+        """
+        rule = self._get_routing_rule(department)
+        strategy = rule.routing_strategy if rule else ChatRoutingRule.RoutingStrategy.ROUND_ROBIN
+        max_concurrent = rule.max_concurrent_chats if rule else 5
+
+        agents = self._get_online_agents(department)
+        if not agents:
+            return None
+
+        # Filter out agents at capacity
+        available = []
+        for agent in agents:
+            active_count = ChatSession.objects.filter(
+                agent=agent,
+                status=ChatSession.Status.ACTIVE,
+            ).count()
+            if active_count < max_concurrent:
+                available.append((agent, active_count))
+
+        if not available:
+            return None
+
+        if strategy == ChatRoutingRule.RoutingStrategy.LEAST_ACTIVE:
+            available.sort(key=lambda x: x[1])
+            return available[0][0]
+        elif strategy == ChatRoutingRule.RoutingStrategy.RANDOM:
+            return random.choice(available)[0]
+        else:
+            # Round robin: pick agent with fewest active chats
+            available.sort(key=lambda x: x[1])
+            return available[0][0]
+
+    def evaluate_routing(self, department=None):
+        """
+        Evaluate routing and return the routing rule and available agent count.
+
+        Returns:
+            dict with routing_rule, available_agents count, and recommendation.
+        """
+        rule = self._get_routing_rule(department)
+        agents = self._get_online_agents(department)
+        max_concurrent = rule.max_concurrent_chats if rule else 5
+
+        available_count = 0
+        for agent in agents:
+            active_count = ChatSession.objects.filter(
+                agent=agent,
+                status=ChatSession.Status.ACTIVE,
+            ).count()
+            if active_count < max_concurrent:
+                available_count += 1
+
+        offline_behavior = rule.offline_behavior if rule else ChatRoutingRule.OfflineBehavior.TICKET
+
+        return {
+            "routing_rule": rule,
+            "total_online_agents": len(agents),
+            "available_agents": available_count,
+            "offline_behavior": offline_behavior,
+            "is_available": available_count > 0,
+        }
+
+    def _get_routing_rule(self, department=None):
+        """Get the applicable routing rule."""
+        if department:
+            rule = ChatRoutingRule.objects.active().filter(department=department).first()
+            if rule:
+                return rule
+
+        # Fall back to global rule (no department)
+        return ChatRoutingRule.objects.active().filter(department__isnull=True).first()
+
+    def _get_online_agents(self, department=None):
+        """Get agents who are online for chat."""
+        profiles = AgentProfile.objects.filter(chat_status=AgentProfile.ChatStatus.ONLINE)
+
+        if department:
+            agent_ids = department.agents.values_list("pk", flat=True)
+            profiles = profiles.filter(user_id__in=agent_ids)
+
+        return [p.user for p in profiles.select_related("user")]

--- a/escalated/services/chat_session_service.py
+++ b/escalated/services/chat_session_service.py
@@ -1,0 +1,171 @@
+import uuid
+
+from django.utils import timezone
+
+from escalated.models import ChatSession, Reply, Ticket
+from escalated.signals import chat_ended, chat_message_sent, chat_rated, chat_started, chat_transferred
+
+
+class ChatSessionService:
+    """Service for managing live chat sessions."""
+
+    def start_chat(self, *, name, email, department=None, metadata=None):
+        """
+        Start a new chat session. Creates a ticket with channel='chat' and
+        a ChatSession in 'waiting' status.
+
+        Returns:
+            tuple: (ticket, session)
+        """
+        customer_session_id = uuid.uuid4().hex
+
+        ticket = Ticket.objects.create(
+            subject=f"Chat from {name}",
+            description="Live chat conversation",
+            status=Ticket.Status.OPEN,
+            priority=Ticket.Priority.MEDIUM,
+            channel="chat",
+            department=department,
+            guest_name=name,
+            guest_email=email,
+            chat_metadata=metadata or {},
+        )
+
+        session = ChatSession.objects.create(
+            ticket=ticket,
+            customer_session_id=customer_session_id,
+            status=ChatSession.Status.WAITING,
+            metadata=metadata or {},
+        )
+
+        chat_started.send(sender=ChatSession, session=session, ticket=ticket)
+
+        return ticket, session
+
+    def assign_agent(self, session, agent):
+        """
+        Assign an agent to a waiting chat session.
+
+        Returns:
+            ChatSession: The updated session.
+        """
+        session.agent = agent
+        session.status = ChatSession.Status.ACTIVE
+        session.save(update_fields=["agent", "status", "updated_at"])
+
+        ticket = session.ticket
+        ticket.assigned_to = agent
+        ticket.status = Ticket.Status.IN_PROGRESS
+        ticket.save(update_fields=["assigned_to", "status", "updated_at"])
+
+        return session
+
+    def end_chat(self, session, ended_by=None):
+        """
+        End a chat session.
+
+        Args:
+            session: The ChatSession to end.
+            ended_by: The user who ended the chat (agent or None for customer).
+
+        Returns:
+            ChatSession: The updated session.
+        """
+        now = timezone.now()
+        session.status = ChatSession.Status.ENDED
+        session.ended_at = now
+        session.save(update_fields=["status", "ended_at", "updated_at"])
+
+        ticket = session.ticket
+        ticket.chat_ended_at = now
+        ticket.status = Ticket.Status.RESOLVED
+        ticket.resolved_at = now
+        ticket.save(update_fields=["chat_ended_at", "status", "resolved_at", "updated_at"])
+
+        chat_ended.send(sender=ChatSession, session=session, ticket=ticket, ended_by=ended_by)
+
+        return session
+
+    def transfer_chat(self, session, from_agent, to_agent):
+        """
+        Transfer a chat session from one agent to another.
+
+        Returns:
+            ChatSession: The updated session.
+        """
+        session.agent = to_agent
+        session.save(update_fields=["agent", "updated_at"])
+
+        ticket = session.ticket
+        ticket.assigned_to = to_agent
+        ticket.save(update_fields=["assigned_to", "updated_at"])
+
+        chat_transferred.send(
+            sender=ChatSession,
+            session=session,
+            ticket=ticket,
+            from_agent=from_agent,
+            to_agent=to_agent,
+        )
+
+        return session
+
+    def send_message(self, session, *, body, sender=None, sender_type="customer"):
+        """
+        Send a message in a chat session. Creates a Reply on the ticket.
+
+        Args:
+            session: The ChatSession.
+            body: The message text.
+            sender: The user sending (agent) or None (customer).
+            sender_type: 'customer' or 'agent'.
+
+        Returns:
+            Reply: The created reply.
+        """
+        reply = Reply.objects.create(
+            ticket=session.ticket,
+            author=sender,
+            body=body,
+            type=Reply.Type.REPLY,
+            metadata={"chat_sender_type": sender_type, "chat_session_id": session.pk},
+        )
+
+        chat_message_sent.send(
+            sender=ChatSession,
+            session=session,
+            ticket=session.ticket,
+            message=reply,
+            sender_type=sender_type,
+        )
+
+        return reply
+
+    def update_typing(self, session, *, is_typing, sender_type="customer"):
+        """
+        Update the typing indicator for a chat session.
+        """
+        now = timezone.now() if is_typing else None
+        if sender_type == "customer":
+            session.customer_typing_at = now
+            session.save(update_fields=["customer_typing_at", "updated_at"])
+        else:
+            session.agent_typing_at = now
+            session.save(update_fields=["agent_typing_at", "updated_at"])
+
+        return session
+
+    def rate_chat(self, session, *, rating, comment=""):
+        """
+        Rate a completed chat session.
+
+        Returns:
+            ChatSession: The updated session.
+        """
+        session.rating = rating
+        session.rating_comment = comment
+        session.save(update_fields=["rating", "rating_comment", "updated_at"])
+
+        chat_rated.send(sender=ChatSession, session=session, rating=rating, comment=comment)
+
+        return session

--- a/escalated/signals.py
+++ b/escalated/signals.py
@@ -26,3 +26,10 @@ tag_removed = django.dispatch.Signal()  # sender=Tag, tag, ticket, user
 
 # Department signals
 department_changed = django.dispatch.Signal()  # sender=Ticket, ticket, user, old_department, new_department
+
+# Live Chat signals
+chat_started = django.dispatch.Signal()  # sender=ChatSession, session, ticket
+chat_message_sent = django.dispatch.Signal()  # sender=ChatSession, session, ticket, message, sender_type
+chat_ended = django.dispatch.Signal()  # sender=ChatSession, session, ticket, ended_by
+chat_transferred = django.dispatch.Signal()  # sender=ChatSession, session, ticket, from_agent, to_agent
+chat_rated = django.dispatch.Signal()  # sender=ChatSession, session, rating, comment

--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -1,7 +1,18 @@
 from django.urls import include, path
 
 from escalated.conf import get_setting
-from escalated.views import admin, admin_plugins, agent, customer, guest, import_views, inbound, widget
+from escalated.views import (
+    admin,
+    admin_plugins,
+    agent,
+    chat,
+    customer,
+    guest,
+    import_views,
+    inbound,
+    widget,
+    widget_chat,
+)
 
 app_name = "escalated"
 
@@ -271,6 +282,18 @@ guest_patterns = [
     path("guest/<str:token>/rate/", guest.ticket_rate, name="guest_ticket_rate"),
 ]
 
+# Agent chat URLs
+chat_patterns = [
+    path("agent/chat/active/", chat.active_chats, name="agent_chat_active"),
+    path("agent/chat/queue/", chat.chat_queue, name="agent_chat_queue"),
+    path("agent/chat/<int:session_id>/accept/", chat.accept_chat, name="agent_chat_accept"),
+    path("agent/chat/<int:session_id>/end/", chat.end_chat, name="agent_chat_end"),
+    path("agent/chat/<int:session_id>/transfer/", chat.transfer_chat, name="agent_chat_transfer"),
+    path("agent/chat/status/", chat.update_status, name="agent_chat_status"),
+    path("agent/chat/<int:session_id>/message/", chat.send_message, name="agent_chat_message"),
+    path("agent/chat/<int:session_id>/typing/", chat.update_typing, name="agent_chat_typing"),
+]
+
 # Widget public API (no authentication)
 widget_patterns = [
     path("widget/config/", widget.widget_config, name="widget_config"),
@@ -280,17 +303,27 @@ widget_patterns = [
     path("widget/tickets/lookup/", widget.widget_lookup_ticket, name="widget_lookup_ticket"),
 ]
 
+# Widget chat API (no authentication)
+widget_chat_patterns = [
+    path("widget/chat/availability/", widget_chat.chat_availability, name="widget_chat_availability"),
+    path("widget/chat/start/", widget_chat.start_chat, name="widget_chat_start"),
+    path("widget/chat/message/", widget_chat.send_message, name="widget_chat_message"),
+    path("widget/chat/typing/", widget_chat.update_typing, name="widget_chat_typing"),
+    path("widget/chat/end/", widget_chat.end_chat, name="widget_chat_end"),
+    path("widget/chat/rate/", widget_chat.rate_chat, name="widget_chat_rate"),
+]
+
 # Inbound email webhook (no authentication — external services POST here)
 inbound_patterns = [
     path("inbound/<str:adapter_name>/", inbound.inbound_webhook, name="inbound_webhook"),
 ]
 
 # Core routes (always registered)
-urlpatterns = list(inbound_patterns) + list(widget_patterns)
+urlpatterns = list(inbound_patterns) + list(widget_patterns) + list(widget_chat_patterns)
 
 # UI routes (only when UI is enabled)
 if get_setting("UI_ENABLED"):
-    urlpatterns = customer_patterns + agent_patterns + admin_patterns + guest_patterns + urlpatterns
+    urlpatterns = customer_patterns + agent_patterns + chat_patterns + admin_patterns + guest_patterns + urlpatterns
 
 # Inject plugin bridge routes (pages, API endpoints, webhooks) if the SDK
 # bridge has booted and registered patterns from plugin manifests.

--- a/escalated/views/chat.py
+++ b/escalated/views/chat.py
@@ -1,0 +1,241 @@
+"""
+Agent-facing chat views for managing live chat sessions.
+"""
+
+import json
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET, require_POST
+
+from escalated.models import AgentProfile, ChatSession
+from escalated.permissions import is_admin, is_agent
+from escalated.services.chat_session_service import ChatSessionService
+
+User = get_user_model()
+
+
+def _require_agent(request):
+    """Return an error response if user is not an agent, else None."""
+    if not request.user.is_authenticated:
+        return JsonResponse({"error": "Authentication required"}, status=401)
+    if not is_agent(request.user) and not is_admin(request.user):
+        return JsonResponse({"error": "Agent access required"}, status=403)
+    return None
+
+
+def _serialize_session(session):
+    """Serialize a ChatSession to a dict."""
+    return {
+        "id": session.pk,
+        "ticket_id": session.ticket_id,
+        "ticket_reference": session.ticket.reference,
+        "customer_session_id": session.customer_session_id,
+        "customer_name": session.ticket.guest_name or session.ticket.requester_name,
+        "agent_id": session.agent_id,
+        "agent_name": session.agent.get_full_name() if session.agent else None,
+        "status": session.status,
+        "rating": session.rating,
+        "started_at": session.started_at.isoformat() if session.started_at else None,
+        "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+    }
+
+
+@login_required
+@require_GET
+def active_chats(request):
+    """List active chats for the current agent."""
+    error = _require_agent(request)
+    if error:
+        return error
+
+    sessions = ChatSession.objects.filter(
+        agent=request.user,
+        status=ChatSession.Status.ACTIVE,
+    ).select_related("ticket", "agent")
+
+    return JsonResponse({"chats": [_serialize_session(s) for s in sessions]})
+
+
+@login_required
+@require_GET
+def chat_queue(request):
+    """List waiting chats in the queue."""
+    error = _require_agent(request)
+    if error:
+        return error
+
+    sessions = ChatSession.objects.filter(
+        status=ChatSession.Status.WAITING,
+    ).select_related("ticket", "agent")
+
+    return JsonResponse({"queue": [_serialize_session(s) for s in sessions]})
+
+
+@login_required
+@require_POST
+def accept_chat(request, session_id):
+    """Accept a waiting chat from the queue."""
+    error = _require_agent(request)
+    if error:
+        return error
+
+    try:
+        session = ChatSession.objects.select_related("ticket").get(pk=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    if session.status != ChatSession.Status.WAITING:
+        return JsonResponse({"error": "Chat is not in waiting state"}, status=400)
+
+    service = ChatSessionService()
+    session = service.assign_agent(session, request.user)
+
+    return JsonResponse({"chat": _serialize_session(session)})
+
+
+@login_required
+@require_POST
+def end_chat(request, session_id):
+    """End an active chat session."""
+    error = _require_agent(request)
+    if error:
+        return error
+
+    try:
+        session = ChatSession.objects.select_related("ticket").get(pk=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    if session.status != ChatSession.Status.ACTIVE:
+        return JsonResponse({"error": "Chat is not active"}, status=400)
+
+    service = ChatSessionService()
+    session = service.end_chat(session, ended_by=request.user)
+
+    return JsonResponse({"chat": _serialize_session(session)})
+
+
+@login_required
+@require_POST
+def transfer_chat(request, session_id):
+    """Transfer a chat to another agent."""
+    error = _require_agent(request)
+    if error:
+        return error
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    agent_id = body.get("agent_id")
+    if not agent_id:
+        return JsonResponse({"error": "agent_id is required"}, status=400)
+
+    try:
+        session = ChatSession.objects.select_related("ticket").get(pk=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    if session.status != ChatSession.Status.ACTIVE:
+        return JsonResponse({"error": "Chat is not active"}, status=400)
+
+    try:
+        to_agent = User.objects.get(pk=agent_id)
+    except User.DoesNotExist:
+        return JsonResponse({"error": "Target agent not found"}, status=404)
+
+    service = ChatSessionService()
+    session = service.transfer_chat(session, from_agent=request.user, to_agent=to_agent)
+
+    return JsonResponse({"chat": _serialize_session(session)})
+
+
+@login_required
+@require_POST
+def update_status(request):
+    """Update the agent's chat status (online/away/offline)."""
+    error = _require_agent(request)
+    if error:
+        return error
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    status = body.get("status")
+    if status not in [c[0] for c in AgentProfile.ChatStatus.choices]:
+        return JsonResponse({"error": "Invalid status"}, status=400)
+
+    profile, _ = AgentProfile.objects.get_or_create(user=request.user)
+    profile.chat_status = status
+    profile.save(update_fields=["chat_status", "updated_at"])
+
+    return JsonResponse({"status": profile.chat_status})
+
+
+@login_required
+@require_POST
+def send_message(request, session_id):
+    """Send a message in a chat session (agent side)."""
+    error = _require_agent(request)
+    if error:
+        return error
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    message_body = body.get("body", "").strip()
+    if not message_body:
+        return JsonResponse({"error": "Message body is required"}, status=400)
+
+    try:
+        session = ChatSession.objects.select_related("ticket").get(pk=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    if session.status != ChatSession.Status.ACTIVE:
+        return JsonResponse({"error": "Chat is not active"}, status=400)
+
+    service = ChatSessionService()
+    reply = service.send_message(session, body=message_body, sender=request.user, sender_type="agent")
+
+    return JsonResponse(
+        {
+            "message": {
+                "id": reply.pk,
+                "body": reply.body,
+                "sender_type": "agent",
+                "created_at": reply.created_at.isoformat(),
+            }
+        }
+    )
+
+
+@login_required
+@require_POST
+def update_typing(request, session_id):
+    """Update typing indicator for agent."""
+    error = _require_agent(request)
+    if error:
+        return error
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    try:
+        session = ChatSession.objects.get(pk=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    service = ChatSessionService()
+    service.update_typing(session, is_typing=body.get("is_typing", False), sender_type="agent")
+
+    return JsonResponse({"ok": True})

--- a/escalated/views/widget_chat.py
+++ b/escalated/views/widget_chat.py
@@ -1,0 +1,252 @@
+"""
+Public-facing widget chat endpoints for customers.
+
+All endpoints are unauthenticated and intended for use from a JavaScript
+widget embedded on a customer's website.
+"""
+
+import json
+import time
+
+from django.core.cache import cache
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_GET, require_POST
+
+from escalated.models import ChatSession, EscalatedSetting
+from escalated.services.chat_availability_service import ChatAvailabilityService
+from escalated.services.chat_routing_service import ChatRoutingService
+from escalated.services.chat_session_service import ChatSessionService
+
+
+def _rate_limited(request, scope="widget_chat", limit=None, window=60):
+    if limit is None:
+        limit = EscalatedSetting.get_int("widget_chat_rate_limit", default=30)
+
+    ip = request.META.get("REMOTE_ADDR", "unknown")
+    key = f"escalated.ratelimit.{scope}.{ip}"
+    data = cache.get(key)
+
+    now = time.time()
+    if data is None:
+        cache.set(key, {"count": 1, "start": now}, window)
+        return False
+
+    if now - data["start"] > window:
+        cache.set(key, {"count": 1, "start": now}, window)
+        return False
+
+    data["count"] += 1
+    cache.set(key, data, window)
+    return data["count"] > limit
+
+
+def _reject():
+    return JsonResponse({"error": "Rate limit exceeded"}, status=429)
+
+
+@require_GET
+def chat_availability(request):
+    """Check if live chat is currently available."""
+    if _rate_limited(request, scope="widget_chat_availability"):
+        return _reject()
+
+    service = ChatAvailabilityService()
+    available = service.is_available()
+
+    routing_service = ChatRoutingService()
+    routing = routing_service.evaluate_routing()
+
+    return JsonResponse(
+        {
+            "available": available,
+            "online_agents": routing["total_online_agents"],
+            "offline_behavior": routing["offline_behavior"],
+        }
+    )
+
+
+@csrf_exempt
+@require_POST
+def start_chat(request):
+    """Start a new chat session from the widget."""
+    if _rate_limited(request, scope="widget_chat_start", limit=5, window=60):
+        return _reject()
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    name = body.get("name", "").strip()
+    email = body.get("email", "").strip()
+
+    errors = {}
+    if not name:
+        errors["name"] = "Name is required"
+    if not email:
+        errors["email"] = "Email is required"
+    if errors:
+        return JsonResponse({"errors": errors}, status=400)
+
+    session_service = ChatSessionService()
+    ticket, session = session_service.start_chat(
+        name=name,
+        email=email,
+        metadata=body.get("metadata"),
+    )
+
+    # Try to auto-assign an agent
+    routing_service = ChatRoutingService()
+    agent = routing_service.find_available_agent()
+    if agent:
+        session_service.assign_agent(session, agent)
+        session.refresh_from_db()
+
+    availability_service = ChatAvailabilityService()
+    queue_position = availability_service.get_queue_position(session)
+
+    return JsonResponse(
+        {
+            "session_id": session.customer_session_id,
+            "ticket_reference": ticket.reference,
+            "status": session.status,
+            "queue_position": queue_position,
+            "agent_name": session.agent.get_full_name() if session.agent else None,
+        }
+    )
+
+
+@csrf_exempt
+@require_POST
+def send_message(request):
+    """Send a message from the customer."""
+    if _rate_limited(request, scope="widget_chat_message", limit=30, window=60):
+        return _reject()
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    session_id = body.get("session_id", "").strip()
+    message_body = body.get("body", "").strip()
+
+    if not session_id:
+        return JsonResponse({"error": "session_id is required"}, status=400)
+    if not message_body:
+        return JsonResponse({"error": "Message body is required"}, status=400)
+
+    try:
+        session = ChatSession.objects.select_related("ticket").get(customer_session_id=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    if session.status not in [ChatSession.Status.ACTIVE, ChatSession.Status.WAITING]:
+        return JsonResponse({"error": "Chat session is not active"}, status=400)
+
+    service = ChatSessionService()
+    reply = service.send_message(session, body=message_body, sender=None, sender_type="customer")
+
+    return JsonResponse(
+        {
+            "message": {
+                "id": reply.pk,
+                "body": reply.body,
+                "sender_type": "customer",
+                "created_at": reply.created_at.isoformat(),
+            }
+        }
+    )
+
+
+@csrf_exempt
+@require_POST
+def update_typing(request):
+    """Update typing indicator from customer."""
+    if _rate_limited(request, scope="widget_chat_typing", limit=60, window=60):
+        return _reject()
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    session_id = body.get("session_id", "").strip()
+    if not session_id:
+        return JsonResponse({"error": "session_id is required"}, status=400)
+
+    try:
+        session = ChatSession.objects.get(customer_session_id=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    service = ChatSessionService()
+    service.update_typing(session, is_typing=body.get("is_typing", False), sender_type="customer")
+
+    return JsonResponse({"ok": True})
+
+
+@csrf_exempt
+@require_POST
+def end_chat(request):
+    """End a chat from the customer side."""
+    if _rate_limited(request, scope="widget_chat_end", limit=10, window=60):
+        return _reject()
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    session_id = body.get("session_id", "").strip()
+    if not session_id:
+        return JsonResponse({"error": "session_id is required"}, status=400)
+
+    try:
+        session = ChatSession.objects.select_related("ticket").get(customer_session_id=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    if session.status not in [ChatSession.Status.ACTIVE, ChatSession.Status.WAITING]:
+        return JsonResponse({"error": "Chat session is not active"}, status=400)
+
+    service = ChatSessionService()
+    service.end_chat(session, ended_by=None)
+
+    return JsonResponse({"ok": True})
+
+
+@csrf_exempt
+@require_POST
+def rate_chat(request):
+    """Rate a completed chat session."""
+    if _rate_limited(request, scope="widget_chat_rate", limit=5, window=60):
+        return _reject()
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    session_id = body.get("session_id", "").strip()
+    rating = body.get("rating")
+    comment = body.get("comment", "")
+
+    if not session_id:
+        return JsonResponse({"error": "session_id is required"}, status=400)
+    if rating is None or not isinstance(rating, int) or rating < 1 or rating > 5:
+        return JsonResponse({"error": "rating must be an integer between 1 and 5"}, status=400)
+
+    try:
+        session = ChatSession.objects.get(customer_session_id=session_id)
+    except ChatSession.DoesNotExist:
+        return JsonResponse({"error": "Chat session not found"}, status=404)
+
+    if session.status != ChatSession.Status.ENDED:
+        return JsonResponse({"error": "Can only rate ended chats"}, status=400)
+
+    service = ChatSessionService()
+    service.rate_chat(session, rating=rating, comment=comment)
+
+    return JsonResponse({"ok": True})

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,6 +11,7 @@ DATABASES = {
 INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",
+    "django.contrib.sessions",
     "escalated",
 ]
 

--- a/tests/unit/test_live_chat.py
+++ b/tests/unit/test_live_chat.py
@@ -1,0 +1,638 @@
+import json
+from datetime import timedelta
+
+import pytest
+from django.core.cache import cache
+from django.utils import timezone
+
+from escalated.models import (
+    AgentProfile,
+    ChatRoutingRule,
+    ChatSession,
+    Ticket,
+)
+from escalated.services.chat_availability_service import ChatAvailabilityService
+from escalated.services.chat_routing_service import ChatRoutingService
+from escalated.services.chat_session_service import ChatSessionService
+from tests.factories import DepartmentFactory, UserFactory
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestChatSessionModel:
+    def test_create_chat_session(self):
+        ticket = Ticket.objects.create(
+            subject="Test chat",
+            description="Chat ticket",
+            channel="chat",
+            guest_name="Alice",
+            guest_email="alice@example.com",
+        )
+        session = ChatSession.objects.create(
+            ticket=ticket,
+            customer_session_id="abc123",
+            status=ChatSession.Status.WAITING,
+        )
+        assert session.is_waiting is True
+        assert session.is_active is False
+        assert str(session) == f"ChatSession {session.pk} (waiting)"
+
+    def test_queryset_filters(self):
+        ticket = Ticket.objects.create(
+            subject="Test",
+            description="desc",
+            channel="chat",
+            guest_name="Bob",
+            guest_email="bob@example.com",
+        )
+        ChatSession.objects.create(
+            ticket=ticket,
+            customer_session_id="s1",
+            status=ChatSession.Status.WAITING,
+        )
+        ChatSession.objects.create(
+            ticket=ticket,
+            customer_session_id="s2",
+            status=ChatSession.Status.ACTIVE,
+        )
+        ChatSession.objects.create(
+            ticket=ticket,
+            customer_session_id="s3",
+            status=ChatSession.Status.ENDED,
+        )
+
+        assert ChatSession.objects.waiting().count() == 1
+        assert ChatSession.objects.active().count() == 1
+        assert ChatSession.objects.ended().count() == 1
+
+
+@pytest.mark.django_db
+class TestChatRoutingRuleModel:
+    def test_create_routing_rule(self):
+        rule = ChatRoutingRule.objects.create(
+            routing_strategy=ChatRoutingRule.RoutingStrategy.ROUND_ROBIN,
+            offline_behavior=ChatRoutingRule.OfflineBehavior.TICKET,
+            max_concurrent_chats=3,
+            welcome_message="Hello!",
+            is_active=True,
+        )
+        assert "Global" in str(rule)
+        assert rule.is_active is True
+
+    def test_queryset_active(self):
+        ChatRoutingRule.objects.create(is_active=True)
+        ChatRoutingRule.objects.create(is_active=False)
+        assert ChatRoutingRule.objects.active().count() == 1
+
+
+@pytest.mark.django_db
+class TestTicketChatFields:
+    def test_ticket_live_chat_fields(self):
+        ticket = Ticket.objects.create(
+            subject="Chat ticket",
+            description="desc",
+            channel="chat",
+            guest_name="Carol",
+            guest_email="carol@example.com",
+            chat_metadata={"source": "widget"},
+        )
+        assert ticket.is_live_chat is True
+        assert ticket.chat_ended_at is None
+        assert ticket.chat_metadata == {"source": "widget"}
+
+    def test_live_chats_queryset(self):
+        Ticket.objects.create(
+            subject="Chat",
+            description="d",
+            channel="chat",
+            guest_name="A",
+            guest_email="a@e.com",
+        )
+        Ticket.objects.create(
+            subject="Email",
+            description="d",
+            channel="email",
+            guest_name="B",
+            guest_email="b@e.com",
+        )
+        assert Ticket.objects.live_chats().count() == 1
+
+
+@pytest.mark.django_db
+class TestAgentProfileChatStatus:
+    def test_chat_status_default(self):
+        user = UserFactory()
+        profile = AgentProfile.objects.create(user=user)
+        assert profile.chat_status == AgentProfile.ChatStatus.OFFLINE
+        assert profile.is_chat_online() is False
+
+    def test_set_online(self):
+        user = UserFactory()
+        profile = AgentProfile.objects.create(user=user, chat_status=AgentProfile.ChatStatus.ONLINE)
+        assert profile.is_chat_online() is True
+
+
+# ---------------------------------------------------------------------------
+# Service tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestChatSessionService:
+    def test_start_chat(self):
+        service = ChatSessionService()
+        ticket, session = service.start_chat(name="Alice", email="alice@test.com")
+
+        assert ticket.channel == "chat"
+        assert ticket.guest_name == "Alice"
+        assert ticket.guest_email == "alice@test.com"
+        assert session.status == ChatSession.Status.WAITING
+        assert session.customer_session_id
+
+    def test_assign_agent(self):
+        service = ChatSessionService()
+        ticket, session = service.start_chat(name="Alice", email="alice@test.com")
+
+        agent = UserFactory(username="agent1")
+        session = service.assign_agent(session, agent)
+
+        assert session.status == ChatSession.Status.ACTIVE
+        assert session.agent == agent
+        ticket.refresh_from_db()
+        assert ticket.assigned_to == agent
+        assert ticket.status == Ticket.Status.IN_PROGRESS
+
+    def test_end_chat(self):
+        service = ChatSessionService()
+        ticket, session = service.start_chat(name="Alice", email="alice@test.com")
+        agent = UserFactory(username="agent2")
+        session = service.assign_agent(session, agent)
+        session = service.end_chat(session, ended_by=agent)
+
+        assert session.status == ChatSession.Status.ENDED
+        assert session.ended_at is not None
+        ticket.refresh_from_db()
+        assert ticket.chat_ended_at is not None
+        assert ticket.status == Ticket.Status.RESOLVED
+
+    def test_transfer_chat(self):
+        service = ChatSessionService()
+        ticket, session = service.start_chat(name="Alice", email="alice@test.com")
+        agent1 = UserFactory(username="agent_a")
+        agent2 = UserFactory(username="agent_b")
+        session = service.assign_agent(session, agent1)
+        session = service.transfer_chat(session, from_agent=agent1, to_agent=agent2)
+
+        assert session.agent == agent2
+        ticket.refresh_from_db()
+        assert ticket.assigned_to == agent2
+
+    def test_send_message(self):
+        service = ChatSessionService()
+        ticket, session = service.start_chat(name="Alice", email="alice@test.com")
+        agent = UserFactory(username="agent3")
+        session = service.assign_agent(session, agent)
+
+        reply = service.send_message(session, body="Hello!", sender=agent, sender_type="agent")
+        assert reply.body == "Hello!"
+        assert reply.author == agent
+        assert reply.metadata["chat_sender_type"] == "agent"
+
+        reply2 = service.send_message(session, body="Hi!", sender=None, sender_type="customer")
+        assert reply2.author is None
+        assert reply2.metadata["chat_sender_type"] == "customer"
+
+    def test_update_typing(self):
+        service = ChatSessionService()
+        ticket, session = service.start_chat(name="Alice", email="alice@test.com")
+
+        session = service.update_typing(session, is_typing=True, sender_type="customer")
+        assert session.customer_typing_at is not None
+
+        session = service.update_typing(session, is_typing=False, sender_type="customer")
+        assert session.customer_typing_at is None
+
+    def test_rate_chat(self):
+        service = ChatSessionService()
+        ticket, session = service.start_chat(name="Alice", email="alice@test.com")
+        agent = UserFactory(username="agent4")
+        session = service.assign_agent(session, agent)
+        session = service.end_chat(session, ended_by=agent)
+
+        session = service.rate_chat(session, rating=5, comment="Great!")
+        assert session.rating == 5
+        assert session.rating_comment == "Great!"
+
+
+@pytest.mark.django_db
+class TestChatRoutingService:
+    def _make_online_agent(self, username, department=None):
+        user = UserFactory(username=username)
+        AgentProfile.objects.create(user=user, chat_status=AgentProfile.ChatStatus.ONLINE)
+        if department:
+            department.agents.add(user)
+        return user
+
+    def test_find_available_agent_no_agents(self):
+        service = ChatRoutingService()
+        assert service.find_available_agent() is None
+
+    def test_find_available_agent_with_online(self):
+        agent = self._make_online_agent("routing_agent")
+        service = ChatRoutingService()
+        found = service.find_available_agent()
+        assert found == agent
+
+    def test_find_available_agent_at_capacity(self):
+        agent = self._make_online_agent("cap_agent")
+        ChatRoutingRule.objects.create(
+            routing_strategy=ChatRoutingRule.RoutingStrategy.ROUND_ROBIN,
+            max_concurrent_chats=1,
+            is_active=True,
+        )
+        # Create an active session to fill capacity
+        ticket = Ticket.objects.create(
+            subject="t",
+            description="d",
+            channel="chat",
+            guest_name="x",
+            guest_email="x@e.com",
+        )
+        ChatSession.objects.create(
+            ticket=ticket,
+            customer_session_id="cap1",
+            status=ChatSession.Status.ACTIVE,
+            agent=agent,
+        )
+
+        service = ChatRoutingService()
+        assert service.find_available_agent() is None
+
+    def test_evaluate_routing(self):
+        self._make_online_agent("eval_agent")
+        service = ChatRoutingService()
+        result = service.evaluate_routing()
+        assert result["is_available"] is True
+        assert result["total_online_agents"] == 1
+        assert result["available_agents"] == 1
+
+
+@pytest.mark.django_db
+class TestChatAvailabilityService:
+    def test_not_available_without_agents(self):
+        service = ChatAvailabilityService()
+        assert service.is_available() is False
+
+    def test_available_with_online_agent(self):
+        user = UserFactory(username="avail_agent")
+        AgentProfile.objects.create(user=user, chat_status=AgentProfile.ChatStatus.ONLINE)
+
+        service = ChatAvailabilityService()
+        assert service.is_available() is True
+
+    def test_get_queue_position(self):
+        service = ChatAvailabilityService()
+        session_service = ChatSessionService()
+
+        _, s1 = session_service.start_chat(name="A", email="a@e.com")
+        _, s2 = session_service.start_chat(name="B", email="b@e.com")
+
+        pos1 = service.get_queue_position(s1)
+        pos2 = service.get_queue_position(s2)
+        assert pos1 == 1
+        assert pos2 == 2
+
+    def test_get_agent_chat_count(self):
+        user = UserFactory(username="count_agent")
+        AgentProfile.objects.create(user=user, chat_status=AgentProfile.ChatStatus.ONLINE)
+
+        service = ChatAvailabilityService()
+        assert service.get_agent_chat_count(user) == 0
+
+        ticket = Ticket.objects.create(
+            subject="t",
+            description="d",
+            channel="chat",
+            guest_name="x",
+            guest_email="x@e.com",
+        )
+        ChatSession.objects.create(
+            ticket=ticket,
+            customer_session_id="cnt1",
+            status=ChatSession.Status.ACTIVE,
+            agent=user,
+        )
+        assert service.get_agent_chat_count(user) == 1
+
+
+# ---------------------------------------------------------------------------
+# View tests - Agent chat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAgentChatViews:
+    def _login_agent(self, client):
+        department = DepartmentFactory()
+        agent = UserFactory(username="view_agent")
+        department.agents.add(agent)
+        client.force_login(agent)
+        return agent
+
+    def test_active_chats_requires_auth(self, client):
+        response = client.get("/support/agent/chat/active/")
+        assert response.status_code == 302  # redirect to login
+
+    def test_active_chats_empty(self, client):
+        self._login_agent(client)
+        response = client.get("/support/agent/chat/active/")
+        assert response.status_code == 200
+        assert response.json()["chats"] == []
+
+    def test_chat_queue(self, client):
+        self._login_agent(client)
+        session_service = ChatSessionService()
+        session_service.start_chat(name="Q", email="q@e.com")
+
+        response = client.get("/support/agent/chat/queue/")
+        assert response.status_code == 200
+        assert len(response.json()["queue"]) == 1
+
+    def test_accept_chat(self, client):
+        self._login_agent(client)
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="Accept", email="a@e.com")
+
+        response = client.post(f"/support/agent/chat/{session.pk}/accept/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["chat"]["status"] == "active"
+
+    def test_end_chat(self, client):
+        agent = self._login_agent(client)
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="End", email="e@e.com")
+        session_service.assign_agent(session, agent)
+
+        response = client.post(f"/support/agent/chat/{session.pk}/end/")
+        assert response.status_code == 200
+        assert response.json()["chat"]["status"] == "ended"
+
+    def test_send_message(self, client):
+        agent = self._login_agent(client)
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="Msg", email="m@e.com")
+        session_service.assign_agent(session, agent)
+
+        response = client.post(
+            f"/support/agent/chat/{session.pk}/message/",
+            data=json.dumps({"body": "Hello from agent"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["message"]["sender_type"] == "agent"
+
+    def test_update_status(self, client):
+        self._login_agent(client)
+        response = client.post(
+            "/support/agent/chat/status/",
+            data=json.dumps({"status": "online"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "online"
+
+    def test_transfer_chat(self, client):
+        agent = self._login_agent(client)
+        agent2 = UserFactory(username="transfer_target")
+
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="Transfer", email="t@e.com")
+        session_service.assign_agent(session, agent)
+
+        response = client.post(
+            f"/support/agent/chat/{session.pk}/transfer/",
+            data=json.dumps({"agent_id": agent2.pk}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["chat"]["agent_id"] == agent2.pk
+
+    def test_update_typing(self, client):
+        self._login_agent(client)
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="Typing", email="ty@e.com")
+
+        response = client.post(
+            f"/support/agent/chat/{session.pk}/typing/",
+            data=json.dumps({"is_typing": True}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# View tests - Widget chat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestWidgetChatViews:
+    def setup_method(self):
+        cache.clear()
+
+    def test_availability_no_agents(self, client):
+        response = client.get("/support/widget/chat/availability/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["available"] is False
+
+    def test_availability_with_agent(self, client):
+        user = UserFactory(username="widget_agent")
+        AgentProfile.objects.create(user=user, chat_status=AgentProfile.ChatStatus.ONLINE)
+
+        response = client.get("/support/widget/chat/availability/")
+        assert response.status_code == 200
+        assert response.json()["available"] is True
+
+    def test_start_chat(self, client):
+        response = client.post(
+            "/support/widget/chat/start/",
+            data=json.dumps({"name": "Visitor", "email": "visitor@example.com"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["session_id"]
+        assert data["ticket_reference"]
+
+    def test_start_chat_validation(self, client):
+        response = client.post(
+            "/support/widget/chat/start/",
+            data=json.dumps({"name": "", "email": ""}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_send_message(self, client):
+        # Start a chat first
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="Msg", email="msg@e.com")
+
+        response = client.post(
+            "/support/widget/chat/message/",
+            data=json.dumps({"session_id": session.customer_session_id, "body": "Hello"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["message"]["body"] == "Hello"
+
+    def test_end_chat(self, client):
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="End", email="end@e.com")
+
+        response = client.post(
+            "/support/widget/chat/end/",
+            data=json.dumps({"session_id": session.customer_session_id}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+    def test_rate_chat(self, client):
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="Rate", email="rate@e.com")
+        agent = UserFactory(username="rate_agent")
+        session_service.assign_agent(session, agent)
+        session_service.end_chat(session)
+
+        response = client.post(
+            "/support/widget/chat/rate/",
+            data=json.dumps(
+                {
+                    "session_id": session.customer_session_id,
+                    "rating": 4,
+                    "comment": "Good",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+    def test_rate_chat_invalid_rating(self, client):
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="Rate2", email="rate2@e.com")
+        agent = UserFactory(username="rate_agent2")
+        session_service.assign_agent(session, agent)
+        session_service.end_chat(session)
+
+        response = client.post(
+            "/support/widget/chat/rate/",
+            data=json.dumps(
+                {
+                    "session_id": session.customer_session_id,
+                    "rating": 10,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_typing(self, client):
+        session_service = ChatSessionService()
+        _, session = session_service.start_chat(name="Typ", email="typ@e.com")
+
+        response = client.post(
+            "/support/widget/chat/typing/",
+            data=json.dumps({"session_id": session.customer_session_id, "is_typing": True}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Management command tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCloseIdleChatsCommand:
+    def test_closes_idle_sessions(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        service = ChatSessionService()
+        _, session = service.start_chat(name="Idle", email="idle@e.com")
+        agent = UserFactory(username="idle_agent")
+        service.assign_agent(session, agent)
+
+        # Make the session appear idle by backdating updated_at
+        ChatSession.objects.filter(pk=session.pk).update(
+            updated_at=timezone.now() - timedelta(minutes=60),
+        )
+
+        out = StringIO()
+        call_command("close_idle_chats", "--minutes=30", stdout=out)
+        output = out.getvalue()
+        assert "1" in output
+
+        session.refresh_from_db()
+        assert session.status == ChatSession.Status.ENDED
+
+    def test_dry_run(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        service = ChatSessionService()
+        _, session = service.start_chat(name="Dry", email="dry@e.com")
+        agent = UserFactory(username="dry_agent")
+        service.assign_agent(session, agent)
+
+        ChatSession.objects.filter(pk=session.pk).update(
+            updated_at=timezone.now() - timedelta(minutes=60),
+        )
+
+        out = StringIO()
+        call_command("close_idle_chats", "--minutes=30", "--dry-run", stdout=out)
+        output = out.getvalue()
+        assert "DRY RUN" in output
+
+        session.refresh_from_db()
+        assert session.status == ChatSession.Status.ACTIVE
+
+
+@pytest.mark.django_db
+class TestCleanupAbandonedChatsCommand:
+    def test_marks_abandoned(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        service = ChatSessionService()
+        _, session = service.start_chat(name="Abandon", email="abandon@e.com")
+
+        # Backdate created_at
+        ChatSession.objects.filter(pk=session.pk).update(
+            created_at=timezone.now() - timedelta(minutes=20),
+        )
+
+        out = StringIO()
+        call_command("cleanup_abandoned_chats", "--minutes=10", stdout=out)
+        output = out.getvalue()
+        assert "1" in output
+
+        session.refresh_from_db()
+        assert session.status == ChatSession.Status.ABANDONED
+
+    def test_no_abandoned(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("cleanup_abandoned_chats", "--minutes=10", stdout=out)
+        assert "No abandoned" in out.getvalue()


### PR DESCRIPTION
## Summary

- Add real-time live chat as a new ticket channel (`channel='chat'`) with ChatSession and ChatRoutingRule models
- Implement ChatSessionService (start/assign/end/transfer/message/typing/rate), ChatRoutingService (agent routing with round-robin/least-active/random strategies), and ChatAvailabilityService (online status and queue position)
- Add agent-facing chat views (`/support/agent/chat/`) and public widget chat views (`/support/widget/chat/`) with rate limiting
- Include Django Channels WebSocket consumer (ChatConsumer) with graceful fallback when channels is not installed
- Add `close_idle_chats` and `cleanup_abandoned_chats` management commands
- 45 pytest tests covering models, querysets, services, views, and management commands (639 total tests pass)

## Test plan

- [x] All 639 existing + new tests pass (`python -m pytest tests/`)
- [x] Ruff lint and format checks pass
- [ ] Verify migration applies cleanly on a fresh database
- [ ] Test agent chat flow: set status online, customer starts chat, agent accepts, exchange messages, agent ends chat
- [ ] Test widget chat flow: check availability, start chat, send messages, end chat, rate chat
- [ ] Test routing: verify round-robin/least-active agent assignment and capacity limits
- [ ] Test management commands: `close_idle_chats --dry-run` and `cleanup_abandoned_chats --dry-run`