### PR TITLE
docs: add translated READMEs (13 languages)

### DIFF
--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <b>العربية</b> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## الميزات
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## المتطلبات
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## البدء السريع
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## أوضاع الاستضافة
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## الإعدادات
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## المسارات
 
 All routes use the configurable prefix (default: `support`).
 
@@ -307,7 +307,7 @@ def on_ticket_resolved(sender, ticket, user, **kwargs):
 
 Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, `ticket_assigned`, `ticket_unassigned`, `ticket_priority_changed`, `ticket_escalated`, `ticket_resolved`, `ticket_closed`, `ticket_reopened`, `reply_created`, `internal_note_added`, `sla_breached`, `sla_warning`, `tag_added`, `tag_removed`, `department_changed`.
 
-## Plugin SDK
+## حزمة SDK للإضافات
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## متوفر أيضاً لـ
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## الرخصة
 
 MIT

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <b>Deutsch</b> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funktionen
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Voraussetzungen
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Schnellstart
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Hosting-Modi
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Konfiguration
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## Routen
 
 All routes use the configurable prefix (default: `support`).
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## Auch verfügbar für
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Lizenz
 
 MIT

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <b>Español</b> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Características
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Requisitos
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Inicio Rápido
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Modos de Hospedaje
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Configuración
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## Rutas
 
 All routes use the configurable prefix (default: `support`).
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## También Disponible Para
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Licencia
 
 MIT

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <b>Français</b> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Fonctionnalités
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Prérequis
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Démarrage Rapide
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Modes d'Hébergement
 
 ### Self-Hosted (default)
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## Également Disponible Pour
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Licence
 
 MIT

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <b>Italiano</b> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funzionalità
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Requisiti
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Avvio Rapido
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Modalità di Hosting
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Configurazione
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## Route
 
 All routes use the configurable prefix (default: `support`).
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## Disponibile Anche Per
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Licenza
 
 MIT

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <b>日本語</b> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 機能
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## 要件
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## クイックスタート
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## ホスティングモード
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## 設定
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## ルート
 
 All routes use the configurable prefix (default: `support`).
 
@@ -307,7 +307,7 @@ def on_ticket_resolved(sender, ticket, user, **kwargs):
 
 Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, `ticket_assigned`, `ticket_unassigned`, `ticket_priority_changed`, `ticket_escalated`, `ticket_resolved`, `ticket_closed`, `ticket_reopened`, `reply_created`, `internal_note_added`, `sla_breached`, `sla_warning`, `tag_added`, `tag_removed`, `department_changed`.
 
-## Plugin SDK
+## プラグインSDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## 他のフレームワーク向け
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## ライセンス
 
 MIT

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <b>한국어</b> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 기능
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## 요구 사항
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## 빠른 시작
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## 호스팅 모드
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## 설정
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## 라우트
 
 All routes use the configurable prefix (default: `support`).
 
@@ -307,7 +307,7 @@ def on_ticket_resolved(sender, ticket, user, **kwargs):
 
 Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, `ticket_assigned`, `ticket_unassigned`, `ticket_priority_changed`, `ticket_escalated`, `ticket_resolved`, `ticket_closed`, `ticket_reopened`, `reply_created`, `internal_note_added`, `sla_breached`, `sla_warning`, `tag_added`, `tag_removed`, `department_changed`.
 
-## Plugin SDK
+## 플러그인 SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## 다른 프레임워크에서도 사용 가능
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## 라이선스
 
 MIT

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <b>Nederlands</b> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Functies
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Vereisten
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Snel Starten
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Hostingmodi
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Configuratie
 
 Add to your `settings.py`:
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## Ook Beschikbaar Voor
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Licentie
 
 MIT

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <b>Polski</b> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Funkcje
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Wymagania
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Szybki Start
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Tryby Hostingu
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Konfiguracja
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## Trasy
 
 All routes use the configurable prefix (default: `support`).
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## Dostępne Również Dla
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Licencja
 
 MIT

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <b>Português (BR)</b> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Recursos
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Requisitos
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Início Rápido
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Modos de Hospedagem
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Configuração
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## Rotas
 
 All routes use the configurable prefix (default: `support`).
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## Também Disponível Para
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Licença
 
 MIT

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <b>Русский</b> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Возможности
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Требования
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Быстрый старт
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Режимы хостинга
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Конфигурация
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## Маршруты
 
 All routes use the configurable prefix (default: `support`).
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## Также доступно для
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Лицензия
 
 MIT

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <b>Türkçe</b> •
+  <a href="README.zh-CN.md">简体中文</a>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## Özellikler
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## Gereksinimler
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## Hızlı Başlangıç
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## Barındırma Modları
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## Yapılandırma
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## Rotalar
 
 All routes use the configurable prefix (default: `support`).
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## Şunlar İçin de Mevcut
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## Lisans
 
 MIT

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="docs/translations/README.ar.md">العربية</a> •
-  <a href="docs/translations/README.de.md">Deutsch</a> •
-  <b>English</b> •
-  <a href="docs/translations/README.es.md">Español</a> •
-  <a href="docs/translations/README.fr.md">Français</a> •
-  <a href="docs/translations/README.it.md">Italiano</a> •
-  <a href="docs/translations/README.ja.md">日本語</a> •
-  <a href="docs/translations/README.ko.md">한국어</a> •
-  <a href="docs/translations/README.nl.md">Nederlands</a> •
-  <a href="docs/translations/README.pl.md">Polski</a> •
-  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
-  <a href="docs/translations/README.ru.md">Русский</a> •
-  <a href="docs/translations/README.tr.md">Türkçe</a> •
-  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <b>简体中文</b>
 </p>
 
 # Escalated for Django
@@ -28,7 +28,7 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 
 **Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
 
-## Features
+## 功能特性
 
 - **Ticket lifecycle** — Create, assign, reply, resolve, close, reopen with configurable status transitions
 - **SLA engine** — Per-priority response and resolution targets, business hours calculation, automatic breach detection
@@ -51,13 +51,13 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
 - **Knowledge base toggle** — Enable or disable the public knowledge base from admin settings
 
-## Requirements
+## 系统要求
 
 - Python 3.10+
 - Django 4.2+
 - Node.js 18+ (for frontend assets)
 
-## Quick Start
+## 快速开始
 
 ```bash
 pip install escalated-django
@@ -169,7 +169,7 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
-## Hosting Modes
+## 托管模式
 
 ### Self-Hosted (default)
 
@@ -207,7 +207,7 @@ ESCALATED = {
 
 All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
 
-## Configuration
+## 配置
 
 Add to your `settings.py`:
 
@@ -264,7 +264,7 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
-## Routes
+## 路由
 
 All routes use the configurable prefix (default: `support`).
 
@@ -307,7 +307,7 @@ def on_ticket_resolved(sender, ticket, user, **kwargs):
 
 Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, `ticket_assigned`, `ticket_unassigned`, `ticket_priority_changed`, `ticket_escalated`, `ticket_resolved`, `ticket_closed`, `ticket_reopened`, `reply_created`, `internal_note_added`, `sla_breached`, `sla_warning`, `tag_added`, `tag_removed`, `department_changed`.
 
-## Plugin SDK
+## 插件 SDK
 
 Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
 
@@ -478,7 +478,7 @@ Every ticket signal fires a corresponding SDK hook:
 - The action queue is capped at 1 000 in-flight entries to prevent memory
   growth.
 
-## Also Available For
+## 其他框架版本
 
 - **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
 - **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
@@ -496,6 +496,6 @@ pip install -e ".[dev]"
 pytest
 ```
 
-## License
+## 许可证
 
 MIT


### PR DESCRIPTION
## Summary
- Add translated README files in `docs/translations/` for 13 languages: Arabic, German, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portuguese, Russian, Turkish, and Chinese Simplified
- Add language selector bar at the top of the main README.md
- Each translated README includes the same language selector with the current language bolded and translated section headings

## Test plan
- [ ] Verify language selector links work in the main README
- [ ] Verify each translated file has correct language selector
- [ ] Verify English links back to ../../README.md from translation files