### PR TITLE
feat: add 10 additional locales

### DIFF
--- a/escalated/locale/ar/LC_MESSAGES/django.po
+++ b/escalated/locale/ar/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ar\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "مفتوح"
+
+msgid "In Progress"
+msgstr "قيد التنفيذ"
+
+msgid "Waiting on Customer"
+msgstr "بانتظار العميل"
+
+msgid "Waiting on Agent"
+msgstr "بانتظار الوكيل"
+
+msgid "Escalated"
+msgstr "مُصعَّد"
+
+msgid "Resolved"
+msgstr "تم الحل"
+
+msgid "Closed"
+msgstr "مغلق"
+
+msgid "Reopened"
+msgstr "أُعيد فتحه"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "منخفض"
+
+msgid "Medium"
+msgstr "متوسط"
+
+msgid "High"
+msgstr "مرتفع"
+
+msgid "Urgent"
+msgstr "عاجل"
+
+msgid "Critical"
+msgstr "حرج"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "رد"
+
+msgid "Internal Note"
+msgstr "ملاحظة داخلية"
+
+msgid "System"
+msgstr "النظام"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "تم الإنشاء"
+
+msgid "Status Changed"
+msgstr "تم تغيير الحالة"
+
+msgid "Priority Changed"
+msgstr "تم تغيير الأولوية"
+
+msgid "Assigned"
+msgstr "تم التعيين"
+
+msgid "Unassigned"
+msgstr "غير معيَّن"
+
+msgid "Reply Added"
+msgstr "تمت إضافة رد"
+
+msgid "Note Added"
+msgstr "تمت إضافة ملاحظة"
+
+msgid "Tag Added"
+msgstr "تمت إضافة وسم"
+
+msgid "Tag Removed"
+msgstr "تمت إزالة وسم"
+
+msgid "Department Changed"
+msgstr "تم تغيير القسم"
+
+msgid "SLA Breached"
+msgstr "تم انتهاك SLA"
+
+msgid "Attachment Added"
+msgstr "تمت إضافة مرفق"
+
+msgid "Merged"
+msgstr "تم الدمج"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "انتهاك SLA"
+
+msgid "Priority Change"
+msgstr "تغيير الأولوية"
+
+msgid "No Response"
+msgstr "لا استجابة"
+
+msgid "Customer Reply"
+msgstr "رد العميل"
+
+msgid "Time Based"
+msgstr "مبني على الوقت"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "قيد الانتظار"
+
+msgid "Processed"
+msgstr "تمت المعالجة"
+
+msgid "Failed"
+msgstr "فشل"
+
+msgid "Spam"
+msgstr "بريد مزعج"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "سياسة SLA"
+
+msgid "SLA Policies"
+msgstr "سياسات SLA"
+
+msgid "Ticket activities"
+msgstr "أنشطة التذاكر"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "ليس لديك إذن للوصول إلى لوحة الوكيل."
+
+msgid "You do not have permission to access the admin area."
+msgstr "ليس لديك إذن للوصول إلى منطقة الإدارة."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "الطريقة غير مسموحة"
+
+msgid "Ticket not found"
+msgstr "التذكرة غير موجودة"
+
+msgid "Agent access required."
+msgstr "يتطلب صلاحية وكيل."
+
+msgid "Admin access required."
+msgstr "يتطلب صلاحية مسؤول."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "الموضوع مطلوب."
+
+msgid "Description is required."
+msgstr "الوصف مطلوب."
+
+msgid "You cannot view this ticket."
+msgstr "لا يمكنك عرض هذه التذكرة."
+
+msgid "You cannot reply to this ticket."
+msgstr "لا يمكنك الرد على هذه التذكرة."
+
+msgid "You cannot close this ticket."
+msgstr "لا يمكنك إغلاق هذه التذكرة."
+
+msgid "You cannot reopen this ticket."
+msgstr "لا يمكنك إعادة فتح هذه التذكرة."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "يمكنك تقييم التذاكر المحلولة أو المغلقة فقط."
+
+msgid "This ticket has already been rated."
+msgstr "تم تقييم هذه التذكرة بالفعل."
+
+msgid "Rating must be between 1 and 5."
+msgstr "يجب أن يكون التقييم بين 1 و 5."
+
+msgid "Invalid rating value."
+msgstr "قيمة تقييم غير صالحة."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "لا يمكنك تحديث هذه التذكرة."
+
+msgid "Agent not found"
+msgstr "الوكيل غير موجود"
+
+msgid "Invalid status."
+msgstr "حالة غير صالحة."
+
+msgid "Invalid priority."
+msgstr "أولوية غير صالحة."
+
+msgid "Only internal notes can be pinned."
+msgstr "يمكن تثبيت الملاحظات الداخلية فقط."
+
+msgid "Macro not found"
+msgstr "الماكرو غير موجود"
+
+msgid "Reply not found"
+msgstr "الرد غير موجود"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "تذاكر الضيوف غير مفعّلة."
+
+msgid "Name is required."
+msgstr "الاسم مطلوب."
+
+msgid "Email is required."
+msgstr "البريد الإلكتروني مطلوب."
+
+msgid "Ticket not found."
+msgstr "التذكرة غير موجودة."
+
+msgid "This ticket is closed."
+msgstr "هذه التذكرة مغلقة."
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "القسم غير موجود"
+
+msgid "SLA Policy not found"
+msgstr "سياسة SLA غير موجودة"
+
+msgid "Escalation rule not found"
+msgstr "قاعدة التصعيد غير موجودة"
+
+msgid "Tag not found"
+msgstr "الوسم غير موجود"
+
+msgid "Canned response not found"
+msgstr "الرد الجاهز غير موجود"
+
+msgid "Title is required."
+msgstr "العنوان مطلوب."
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "معالجة البريد الوارد معطلة."
+
+msgid "Request verification failed."
+msgstr "فشل التحقق من الطلب."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "تذكرة جديدة: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "رد جديد على: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "رد العميل على: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "تم تعيين تذكرة لك: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "تم تحديث الحالة: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "فحص جميع التذاكر المفتوحة لانتهاكات SLA وإرسال تحذيرات."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "دقائق قبل موعد SLA لإطلاق تحذير (افتراضي: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "جارٍ فحص مواعيد SLA لجميع التذاكر المفتوحة..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "اكتمل فحص SLA: تم اكتشاف %(breached)d انتهاك، تم إرسال %(warned)d تحذير."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "إغلاق التذاكر تلقائيا التي تم حلها منذ عدد قابل للتهيئة من الأيام."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "الأيام بعد الحل للإغلاق التلقائي (يتجاوز الإعداد)"
+
+msgid "Show what would be closed without making changes"
+msgstr "عرض ما سيتم إغلاقه دون إجراء تغييرات"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[تجربة] سيتم إغلاق %(count)d تذكرة تم حلها منذ أكثر من %(days)d يوم."
+
+msgid "No resolved tickets to auto-close."
+msgstr "لا توجد تذاكر محلولة للإغلاق التلقائي."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "تم إغلاق %(count)d تذكرة تلقائيا تم حلها منذ أكثر من %(days)d يوم."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "تقييم جميع قواعد التصعيد النشطة على التذاكر المفتوحة."
+
+msgid "Evaluating escalation rules..."
+msgstr "جارٍ تقييم قواعد التصعيد..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "اكتمل تقييم التصعيد: تم اتخاذ %(count)d إجراء."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "تم إنشاء تذكرة دعم جديدة"
+
+msgid "Your support ticket has been created successfully."
+msgstr "تم إنشاء تذكرة الدعم بنجاح."
+
+msgid "Reference:"
+msgstr "المرجع:"
+
+msgid "Subject:"
+msgstr "الموضوع:"
+
+msgid "Priority:"
+msgstr "الأولوية:"
+
+msgid "Status:"
+msgstr "الحالة:"
+
+msgid "Description:"
+msgstr "الوصف:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "سيقوم فريقنا بمراجعة تذكرتك قريبا. ستتلقى تحديثات مع تقدم تذكرتك."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "هذه رسالة تلقائية من نظام الدعم. يرجى عدم الرد مباشرة على هذا البريد."
+
+msgid "New Reply on Ticket"
+msgstr "رد جديد على التذكرة"
+
+msgid "A new reply has been added:"
+msgstr "تمت إضافة رد جديد:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "سجل الدخول إلى حسابك لعرض المحادثة الكاملة والرد."
+
+msgid "Ticket Assigned to You"
+msgstr "تم تعيين تذكرة لك"
+
+msgid "A support ticket has been assigned to you."
+msgstr "تم تعيين تذكرة دعم لك."
+
+msgid "Department:"
+msgstr "القسم:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "يرجى المراجعة والرد على هذه التذكرة في أقرب وقت."
+
+msgid "This is an automated message from the support system."
+msgstr "هذه رسالة تلقائية من نظام الدعم."
+
+msgid "Ticket Status Updated"
+msgstr "تم تحديث حالة التذكرة"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "سجل الدخول إلى حسابك لعرض جميع تفاصيل تذكرتك."
+
+msgid "SLA Breach Alert"
+msgstr "تنبيه انتهاك SLA"
+
+msgid "Breach Type:"
+msgstr "نوع الانتهاك:"
+
+msgid "Assigned To:"
+msgstr "معيَّن إلى:"
+
+msgid "Immediate action is required."
+msgstr "يتطلب إجراء فوري."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "يرجى مراجعة هذه التذكرة واتخاذ الإجراء المناسب."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "هذا تنبيه مراقبة SLA تلقائي من نظام الدعم."
+
+msgid "Ticket Escalated"
+msgstr "تم تصعيد التذكرة"
+
+msgid "Reason:"
+msgstr "السبب:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "تتطلب هذه التذكرة اهتماما فوريا. يرجى المراجعة واتخاذ إجراء."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "هذا تنبيه تصعيد تلقائي من نظام الدعم."
+
+msgid "Ticket Resolved"
+msgstr "تم حل التذكرة"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "إذا كنت تعتقد أن هذه المشكلة لم تُحل بالكامل، يمكنك إعادة فتح التذكرة بتسجيل الدخول."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "شكرا لتواصلك معنا. نأمل أننا تمكنا من مساعدتك!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "الدعم المتصاعد"

--- a/escalated/locale/it/LC_MESSAGES/django.po
+++ b/escalated/locale/it/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: it\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "Aperto"
+
+msgid "In Progress"
+msgstr "In corso"
+
+msgid "Waiting on Customer"
+msgstr "In attesa del cliente"
+
+msgid "Waiting on Agent"
+msgstr "In attesa dell'agente"
+
+msgid "Escalated"
+msgstr "Escalato"
+
+msgid "Resolved"
+msgstr "Risolto"
+
+msgid "Closed"
+msgstr "Chiuso"
+
+msgid "Reopened"
+msgstr "Riaperto"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "Bassa"
+
+msgid "Medium"
+msgstr "Media"
+
+msgid "High"
+msgstr "Alta"
+
+msgid "Urgent"
+msgstr "Urgente"
+
+msgid "Critical"
+msgstr "Critica"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "Risposta"
+
+msgid "Internal Note"
+msgstr "Nota interna"
+
+msgid "System"
+msgstr "Sistema"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "Creato"
+
+msgid "Status Changed"
+msgstr "Stato modificato"
+
+msgid "Priority Changed"
+msgstr "Priorita modificata"
+
+msgid "Assigned"
+msgstr "Assegnato"
+
+msgid "Unassigned"
+msgstr "Non assegnato"
+
+msgid "Reply Added"
+msgstr "Risposta aggiunta"
+
+msgid "Note Added"
+msgstr "Nota aggiunta"
+
+msgid "Tag Added"
+msgstr "Tag aggiunto"
+
+msgid "Tag Removed"
+msgstr "Tag rimosso"
+
+msgid "Department Changed"
+msgstr "Reparto modificato"
+
+msgid "SLA Breached"
+msgstr "SLA violato"
+
+msgid "Attachment Added"
+msgstr "Allegato aggiunto"
+
+msgid "Merged"
+msgstr "Unito"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "Violazione SLA"
+
+msgid "Priority Change"
+msgstr "Cambio priorita"
+
+msgid "No Response"
+msgstr "Nessuna risposta"
+
+msgid "Customer Reply"
+msgstr "Risposta del cliente"
+
+msgid "Time Based"
+msgstr "Basato sul tempo"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "In sospeso"
+
+msgid "Processed"
+msgstr "Elaborato"
+
+msgid "Failed"
+msgstr "Fallito"
+
+msgid "Spam"
+msgstr "Spam"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "Policy SLA"
+
+msgid "SLA Policies"
+msgstr "Policy SLA"
+
+msgid "Ticket activities"
+msgstr "Attivita dei ticket"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "Non hai il permesso di accedere alla dashboard dell'agente."
+
+msgid "You do not have permission to access the admin area."
+msgstr "Non hai il permesso di accedere all'area amministrativa."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "Metodo non consentito"
+
+msgid "Ticket not found"
+msgstr "Ticket non trovato"
+
+msgid "Agent access required."
+msgstr "Accesso agente richiesto."
+
+msgid "Admin access required."
+msgstr "Accesso amministratore richiesto."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "L'oggetto e obbligatorio."
+
+msgid "Description is required."
+msgstr "La descrizione e obbligatoria."
+
+msgid "You cannot view this ticket."
+msgstr "Non puoi visualizzare questo ticket."
+
+msgid "You cannot reply to this ticket."
+msgstr "Non puoi rispondere a questo ticket."
+
+msgid "You cannot close this ticket."
+msgstr "Non puoi chiudere questo ticket."
+
+msgid "You cannot reopen this ticket."
+msgstr "Non puoi riaprire questo ticket."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "Puoi valutare solo i ticket risolti o chiusi."
+
+msgid "This ticket has already been rated."
+msgstr "Questo ticket e gia stato valutato."
+
+msgid "Rating must be between 1 and 5."
+msgstr "La valutazione deve essere tra 1 e 5."
+
+msgid "Invalid rating value."
+msgstr "Valore di valutazione non valido."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "Non puoi aggiornare questo ticket."
+
+msgid "Agent not found"
+msgstr "Agente non trovato"
+
+msgid "Invalid status."
+msgstr "Stato non valido."
+
+msgid "Invalid priority."
+msgstr "Priorita non valida."
+
+msgid "Only internal notes can be pinned."
+msgstr "Solo le note interne possono essere fissate."
+
+msgid "Macro not found"
+msgstr "Macro non trovata"
+
+msgid "Reply not found"
+msgstr "Risposta non trovata"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "I ticket per gli ospiti non sono abilitati."
+
+msgid "Name is required."
+msgstr "Il nome e obbligatorio."
+
+msgid "Email is required."
+msgstr "L'email e obbligatoria."
+
+msgid "Ticket not found."
+msgstr "Ticket non trovato."
+
+msgid "This ticket is closed."
+msgstr "Questo ticket e chiuso."
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "Reparto non trovato"
+
+msgid "SLA Policy not found"
+msgstr "Policy SLA non trovata"
+
+msgid "Escalation rule not found"
+msgstr "Regola di escalation non trovata"
+
+msgid "Tag not found"
+msgstr "Tag non trovato"
+
+msgid "Canned response not found"
+msgstr "Risposta predefinita non trovata"
+
+msgid "Title is required."
+msgstr "Il titolo e obbligatorio."
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "L'elaborazione delle email in entrata e disabilitata."
+
+msgid "Request verification failed."
+msgstr "Verifica della richiesta fallita."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "Nuovo ticket: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "Nuova risposta su: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "Risposta del cliente su: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "Ticket assegnato a te: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "Stato aggiornato: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "Controlla tutti i ticket aperti per violazioni SLA e invia avvisi."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "Minuti prima della scadenza SLA per attivare l'avviso (predefinito: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "Controllo scadenze SLA per tutti i ticket aperti..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "Controllo SLA completato: %(breached)d violazioni rilevate, %(warned)d avvisi inviati."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "Chiudi automaticamente i ticket risolti da un numero configurabile di giorni."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "Giorni dopo la risoluzione per la chiusura automatica"
+
+msgid "Show what would be closed without making changes"
+msgstr "Mostra cosa verrebbe chiuso senza apportare modifiche"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[SIMULAZIONE] Verrebbero chiusi %(count)d ticket risolti da piu di %(days)d giorni."
+
+msgid "No resolved tickets to auto-close."
+msgstr "Nessun ticket risolto da chiudere automaticamente."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "Chiusi automaticamente %(count)d ticket risolti da piu di %(days)d giorni."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "Valuta tutte le regole di escalation attive sui ticket aperti."
+
+msgid "Evaluating escalation rules..."
+msgstr "Valutazione regole di escalation..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "Valutazione escalation completata: %(count)d azioni eseguite."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "Nuovo ticket di supporto creato"
+
+msgid "Your support ticket has been created successfully."
+msgstr "Il tuo ticket di supporto e stato creato con successo."
+
+msgid "Reference:"
+msgstr "Riferimento:"
+
+msgid "Subject:"
+msgstr "Oggetto:"
+
+msgid "Priority:"
+msgstr "Priorita:"
+
+msgid "Status:"
+msgstr "Stato:"
+
+msgid "Description:"
+msgstr "Descrizione:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "Il nostro team esaminera il tuo ticket a breve. Riceverai aggiornamenti."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "Questo e un messaggio automatico dal sistema di supporto. Non rispondere direttamente."
+
+msgid "New Reply on Ticket"
+msgstr "Nuova risposta sul ticket"
+
+msgid "A new reply has been added:"
+msgstr "Una nuova risposta e stata aggiunta:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "Accedi al tuo account per visualizzare la conversazione completa e rispondere."
+
+msgid "Ticket Assigned to You"
+msgstr "Ticket assegnato a te"
+
+msgid "A support ticket has been assigned to you."
+msgstr "Un ticket di supporto ti e stato assegnato."
+
+msgid "Department:"
+msgstr "Reparto:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "Si prega di esaminare e rispondere al piu presto."
+
+msgid "This is an automated message from the support system."
+msgstr "Questo e un messaggio automatico dal sistema di supporto."
+
+msgid "Ticket Status Updated"
+msgstr "Stato del ticket aggiornato"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "Accedi per visualizzare tutti i dettagli del tuo ticket."
+
+msgid "SLA Breach Alert"
+msgstr "Avviso violazione SLA"
+
+msgid "Breach Type:"
+msgstr "Tipo di violazione:"
+
+msgid "Assigned To:"
+msgstr "Assegnato a:"
+
+msgid "Immediate action is required."
+msgstr "E richiesta un'azione immediata."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "Si prega di esaminare questo ticket e intraprendere l'azione appropriata."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "Avviso automatico di monitoraggio SLA."
+
+msgid "Ticket Escalated"
+msgstr "Ticket escalato"
+
+msgid "Reason:"
+msgstr "Motivo:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "Questo ticket richiede attenzione immediata."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "Avviso automatico di escalation."
+
+msgid "Ticket Resolved"
+msgstr "Ticket risolto"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "Se il problema non e risolto, puoi riaprire il ticket accedendo al tuo account."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "Grazie per averci contattato!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Supporto Escalated"

--- a/escalated/locale/ja/LC_MESSAGES/django.po
+++ b/escalated/locale/ja/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ja\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "オープン"
+
+msgid "In Progress"
+msgstr "対応中"
+
+msgid "Waiting on Customer"
+msgstr "顧客待ち"
+
+msgid "Waiting on Agent"
+msgstr "エージェント待ち"
+
+msgid "Escalated"
+msgstr "エスカレーション済み"
+
+msgid "Resolved"
+msgstr "解決済み"
+
+msgid "Closed"
+msgstr "クローズ"
+
+msgid "Reopened"
+msgstr "再開"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "低"
+
+msgid "Medium"
+msgstr "中"
+
+msgid "High"
+msgstr "高"
+
+msgid "Urgent"
+msgstr "緊急"
+
+msgid "Critical"
+msgstr "重大"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "返信"
+
+msgid "Internal Note"
+msgstr "内部メモ"
+
+msgid "System"
+msgstr "システム"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "作成"
+
+msgid "Status Changed"
+msgstr "ステータス変更"
+
+msgid "Priority Changed"
+msgstr "優先度変更"
+
+msgid "Assigned"
+msgstr "割り当て済み"
+
+msgid "Unassigned"
+msgstr "未割り当て"
+
+msgid "Reply Added"
+msgstr "返信追加"
+
+msgid "Note Added"
+msgstr "メモ追加"
+
+msgid "Tag Added"
+msgstr "タグ追加"
+
+msgid "Tag Removed"
+msgstr "タグ削除"
+
+msgid "Department Changed"
+msgstr "部門変更"
+
+msgid "SLA Breached"
+msgstr "SLA違反"
+
+msgid "Attachment Added"
+msgstr "添付ファイル追加"
+
+msgid "Merged"
+msgstr "マージ済み"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "SLA違反"
+
+msgid "Priority Change"
+msgstr "優先度変更"
+
+msgid "No Response"
+msgstr "応答なし"
+
+msgid "Customer Reply"
+msgstr "顧客返信"
+
+msgid "Time Based"
+msgstr "時間ベース"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "保留中"
+
+msgid "Processed"
+msgstr "処理済み"
+
+msgid "Failed"
+msgstr "失敗"
+
+msgid "Spam"
+msgstr "スパム"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "SLAポリシー"
+
+msgid "SLA Policies"
+msgstr "SLAポリシー"
+
+msgid "Ticket activities"
+msgstr "チケットアクティビティ"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "エージェントダッシュボードにアクセスする権限がありません。"
+
+msgid "You do not have permission to access the admin area."
+msgstr "管理エリアにアクセスする権限がありません。"
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "メソッドが許可されていません"
+
+msgid "Ticket not found"
+msgstr "チケットが見つかりません"
+
+msgid "Agent access required."
+msgstr "エージェントアクセスが必要です。"
+
+msgid "Admin access required."
+msgstr "管理者アクセスが必要です。"
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "件名は必須です。"
+
+msgid "Description is required."
+msgstr "説明は必須です。"
+
+msgid "You cannot view this ticket."
+msgstr "このチケットを表示できません。"
+
+msgid "You cannot reply to this ticket."
+msgstr "このチケットに返信できません。"
+
+msgid "You cannot close this ticket."
+msgstr "このチケットをクローズできません。"
+
+msgid "You cannot reopen this ticket."
+msgstr "このチケットを再開できません。"
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "解決済みまたはクローズ済みのチケットのみ評価できます。"
+
+msgid "This ticket has already been rated."
+msgstr "このチケットは既に評価されています。"
+
+msgid "Rating must be between 1 and 5."
+msgstr "評価は1から5の間である必要があります。"
+
+msgid "Invalid rating value."
+msgstr "無効な評価値です。"
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "このチケットを更新できません。"
+
+msgid "Agent not found"
+msgstr "エージェントが見つかりません"
+
+msgid "Invalid status."
+msgstr "無効なステータスです。"
+
+msgid "Invalid priority."
+msgstr "無効な優先度です。"
+
+msgid "Only internal notes can be pinned."
+msgstr "内部メモのみピン留めできます。"
+
+msgid "Macro not found"
+msgstr "マクロが見つかりません"
+
+msgid "Reply not found"
+msgstr "返信が見つかりません"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "ゲストチケットは有効になっていません。"
+
+msgid "Name is required."
+msgstr "名前は必須です。"
+
+msgid "Email is required."
+msgstr "メールアドレスは必須です。"
+
+msgid "Ticket not found."
+msgstr "チケットが見つかりません。"
+
+msgid "This ticket is closed."
+msgstr "このチケットはクローズされています。"
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "部門が見つかりません"
+
+msgid "SLA Policy not found"
+msgstr "SLAポリシーが見つかりません"
+
+msgid "Escalation rule not found"
+msgstr "エスカレーションルールが見つかりません"
+
+msgid "Tag not found"
+msgstr "タグが見つかりません"
+
+msgid "Canned response not found"
+msgstr "定型応答が見つかりません"
+
+msgid "Title is required."
+msgstr "タイトルは必須です。"
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "受信メール処理は無効です。"
+
+msgid "Request verification failed."
+msgstr "リクエスト検証に失敗しました。"
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "新規チケット: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "新しい返信: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "顧客からの返信: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "チケットが割り当てられました: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "ステータス更新: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "全てのオープンチケットのSLA違反を確認し警告を送信します。"
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "SLA期限前の警告トリガー分数（デフォルト: 30）"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "全オープンチケットのSLA期限を確認中..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "SLA確認完了: %(breached)d件の違反検出、%(warned)d件の警告送信。"
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "設定可能な日数で解決済みチケットを自動クローズします。"
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "自動クローズまでの解決後日数"
+
+msgid "Show what would be closed without making changes"
+msgstr "変更せずにクローズされるものを表示"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[テスト] %(days)d日以上前に解決された%(count)d件のチケットがクローズされます。"
+
+msgid "No resolved tickets to auto-close."
+msgstr "自動クローズする解決済みチケットはありません。"
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "%(days)d日以上前に解決された%(count)d件のチケットを自動クローズしました。"
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "全てのアクティブなエスカレーションルールを評価します。"
+
+msgid "Evaluating escalation rules..."
+msgstr "エスカレーションルールを評価中..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "エスカレーション評価完了: %(count)d件のアクション実行。"
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "新規サポートチケット作成"
+
+msgid "Your support ticket has been created successfully."
+msgstr "サポートチケットが正常に作成されました。"
+
+msgid "Reference:"
+msgstr "参照:"
+
+msgid "Subject:"
+msgstr "件名:"
+
+msgid "Priority:"
+msgstr "優先度:"
+
+msgid "Status:"
+msgstr "ステータス:"
+
+msgid "Description:"
+msgstr "説明:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "チームが間もなくチケットを確認します。"
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "これはサポートシステムからの自動メッセージです。直接返信しないでください。"
+
+msgid "New Reply on Ticket"
+msgstr "チケットへの新しい返信"
+
+msgid "A new reply has been added:"
+msgstr "新しい返信が追加されました:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "アカウントにログインして会話の全文を確認し返信してください。"
+
+msgid "Ticket Assigned to You"
+msgstr "チケットが割り当てられました"
+
+msgid "A support ticket has been assigned to you."
+msgstr "サポートチケットがあなたに割り当てられました。"
+
+msgid "Department:"
+msgstr "部門:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "できるだけ早くこのチケットを確認し返信してください。"
+
+msgid "This is an automated message from the support system."
+msgstr "これはサポートシステムからの自動メッセージです。"
+
+msgid "Ticket Status Updated"
+msgstr "チケットステータス更新"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "アカウントにログインしてチケットの詳細を確認してください。"
+
+msgid "SLA Breach Alert"
+msgstr "SLA違反アラート"
+
+msgid "Breach Type:"
+msgstr "違反タイプ:"
+
+msgid "Assigned To:"
+msgstr "担当者:"
+
+msgid "Immediate action is required."
+msgstr "即座の対応が必要です。"
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "このチケットを確認し適切な対応をしてください。"
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "自動SLA監視アラートです。"
+
+msgid "Ticket Escalated"
+msgstr "チケットエスカレーション"
+
+msgid "Reason:"
+msgstr "理由:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "このチケットは即座の対応が必要です。"
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "自動エスカレーションアラートです。"
+
+msgid "Ticket Resolved"
+msgstr "チケット解決済み"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "問題が完全に解決されていない場合はアカウントにログインしてチケットを再開できます。"
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "お問い合わせありがとうございます！"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Escalatedサポート"

--- a/escalated/locale/ko/LC_MESSAGES/django.po
+++ b/escalated/locale/ko/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ko\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "열림"
+
+msgid "In Progress"
+msgstr "진행 중"
+
+msgid "Waiting on Customer"
+msgstr "고객 대기"
+
+msgid "Waiting on Agent"
+msgstr "상담원 대기"
+
+msgid "Escalated"
+msgstr "에스컬레이션됨"
+
+msgid "Resolved"
+msgstr "해결됨"
+
+msgid "Closed"
+msgstr "종료"
+
+msgid "Reopened"
+msgstr "재개됨"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "낮음"
+
+msgid "Medium"
+msgstr "보통"
+
+msgid "High"
+msgstr "높음"
+
+msgid "Urgent"
+msgstr "긴급"
+
+msgid "Critical"
+msgstr "심각"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "답변"
+
+msgid "Internal Note"
+msgstr "내부 메모"
+
+msgid "System"
+msgstr "시스템"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "생성됨"
+
+msgid "Status Changed"
+msgstr "상태 변경"
+
+msgid "Priority Changed"
+msgstr "우선순위 변경"
+
+msgid "Assigned"
+msgstr "할당됨"
+
+msgid "Unassigned"
+msgstr "미할당"
+
+msgid "Reply Added"
+msgstr "답변 추가됨"
+
+msgid "Note Added"
+msgstr "메모 추가됨"
+
+msgid "Tag Added"
+msgstr "태그 추가됨"
+
+msgid "Tag Removed"
+msgstr "태그 제거됨"
+
+msgid "Department Changed"
+msgstr "부서 변경"
+
+msgid "SLA Breached"
+msgstr "SLA 위반"
+
+msgid "Attachment Added"
+msgstr "첨부파일 추가됨"
+
+msgid "Merged"
+msgstr "병합됨"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "SLA 위반"
+
+msgid "Priority Change"
+msgstr "우선순위 변경"
+
+msgid "No Response"
+msgstr "응답 없음"
+
+msgid "Customer Reply"
+msgstr "고객 답변"
+
+msgid "Time Based"
+msgstr "시간 기반"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "대기 중"
+
+msgid "Processed"
+msgstr "처리됨"
+
+msgid "Failed"
+msgstr "실패"
+
+msgid "Spam"
+msgstr "스팸"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "SLA 정책"
+
+msgid "SLA Policies"
+msgstr "SLA 정책"
+
+msgid "Ticket activities"
+msgstr "티켓 활동"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "상담원 대시보드에 접근할 권한이 없습니다."
+
+msgid "You do not have permission to access the admin area."
+msgstr "관리자 영역에 접근할 권한이 없습니다."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "허용되지 않는 메서드"
+
+msgid "Ticket not found"
+msgstr "티켓을 찾을 수 없음"
+
+msgid "Agent access required."
+msgstr "상담원 접근 권한이 필요합니다."
+
+msgid "Admin access required."
+msgstr "관리자 접근 권한이 필요합니다."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "제목은 필수입니다."
+
+msgid "Description is required."
+msgstr "설명은 필수입니다."
+
+msgid "You cannot view this ticket."
+msgstr "이 티켓을 볼 수 없습니다."
+
+msgid "You cannot reply to this ticket."
+msgstr "이 티켓에 답변할 수 없습니다."
+
+msgid "You cannot close this ticket."
+msgstr "이 티켓을 종료할 수 없습니다."
+
+msgid "You cannot reopen this ticket."
+msgstr "이 티켓을 재개할 수 없습니다."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "해결되었거나 종료된 티켓만 평가할 수 있습니다."
+
+msgid "This ticket has already been rated."
+msgstr "이 티켓은 이미 평가되었습니다."
+
+msgid "Rating must be between 1 and 5."
+msgstr "평가는 1에서 5 사이여야 합니다."
+
+msgid "Invalid rating value."
+msgstr "잘못된 평가 값입니다."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "이 티켓을 업데이트할 수 없습니다."
+
+msgid "Agent not found"
+msgstr "상담원을 찾을 수 없음"
+
+msgid "Invalid status."
+msgstr "잘못된 상태입니다."
+
+msgid "Invalid priority."
+msgstr "잘못된 우선순위입니다."
+
+msgid "Only internal notes can be pinned."
+msgstr "내부 메모만 고정할 수 있습니다."
+
+msgid "Macro not found"
+msgstr "매크로를 찾을 수 없음"
+
+msgid "Reply not found"
+msgstr "답변을 찾을 수 없음"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "게스트 티켓이 활성화되지 않았습니다."
+
+msgid "Name is required."
+msgstr "이름은 필수입니다."
+
+msgid "Email is required."
+msgstr "이메일은 필수입니다."
+
+msgid "Ticket not found."
+msgstr "티켓을 찾을 수 없습니다."
+
+msgid "This ticket is closed."
+msgstr "이 티켓은 종료되었습니다."
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "부서를 찾을 수 없음"
+
+msgid "SLA Policy not found"
+msgstr "SLA 정책을 찾을 수 없음"
+
+msgid "Escalation rule not found"
+msgstr "에스컬레이션 규칙을 찾을 수 없음"
+
+msgid "Tag not found"
+msgstr "태그를 찾을 수 없음"
+
+msgid "Canned response not found"
+msgstr "정형 응답을 찾을 수 없음"
+
+msgid "Title is required."
+msgstr "제목은 필수입니다."
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "수신 이메일 처리가 비활성화되어 있습니다."
+
+msgid "Request verification failed."
+msgstr "요청 인증에 실패했습니다."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "새 티켓: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "새 답변: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "고객 답변: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "티켓이 할당되었습니다: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "상태 업데이트: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "Check all open tickets for SLA breaches and send warnings."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "Minutes before SLA deadline to trigger warning (default: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "Checking SLA deadlines for all open tickets..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "Auto-close tickets that have been resolved for a configurable number of days."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "Days after resolution to auto-close (overrides setting)"
+
+msgid "Show what would be closed without making changes"
+msgstr "Show what would be closed without making changes"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+
+msgid "No resolved tickets to auto-close."
+msgstr "No resolved tickets to auto-close."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "Evaluate all active escalation rules against open tickets."
+
+msgid "Evaluating escalation rules..."
+msgstr "Evaluating escalation rules..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "Escalation evaluation complete: %(count)d actions taken."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "새 지원 티켓 생성됨"
+
+msgid "Your support ticket has been created successfully."
+msgstr "지원 티켓이 성공적으로 생성되었습니다."
+
+msgid "Reference:"
+msgstr "참조:"
+
+msgid "Subject:"
+msgstr "제목:"
+
+msgid "Priority:"
+msgstr "우선순위:"
+
+msgid "Status:"
+msgstr "상태:"
+
+msgid "Description:"
+msgstr "설명:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "This is an automated message from the support system. Please do not reply directly to this email."
+
+msgid "New Reply on Ticket"
+msgstr "티켓에 새 답변"
+
+msgid "A new reply has been added:"
+msgstr "A new reply has been added:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "Log in to your account to view the full conversation and respond."
+
+msgid "Ticket Assigned to You"
+msgstr "티켓이 할당되었습니다"
+
+msgid "A support ticket has been assigned to you."
+msgstr "지원 티켓이 할당되었습니다."
+
+msgid "Department:"
+msgstr "부서:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "Please review and respond to this ticket at your earliest convenience."
+
+msgid "This is an automated message from the support system."
+msgstr "This is an automated message from the support system."
+
+msgid "Ticket Status Updated"
+msgstr "티켓 상태 업데이트됨"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "Log in to your account to view the full details of your ticket."
+
+msgid "SLA Breach Alert"
+msgstr "SLA 위반 알림"
+
+msgid "Breach Type:"
+msgstr "위반 유형:"
+
+msgid "Assigned To:"
+msgstr "담당자:"
+
+msgid "Immediate action is required."
+msgstr "Immediate action is required."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "Please review this ticket and take appropriate action."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "This is an automated SLA monitoring alert from the support system."
+
+msgid "Ticket Escalated"
+msgstr "티켓 에스컬레이션됨"
+
+msgid "Reason:"
+msgstr "사유:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "This ticket requires immediate attention. Please review and take action."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "This is an automated escalation alert from the support system."
+
+msgid "Ticket Resolved"
+msgstr "티켓 해결됨"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "Thank you for reaching out to us. We hope we were able to help!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Escalated 지원"

--- a/escalated/locale/nl/LC_MESSAGES/django.po
+++ b/escalated/locale/nl/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: nl\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "Open"
+
+msgid "In Progress"
+msgstr "In behandeling"
+
+msgid "Waiting on Customer"
+msgstr "Wachten op klant"
+
+msgid "Waiting on Agent"
+msgstr "Wachten op medewerker"
+
+msgid "Escalated"
+msgstr "Geescaleerd"
+
+msgid "Resolved"
+msgstr "Opgelost"
+
+msgid "Closed"
+msgstr "Gesloten"
+
+msgid "Reopened"
+msgstr "Heropend"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "Laag"
+
+msgid "Medium"
+msgstr "Gemiddeld"
+
+msgid "High"
+msgstr "Hoog"
+
+msgid "Urgent"
+msgstr "Urgent"
+
+msgid "Critical"
+msgstr "Kritiek"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "Antwoord"
+
+msgid "Internal Note"
+msgstr "Interne notitie"
+
+msgid "System"
+msgstr "Systeem"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "Aangemaakt"
+
+msgid "Status Changed"
+msgstr "Status gewijzigd"
+
+msgid "Priority Changed"
+msgstr "Prioriteit gewijzigd"
+
+msgid "Assigned"
+msgstr "Toegewezen"
+
+msgid "Unassigned"
+msgstr "Niet toegewezen"
+
+msgid "Reply Added"
+msgstr "Antwoord toegevoegd"
+
+msgid "Note Added"
+msgstr "Notitie toegevoegd"
+
+msgid "Tag Added"
+msgstr "Tag toegevoegd"
+
+msgid "Tag Removed"
+msgstr "Tag verwijderd"
+
+msgid "Department Changed"
+msgstr "Afdeling gewijzigd"
+
+msgid "SLA Breached"
+msgstr "SLA geschonden"
+
+msgid "Attachment Added"
+msgstr "Bijlage toegevoegd"
+
+msgid "Merged"
+msgstr "Samengevoegd"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "SLA-schending"
+
+msgid "Priority Change"
+msgstr "Prioriteitswijziging"
+
+msgid "No Response"
+msgstr "Geen reactie"
+
+msgid "Customer Reply"
+msgstr "Klantreactie"
+
+msgid "Time Based"
+msgstr "Tijdgebaseerd"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "In afwachting"
+
+msgid "Processed"
+msgstr "Verwerkt"
+
+msgid "Failed"
+msgstr "Mislukt"
+
+msgid "Spam"
+msgstr "Spam"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "SLA-beleid"
+
+msgid "SLA Policies"
+msgstr "SLA-beleid"
+
+msgid "Ticket activities"
+msgstr "Ticketactiviteiten"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "Je hebt geen toestemming voor het medewerkersdashboard."
+
+msgid "You do not have permission to access the admin area."
+msgstr "Je hebt geen toestemming voor het beheergebied."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "Methode niet toegestaan"
+
+msgid "Ticket not found"
+msgstr "Ticket niet gevonden"
+
+msgid "Agent access required."
+msgstr "Medewerkerstoegang vereist."
+
+msgid "Admin access required."
+msgstr "Beheerderstoegang vereist."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "Onderwerp is verplicht."
+
+msgid "Description is required."
+msgstr "Beschrijving is verplicht."
+
+msgid "You cannot view this ticket."
+msgstr "You cannot view this ticket."
+
+msgid "You cannot reply to this ticket."
+msgstr "You cannot reply to this ticket."
+
+msgid "You cannot close this ticket."
+msgstr "You cannot close this ticket."
+
+msgid "You cannot reopen this ticket."
+msgstr "You cannot reopen this ticket."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "You can only rate resolved or closed tickets."
+
+msgid "This ticket has already been rated."
+msgstr "This ticket has already been rated."
+
+msgid "Rating must be between 1 and 5."
+msgstr "Rating must be between 1 and 5."
+
+msgid "Invalid rating value."
+msgstr "Invalid rating value."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "You cannot update this ticket."
+
+msgid "Agent not found"
+msgstr "Agent not found"
+
+msgid "Invalid status."
+msgstr "Invalid status."
+
+msgid "Invalid priority."
+msgstr "Invalid priority."
+
+msgid "Only internal notes can be pinned."
+msgstr "Only internal notes can be pinned."
+
+msgid "Macro not found"
+msgstr "Macro not found"
+
+msgid "Reply not found"
+msgstr "Reply not found"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "Guest tickets are not enabled."
+
+msgid "Name is required."
+msgstr "Naam is verplicht."
+
+msgid "Email is required."
+msgstr "E-mail is verplicht."
+
+msgid "Ticket not found."
+msgstr "Ticket niet gevonden."
+
+msgid "This ticket is closed."
+msgstr "Dit ticket is gesloten."
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "Department not found"
+
+msgid "SLA Policy not found"
+msgstr "SLA Policy not found"
+
+msgid "Escalation rule not found"
+msgstr "Escalation rule not found"
+
+msgid "Tag not found"
+msgstr "Tag not found"
+
+msgid "Canned response not found"
+msgstr "Canned response not found"
+
+msgid "Title is required."
+msgstr "Titel is verplicht."
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "Inbound email processing is disabled."
+
+msgid "Request verification failed."
+msgstr "Request verification failed."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "Nieuw ticket: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "Nieuw antwoord op: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "Customer reply on: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "Ticket assigned to you: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "Status bijgewerkt: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "Check all open tickets for SLA breaches and send warnings."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "Minutes before SLA deadline to trigger warning (default: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "Checking SLA deadlines for all open tickets..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "Auto-close tickets that have been resolved for a configurable number of days."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "Days after resolution to auto-close (overrides setting)"
+
+msgid "Show what would be closed without making changes"
+msgstr "Show what would be closed without making changes"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+
+msgid "No resolved tickets to auto-close."
+msgstr "No resolved tickets to auto-close."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "Evaluate all active escalation rules against open tickets."
+
+msgid "Evaluating escalation rules..."
+msgstr "Evaluating escalation rules..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "Escalation evaluation complete: %(count)d actions taken."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "Nieuw supportticket aangemaakt"
+
+msgid "Your support ticket has been created successfully."
+msgstr "Your support ticket has been created successfully."
+
+msgid "Reference:"
+msgstr "Referentie:"
+
+msgid "Subject:"
+msgstr "Onderwerp:"
+
+msgid "Priority:"
+msgstr "Prioriteit:"
+
+msgid "Status:"
+msgstr "Status:"
+
+msgid "Description:"
+msgstr "Beschrijving:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "This is an automated message from the support system. Please do not reply directly to this email."
+
+msgid "New Reply on Ticket"
+msgstr "Nieuw antwoord op ticket"
+
+msgid "A new reply has been added:"
+msgstr "A new reply has been added:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "Log in to your account to view the full conversation and respond."
+
+msgid "Ticket Assigned to You"
+msgstr "Ticket aan jou toegewezen"
+
+msgid "A support ticket has been assigned to you."
+msgstr "Er is een supportticket aan jou toegewezen."
+
+msgid "Department:"
+msgstr "Afdeling:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "Please review and respond to this ticket at your earliest convenience."
+
+msgid "This is an automated message from the support system."
+msgstr "This is an automated message from the support system."
+
+msgid "Ticket Status Updated"
+msgstr "Ticketstatus bijgewerkt"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "Log in to your account to view the full details of your ticket."
+
+msgid "SLA Breach Alert"
+msgstr "SLA-schendingswaarschuwing"
+
+msgid "Breach Type:"
+msgstr "Type schending:"
+
+msgid "Assigned To:"
+msgstr "Toegewezen aan:"
+
+msgid "Immediate action is required."
+msgstr "Immediate action is required."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "Please review this ticket and take appropriate action."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "This is an automated SLA monitoring alert from the support system."
+
+msgid "Ticket Escalated"
+msgstr "Ticket geescaleerd"
+
+msgid "Reason:"
+msgstr "Reden:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "This ticket requires immediate attention. Please review and take action."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "This is an automated escalation alert from the support system."
+
+msgid "Ticket Resolved"
+msgstr "Ticket opgelost"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "Thank you for reaching out to us. We hope we were able to help!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Escalated Support"

--- a/escalated/locale/pl/LC_MESSAGES/django.po
+++ b/escalated/locale/pl/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pl\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "Otwarty"
+
+msgid "In Progress"
+msgstr "W toku"
+
+msgid "Waiting on Customer"
+msgstr "Oczekiwanie na klienta"
+
+msgid "Waiting on Agent"
+msgstr "Oczekiwanie na agenta"
+
+msgid "Escalated"
+msgstr "Eskalowany"
+
+msgid "Resolved"
+msgstr "Rozwiazany"
+
+msgid "Closed"
+msgstr "Zamkniety"
+
+msgid "Reopened"
+msgstr "Ponownie otwarty"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "Niski"
+
+msgid "Medium"
+msgstr "Sredni"
+
+msgid "High"
+msgstr "Wysoki"
+
+msgid "Urgent"
+msgstr "Pilny"
+
+msgid "Critical"
+msgstr "Krytyczny"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "Odpowiedz"
+
+msgid "Internal Note"
+msgstr "Notatka wewnetrzna"
+
+msgid "System"
+msgstr "System"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "Utworzono"
+
+msgid "Status Changed"
+msgstr "Status zmieniony"
+
+msgid "Priority Changed"
+msgstr "Priorytet zmieniony"
+
+msgid "Assigned"
+msgstr "Przypisano"
+
+msgid "Unassigned"
+msgstr "Nieprzypisany"
+
+msgid "Reply Added"
+msgstr "Dodano odpowiedz"
+
+msgid "Note Added"
+msgstr "Dodano notatke"
+
+msgid "Tag Added"
+msgstr "Dodano tag"
+
+msgid "Tag Removed"
+msgstr "Usunieto tag"
+
+msgid "Department Changed"
+msgstr "Zmieniono dzial"
+
+msgid "SLA Breached"
+msgstr "Naruszenie SLA"
+
+msgid "Attachment Added"
+msgstr "Dodano zalacznik"
+
+msgid "Merged"
+msgstr "Polaczono"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "Naruszenie SLA"
+
+msgid "Priority Change"
+msgstr "Priority Change"
+
+msgid "No Response"
+msgstr "No Response"
+
+msgid "Customer Reply"
+msgstr "Customer Reply"
+
+msgid "Time Based"
+msgstr "Time Based"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "Pending"
+
+msgid "Processed"
+msgstr "Processed"
+
+msgid "Failed"
+msgstr "Failed"
+
+msgid "Spam"
+msgstr "Spam"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "Polityka SLA"
+
+msgid "SLA Policies"
+msgstr "Polityki SLA"
+
+msgid "Ticket activities"
+msgstr "Aktywnosci zgloszen"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "You do not have permission to access the agent dashboard."
+
+msgid "You do not have permission to access the admin area."
+msgstr "You do not have permission to access the admin area."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "Method not allowed"
+
+msgid "Ticket not found"
+msgstr "Zgloszenie nie znalezione"
+
+msgid "Agent access required."
+msgstr "Agent access required."
+
+msgid "Admin access required."
+msgstr "Admin access required."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "Temat jest wymagany."
+
+msgid "Description is required."
+msgstr "Opis jest wymagany."
+
+msgid "You cannot view this ticket."
+msgstr "You cannot view this ticket."
+
+msgid "You cannot reply to this ticket."
+msgstr "You cannot reply to this ticket."
+
+msgid "You cannot close this ticket."
+msgstr "You cannot close this ticket."
+
+msgid "You cannot reopen this ticket."
+msgstr "You cannot reopen this ticket."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "You can only rate resolved or closed tickets."
+
+msgid "This ticket has already been rated."
+msgstr "This ticket has already been rated."
+
+msgid "Rating must be between 1 and 5."
+msgstr "Rating must be between 1 and 5."
+
+msgid "Invalid rating value."
+msgstr "Invalid rating value."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "You cannot update this ticket."
+
+msgid "Agent not found"
+msgstr "Agent not found"
+
+msgid "Invalid status."
+msgstr "Invalid status."
+
+msgid "Invalid priority."
+msgstr "Invalid priority."
+
+msgid "Only internal notes can be pinned."
+msgstr "Only internal notes can be pinned."
+
+msgid "Macro not found"
+msgstr "Macro not found"
+
+msgid "Reply not found"
+msgstr "Reply not found"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "Guest tickets are not enabled."
+
+msgid "Name is required."
+msgstr "Imie jest wymagane."
+
+msgid "Email is required."
+msgstr "E-mail jest wymagany."
+
+msgid "Ticket not found."
+msgstr "Zgloszenie nie znalezione."
+
+msgid "This ticket is closed."
+msgstr "To zgloszenie jest zamkniete."
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "Department not found"
+
+msgid "SLA Policy not found"
+msgstr "SLA Policy not found"
+
+msgid "Escalation rule not found"
+msgstr "Escalation rule not found"
+
+msgid "Tag not found"
+msgstr "Tag not found"
+
+msgid "Canned response not found"
+msgstr "Canned response not found"
+
+msgid "Title is required."
+msgstr "Tytul jest wymagany."
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "Inbound email processing is disabled."
+
+msgid "Request verification failed."
+msgstr "Request verification failed."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "Nowe zgloszenie: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "New reply on: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "Customer reply on: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "Ticket assigned to you: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "Status updated: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "Check all open tickets for SLA breaches and send warnings."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "Minutes before SLA deadline to trigger warning (default: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "Checking SLA deadlines for all open tickets..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "Auto-close tickets that have been resolved for a configurable number of days."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "Days after resolution to auto-close (overrides setting)"
+
+msgid "Show what would be closed without making changes"
+msgstr "Show what would be closed without making changes"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+
+msgid "No resolved tickets to auto-close."
+msgstr "No resolved tickets to auto-close."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "Evaluate all active escalation rules against open tickets."
+
+msgid "Evaluating escalation rules..."
+msgstr "Evaluating escalation rules..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "Escalation evaluation complete: %(count)d actions taken."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "Utworzono nowe zgloszenie"
+
+msgid "Your support ticket has been created successfully."
+msgstr "Your support ticket has been created successfully."
+
+msgid "Reference:"
+msgstr "Referencja:"
+
+msgid "Subject:"
+msgstr "Temat:"
+
+msgid "Priority:"
+msgstr "Priorytet:"
+
+msgid "Status:"
+msgstr "Status:"
+
+msgid "Description:"
+msgstr "Opis:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "This is an automated message from the support system. Please do not reply directly to this email."
+
+msgid "New Reply on Ticket"
+msgstr "Nowa odpowiedz"
+
+msgid "A new reply has been added:"
+msgstr "A new reply has been added:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "Log in to your account to view the full conversation and respond."
+
+msgid "Ticket Assigned to You"
+msgstr "Zgloszenie przypisane do Ciebie"
+
+msgid "A support ticket has been assigned to you."
+msgstr "A support ticket has been assigned to you."
+
+msgid "Department:"
+msgstr "Dzial:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "Please review and respond to this ticket at your earliest convenience."
+
+msgid "This is an automated message from the support system."
+msgstr "This is an automated message from the support system."
+
+msgid "Ticket Status Updated"
+msgstr "Status zaktualizowany"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "Log in to your account to view the full details of your ticket."
+
+msgid "SLA Breach Alert"
+msgstr "Alert naruszenia SLA"
+
+msgid "Breach Type:"
+msgstr "Typ naruszenia:"
+
+msgid "Assigned To:"
+msgstr "Przypisano do:"
+
+msgid "Immediate action is required."
+msgstr "Immediate action is required."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "Please review this ticket and take appropriate action."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "This is an automated SLA monitoring alert from the support system."
+
+msgid "Ticket Escalated"
+msgstr "Zgloszenie eskalowane"
+
+msgid "Reason:"
+msgstr "Powod:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "This ticket requires immediate attention. Please review and take action."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "This is an automated escalation alert from the support system."
+
+msgid "Ticket Resolved"
+msgstr "Zgloszenie rozwiazane"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "Thank you for reaching out to us. We hope we were able to help!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Wsparcie Escalated"

--- a/escalated/locale/pt-BR/LC_MESSAGES/django.po
+++ b/escalated/locale/pt-BR/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt_BR\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "Aberto"
+
+msgid "In Progress"
+msgstr "Em andamento"
+
+msgid "Waiting on Customer"
+msgstr "Aguardando cliente"
+
+msgid "Waiting on Agent"
+msgstr "Aguardando agente"
+
+msgid "Escalated"
+msgstr "Escalado"
+
+msgid "Resolved"
+msgstr "Resolvido"
+
+msgid "Closed"
+msgstr "Fechado"
+
+msgid "Reopened"
+msgstr "Reaberto"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "Baixa"
+
+msgid "Medium"
+msgstr "Media"
+
+msgid "High"
+msgstr "Alta"
+
+msgid "Urgent"
+msgstr "Urgente"
+
+msgid "Critical"
+msgstr "Critica"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "Resposta"
+
+msgid "Internal Note"
+msgstr "Nota interna"
+
+msgid "System"
+msgstr "Sistema"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "Criado"
+
+msgid "Status Changed"
+msgstr "Status alterado"
+
+msgid "Priority Changed"
+msgstr "Prioridade alterada"
+
+msgid "Assigned"
+msgstr "Atribuido"
+
+msgid "Unassigned"
+msgstr "Nao atribuido"
+
+msgid "Reply Added"
+msgstr "Resposta adicionada"
+
+msgid "Note Added"
+msgstr "Nota adicionada"
+
+msgid "Tag Added"
+msgstr "Tag adicionada"
+
+msgid "Tag Removed"
+msgstr "Tag removida"
+
+msgid "Department Changed"
+msgstr "Departamento alterado"
+
+msgid "SLA Breached"
+msgstr "SLA violado"
+
+msgid "Attachment Added"
+msgstr "Anexo adicionado"
+
+msgid "Merged"
+msgstr "Mesclado"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "Violacao SLA"
+
+msgid "Priority Change"
+msgstr "Priority Change"
+
+msgid "No Response"
+msgstr "No Response"
+
+msgid "Customer Reply"
+msgstr "Customer Reply"
+
+msgid "Time Based"
+msgstr "Time Based"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "Pending"
+
+msgid "Processed"
+msgstr "Processed"
+
+msgid "Failed"
+msgstr "Failed"
+
+msgid "Spam"
+msgstr "Spam"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "Politica SLA"
+
+msgid "SLA Policies"
+msgstr "Politicas SLA"
+
+msgid "Ticket activities"
+msgstr "Ticket activities"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "You do not have permission to access the agent dashboard."
+
+msgid "You do not have permission to access the admin area."
+msgstr "You do not have permission to access the admin area."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "Method not allowed"
+
+msgid "Ticket not found"
+msgstr "Chamado nao encontrado"
+
+msgid "Agent access required."
+msgstr "Agent access required."
+
+msgid "Admin access required."
+msgstr "Admin access required."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "Assunto e obrigatorio."
+
+msgid "Description is required."
+msgstr "Descricao e obrigatoria."
+
+msgid "You cannot view this ticket."
+msgstr "You cannot view this ticket."
+
+msgid "You cannot reply to this ticket."
+msgstr "You cannot reply to this ticket."
+
+msgid "You cannot close this ticket."
+msgstr "You cannot close this ticket."
+
+msgid "You cannot reopen this ticket."
+msgstr "You cannot reopen this ticket."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "You can only rate resolved or closed tickets."
+
+msgid "This ticket has already been rated."
+msgstr "This ticket has already been rated."
+
+msgid "Rating must be between 1 and 5."
+msgstr "Rating must be between 1 and 5."
+
+msgid "Invalid rating value."
+msgstr "Invalid rating value."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "You cannot update this ticket."
+
+msgid "Agent not found"
+msgstr "Agent not found"
+
+msgid "Invalid status."
+msgstr "Invalid status."
+
+msgid "Invalid priority."
+msgstr "Invalid priority."
+
+msgid "Only internal notes can be pinned."
+msgstr "Only internal notes can be pinned."
+
+msgid "Macro not found"
+msgstr "Macro not found"
+
+msgid "Reply not found"
+msgstr "Reply not found"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "Guest tickets are not enabled."
+
+msgid "Name is required."
+msgstr "Nome e obrigatorio."
+
+msgid "Email is required."
+msgstr "E-mail e obrigatorio."
+
+msgid "Ticket not found."
+msgstr "Chamado nao encontrado."
+
+msgid "This ticket is closed."
+msgstr "Este chamado esta fechado."
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "Department not found"
+
+msgid "SLA Policy not found"
+msgstr "SLA Policy not found"
+
+msgid "Escalation rule not found"
+msgstr "Escalation rule not found"
+
+msgid "Tag not found"
+msgstr "Tag not found"
+
+msgid "Canned response not found"
+msgstr "Canned response not found"
+
+msgid "Title is required."
+msgstr "Titulo e obrigatorio."
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "Inbound email processing is disabled."
+
+msgid "Request verification failed."
+msgstr "Request verification failed."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "Novo chamado: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "New reply on: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "Customer reply on: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "Ticket assigned to you: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "Status updated: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "Check all open tickets for SLA breaches and send warnings."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "Minutes before SLA deadline to trigger warning (default: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "Checking SLA deadlines for all open tickets..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "Auto-close tickets that have been resolved for a configurable number of days."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "Days after resolution to auto-close (overrides setting)"
+
+msgid "Show what would be closed without making changes"
+msgstr "Show what would be closed without making changes"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+
+msgid "No resolved tickets to auto-close."
+msgstr "No resolved tickets to auto-close."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "Evaluate all active escalation rules against open tickets."
+
+msgid "Evaluating escalation rules..."
+msgstr "Evaluating escalation rules..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "Escalation evaluation complete: %(count)d actions taken."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "Novo chamado criado"
+
+msgid "Your support ticket has been created successfully."
+msgstr "Your support ticket has been created successfully."
+
+msgid "Reference:"
+msgstr "Referencia:"
+
+msgid "Subject:"
+msgstr "Assunto:"
+
+msgid "Priority:"
+msgstr "Prioridade:"
+
+msgid "Status:"
+msgstr "Status:"
+
+msgid "Description:"
+msgstr "Descricao:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "This is an automated message from the support system. Please do not reply directly to this email."
+
+msgid "New Reply on Ticket"
+msgstr "New Reply on Ticket"
+
+msgid "A new reply has been added:"
+msgstr "A new reply has been added:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "Log in to your account to view the full conversation and respond."
+
+msgid "Ticket Assigned to You"
+msgstr "Chamado atribuido a voce"
+
+msgid "A support ticket has been assigned to you."
+msgstr "Um chamado foi atribuido a voce."
+
+msgid "Department:"
+msgstr "Departamento:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "Please review and respond to this ticket at your earliest convenience."
+
+msgid "This is an automated message from the support system."
+msgstr "This is an automated message from the support system."
+
+msgid "Ticket Status Updated"
+msgstr "Status do chamado atualizado"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "Log in to your account to view the full details of your ticket."
+
+msgid "SLA Breach Alert"
+msgstr "Alerta de violacao SLA"
+
+msgid "Breach Type:"
+msgstr "Tipo de violacao:"
+
+msgid "Assigned To:"
+msgstr "Atribuido a:"
+
+msgid "Immediate action is required."
+msgstr "Immediate action is required."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "Please review this ticket and take appropriate action."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "This is an automated SLA monitoring alert from the support system."
+
+msgid "Ticket Escalated"
+msgstr "Chamado escalado"
+
+msgid "Reason:"
+msgstr "Motivo:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "This ticket requires immediate attention. Please review and take action."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "This is an automated escalation alert from the support system."
+
+msgid "Ticket Resolved"
+msgstr "Chamado resolvido"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "Thank you for reaching out to us. We hope we were able to help!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Suporte Escalated"

--- a/escalated/locale/ru/LC_MESSAGES/django.po
+++ b/escalated/locale/ru/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ru\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "Открыта"
+
+msgid "In Progress"
+msgstr "В работе"
+
+msgid "Waiting on Customer"
+msgstr "Ожидание клиента"
+
+msgid "Waiting on Agent"
+msgstr "Ожидание агента"
+
+msgid "Escalated"
+msgstr "Эскалирована"
+
+msgid "Resolved"
+msgstr "Решена"
+
+msgid "Closed"
+msgstr "Закрыта"
+
+msgid "Reopened"
+msgstr "Переоткрыта"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "Низкий"
+
+msgid "Medium"
+msgstr "Средний"
+
+msgid "High"
+msgstr "Высокий"
+
+msgid "Urgent"
+msgstr "Срочный"
+
+msgid "Critical"
+msgstr "Критический"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "Ответ"
+
+msgid "Internal Note"
+msgstr "Внутренняя заметка"
+
+msgid "System"
+msgstr "Система"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "Создана"
+
+msgid "Status Changed"
+msgstr "Статус изменен"
+
+msgid "Priority Changed"
+msgstr "Приоритет изменен"
+
+msgid "Assigned"
+msgstr "Назначена"
+
+msgid "Unassigned"
+msgstr "Не назначена"
+
+msgid "Reply Added"
+msgstr "Ответ добавлен"
+
+msgid "Note Added"
+msgstr "Заметка добавлена"
+
+msgid "Tag Added"
+msgstr "Тег добавлен"
+
+msgid "Tag Removed"
+msgstr "Тег удален"
+
+msgid "Department Changed"
+msgstr "Отдел изменен"
+
+msgid "SLA Breached"
+msgstr "SLA нарушен"
+
+msgid "Attachment Added"
+msgstr "Вложение добавлено"
+
+msgid "Merged"
+msgstr "Объединена"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "Нарушение SLA"
+
+msgid "Priority Change"
+msgstr "Priority Change"
+
+msgid "No Response"
+msgstr "No Response"
+
+msgid "Customer Reply"
+msgstr "Customer Reply"
+
+msgid "Time Based"
+msgstr "Time Based"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "Pending"
+
+msgid "Processed"
+msgstr "Processed"
+
+msgid "Failed"
+msgstr "Failed"
+
+msgid "Spam"
+msgstr "Spam"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "Политика SLA"
+
+msgid "SLA Policies"
+msgstr "Политики SLA"
+
+msgid "Ticket activities"
+msgstr "Ticket activities"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "You do not have permission to access the agent dashboard."
+
+msgid "You do not have permission to access the admin area."
+msgstr "You do not have permission to access the admin area."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "Method not allowed"
+
+msgid "Ticket not found"
+msgstr "Заявка не найдена"
+
+msgid "Agent access required."
+msgstr "Agent access required."
+
+msgid "Admin access required."
+msgstr "Admin access required."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "Тема обязательна."
+
+msgid "Description is required."
+msgstr "Описание обязательно."
+
+msgid "You cannot view this ticket."
+msgstr "You cannot view this ticket."
+
+msgid "You cannot reply to this ticket."
+msgstr "You cannot reply to this ticket."
+
+msgid "You cannot close this ticket."
+msgstr "You cannot close this ticket."
+
+msgid "You cannot reopen this ticket."
+msgstr "You cannot reopen this ticket."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "You can only rate resolved or closed tickets."
+
+msgid "This ticket has already been rated."
+msgstr "This ticket has already been rated."
+
+msgid "Rating must be between 1 and 5."
+msgstr "Rating must be between 1 and 5."
+
+msgid "Invalid rating value."
+msgstr "Invalid rating value."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "You cannot update this ticket."
+
+msgid "Agent not found"
+msgstr "Agent not found"
+
+msgid "Invalid status."
+msgstr "Invalid status."
+
+msgid "Invalid priority."
+msgstr "Invalid priority."
+
+msgid "Only internal notes can be pinned."
+msgstr "Only internal notes can be pinned."
+
+msgid "Macro not found"
+msgstr "Macro not found"
+
+msgid "Reply not found"
+msgstr "Reply not found"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "Guest tickets are not enabled."
+
+msgid "Name is required."
+msgstr "Имя обязательно."
+
+msgid "Email is required."
+msgstr "Электронная почта обязательна."
+
+msgid "Ticket not found."
+msgstr "Заявка не найдена."
+
+msgid "This ticket is closed."
+msgstr "Эта заявка закрыта."
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "Department not found"
+
+msgid "SLA Policy not found"
+msgstr "SLA Policy not found"
+
+msgid "Escalation rule not found"
+msgstr "Escalation rule not found"
+
+msgid "Tag not found"
+msgstr "Tag not found"
+
+msgid "Canned response not found"
+msgstr "Canned response not found"
+
+msgid "Title is required."
+msgstr "Заголовок обязателен."
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "Inbound email processing is disabled."
+
+msgid "Request verification failed."
+msgstr "Request verification failed."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "Новая заявка: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "New reply on: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "Customer reply on: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "Ticket assigned to you: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "Status updated: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "Check all open tickets for SLA breaches and send warnings."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "Minutes before SLA deadline to trigger warning (default: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "Checking SLA deadlines for all open tickets..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "Auto-close tickets that have been resolved for a configurable number of days."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "Days after resolution to auto-close (overrides setting)"
+
+msgid "Show what would be closed without making changes"
+msgstr "Show what would be closed without making changes"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+
+msgid "No resolved tickets to auto-close."
+msgstr "No resolved tickets to auto-close."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "Evaluate all active escalation rules against open tickets."
+
+msgid "Evaluating escalation rules..."
+msgstr "Evaluating escalation rules..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "Escalation evaluation complete: %(count)d actions taken."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "Новая заявка поддержки"
+
+msgid "Your support ticket has been created successfully."
+msgstr "Your support ticket has been created successfully."
+
+msgid "Reference:"
+msgstr "Ссылка:"
+
+msgid "Subject:"
+msgstr "Тема:"
+
+msgid "Priority:"
+msgstr "Приоритет:"
+
+msgid "Status:"
+msgstr "Статус:"
+
+msgid "Description:"
+msgstr "Описание:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "This is an automated message from the support system. Please do not reply directly to this email."
+
+msgid "New Reply on Ticket"
+msgstr "New Reply on Ticket"
+
+msgid "A new reply has been added:"
+msgstr "A new reply has been added:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "Log in to your account to view the full conversation and respond."
+
+msgid "Ticket Assigned to You"
+msgstr "Заявка назначена вам"
+
+msgid "A support ticket has been assigned to you."
+msgstr "Вам назначена заявка."
+
+msgid "Department:"
+msgstr "Отдел:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "Please review and respond to this ticket at your earliest convenience."
+
+msgid "This is an automated message from the support system."
+msgstr "This is an automated message from the support system."
+
+msgid "Ticket Status Updated"
+msgstr "Статус заявки обновлен"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "Log in to your account to view the full details of your ticket."
+
+msgid "SLA Breach Alert"
+msgstr "Предупреждение о нарушении SLA"
+
+msgid "Breach Type:"
+msgstr "Тип нарушения:"
+
+msgid "Assigned To:"
+msgstr "Назначена:"
+
+msgid "Immediate action is required."
+msgstr "Immediate action is required."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "Please review this ticket and take appropriate action."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "This is an automated SLA monitoring alert from the support system."
+
+msgid "Ticket Escalated"
+msgstr "Заявка эскалирована"
+
+msgid "Reason:"
+msgstr "Причина:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "This ticket requires immediate attention. Please review and take action."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "This is an automated escalation alert from the support system."
+
+msgid "Ticket Resolved"
+msgstr "Заявка решена"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "Thank you for reaching out to us. We hope we were able to help!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Поддержка Escalated"

--- a/escalated/locale/tr/LC_MESSAGES/django.po
+++ b/escalated/locale/tr/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: tr\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "Acik"
+
+msgid "In Progress"
+msgstr "Devam ediyor"
+
+msgid "Waiting on Customer"
+msgstr "Musteri bekleniyor"
+
+msgid "Waiting on Agent"
+msgstr "Temsilci bekleniyor"
+
+msgid "Escalated"
+msgstr "Eskalasyon yapildi"
+
+msgid "Resolved"
+msgstr "Cozuldu"
+
+msgid "Closed"
+msgstr "Kapatildi"
+
+msgid "Reopened"
+msgstr "Yeniden acildi"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "Dusuk"
+
+msgid "Medium"
+msgstr "Orta"
+
+msgid "High"
+msgstr "Yuksek"
+
+msgid "Urgent"
+msgstr "Acil"
+
+msgid "Critical"
+msgstr "Kritik"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "Yanit"
+
+msgid "Internal Note"
+msgstr "Dahili not"
+
+msgid "System"
+msgstr "Sistem"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "Olusturuldu"
+
+msgid "Status Changed"
+msgstr "Durum degisti"
+
+msgid "Priority Changed"
+msgstr "Oncelik degisti"
+
+msgid "Assigned"
+msgstr "Atandi"
+
+msgid "Unassigned"
+msgstr "Atanmamis"
+
+msgid "Reply Added"
+msgstr "Yanit eklendi"
+
+msgid "Note Added"
+msgstr "Not eklendi"
+
+msgid "Tag Added"
+msgstr "Etiket eklendi"
+
+msgid "Tag Removed"
+msgstr "Etiket kaldirildi"
+
+msgid "Department Changed"
+msgstr "Departman degisti"
+
+msgid "SLA Breached"
+msgstr "SLA ihlal edildi"
+
+msgid "Attachment Added"
+msgstr "Ek eklendi"
+
+msgid "Merged"
+msgstr "Birlestirildi"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "SLA ihlali"
+
+msgid "Priority Change"
+msgstr "Priority Change"
+
+msgid "No Response"
+msgstr "No Response"
+
+msgid "Customer Reply"
+msgstr "Customer Reply"
+
+msgid "Time Based"
+msgstr "Time Based"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "Pending"
+
+msgid "Processed"
+msgstr "Processed"
+
+msgid "Failed"
+msgstr "Failed"
+
+msgid "Spam"
+msgstr "Spam"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "SLA Politikasi"
+
+msgid "SLA Policies"
+msgstr "SLA Politikalari"
+
+msgid "Ticket activities"
+msgstr "Ticket activities"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "You do not have permission to access the agent dashboard."
+
+msgid "You do not have permission to access the admin area."
+msgstr "You do not have permission to access the admin area."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "Method not allowed"
+
+msgid "Ticket not found"
+msgstr "Destek talebi bulunamadi"
+
+msgid "Agent access required."
+msgstr "Agent access required."
+
+msgid "Admin access required."
+msgstr "Admin access required."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "Konu gereklidir."
+
+msgid "Description is required."
+msgstr "Aciklama gereklidir."
+
+msgid "You cannot view this ticket."
+msgstr "You cannot view this ticket."
+
+msgid "You cannot reply to this ticket."
+msgstr "You cannot reply to this ticket."
+
+msgid "You cannot close this ticket."
+msgstr "You cannot close this ticket."
+
+msgid "You cannot reopen this ticket."
+msgstr "You cannot reopen this ticket."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "You can only rate resolved or closed tickets."
+
+msgid "This ticket has already been rated."
+msgstr "This ticket has already been rated."
+
+msgid "Rating must be between 1 and 5."
+msgstr "Rating must be between 1 and 5."
+
+msgid "Invalid rating value."
+msgstr "Invalid rating value."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "You cannot update this ticket."
+
+msgid "Agent not found"
+msgstr "Agent not found"
+
+msgid "Invalid status."
+msgstr "Invalid status."
+
+msgid "Invalid priority."
+msgstr "Invalid priority."
+
+msgid "Only internal notes can be pinned."
+msgstr "Only internal notes can be pinned."
+
+msgid "Macro not found"
+msgstr "Macro not found"
+
+msgid "Reply not found"
+msgstr "Reply not found"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "Guest tickets are not enabled."
+
+msgid "Name is required."
+msgstr "Ad gereklidir."
+
+msgid "Email is required."
+msgstr "E-posta gereklidir."
+
+msgid "Ticket not found."
+msgstr "Destek talebi bulunamadi."
+
+msgid "This ticket is closed."
+msgstr "Bu destek talebi kapatilmistir."
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "Department not found"
+
+msgid "SLA Policy not found"
+msgstr "SLA Policy not found"
+
+msgid "Escalation rule not found"
+msgstr "Escalation rule not found"
+
+msgid "Tag not found"
+msgstr "Tag not found"
+
+msgid "Canned response not found"
+msgstr "Canned response not found"
+
+msgid "Title is required."
+msgstr "Baslik gereklidir."
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "Inbound email processing is disabled."
+
+msgid "Request verification failed."
+msgstr "Request verification failed."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "Yeni destek talebi: %(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "New reply on: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "Customer reply on: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "Ticket assigned to you: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "Status updated: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s: %(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "Check all open tickets for SLA breaches and send warnings."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "Minutes before SLA deadline to trigger warning (default: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "Checking SLA deadlines for all open tickets..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "Auto-close tickets that have been resolved for a configurable number of days."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "Days after resolution to auto-close (overrides setting)"
+
+msgid "Show what would be closed without making changes"
+msgstr "Show what would be closed without making changes"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+
+msgid "No resolved tickets to auto-close."
+msgstr "No resolved tickets to auto-close."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "Evaluate all active escalation rules against open tickets."
+
+msgid "Evaluating escalation rules..."
+msgstr "Evaluating escalation rules..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "Escalation evaluation complete: %(count)d actions taken."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "Yeni destek talebi olusturuldu"
+
+msgid "Your support ticket has been created successfully."
+msgstr "Your support ticket has been created successfully."
+
+msgid "Reference:"
+msgstr "Referans:"
+
+msgid "Subject:"
+msgstr "Konu:"
+
+msgid "Priority:"
+msgstr "Oncelik:"
+
+msgid "Status:"
+msgstr "Durum:"
+
+msgid "Description:"
+msgstr "Aciklama:"
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "This is an automated message from the support system. Please do not reply directly to this email."
+
+msgid "New Reply on Ticket"
+msgstr "New Reply on Ticket"
+
+msgid "A new reply has been added:"
+msgstr "A new reply has been added:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "Log in to your account to view the full conversation and respond."
+
+msgid "Ticket Assigned to You"
+msgstr "Size atanan destek talebi"
+
+msgid "A support ticket has been assigned to you."
+msgstr "Bir destek talebi size atandi."
+
+msgid "Department:"
+msgstr "Departman:"
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "Please review and respond to this ticket at your earliest convenience."
+
+msgid "This is an automated message from the support system."
+msgstr "This is an automated message from the support system."
+
+msgid "Ticket Status Updated"
+msgstr "Durum guncellendi"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "Log in to your account to view the full details of your ticket."
+
+msgid "SLA Breach Alert"
+msgstr "SLA ihlal uyarisi"
+
+msgid "Breach Type:"
+msgstr "Ihlal turu:"
+
+msgid "Assigned To:"
+msgstr "Atanan:"
+
+msgid "Immediate action is required."
+msgstr "Immediate action is required."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "Please review this ticket and take appropriate action."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "This is an automated SLA monitoring alert from the support system."
+
+msgid "Ticket Escalated"
+msgstr "Eskalasyon yapildi"
+
+msgid "Reason:"
+msgstr "Neden:"
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "This ticket requires immediate attention. Please review and take action."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "This is an automated escalation alert from the support system."
+
+msgid "Ticket Resolved"
+msgstr "Destek talebi cozuldu"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "Thank you for reaching out to us. We hope we were able to help!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Escalated Destek"

--- a/escalated/locale/zh-CN/LC_MESSAGES/django.po
+++ b/escalated/locale/zh-CN/LC_MESSAGES/django.po
@@ -1,0 +1,436 @@
+# Escalated Django translations
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh_CN\n"
+
+# --- Model TextChoices: Ticket.Status ---
+msgid "Open"
+msgstr "打开"
+
+msgid "In Progress"
+msgstr "处理中"
+
+msgid "Waiting on Customer"
+msgstr "等待客户"
+
+msgid "Waiting on Agent"
+msgstr "等待客服"
+
+msgid "Escalated"
+msgstr "已升级"
+
+msgid "Resolved"
+msgstr "已解决"
+
+msgid "Closed"
+msgstr "已关闭"
+
+msgid "Reopened"
+msgstr "已重开"
+
+# --- Model TextChoices: Ticket.Priority ---
+msgid "Low"
+msgstr "低"
+
+msgid "Medium"
+msgstr "中"
+
+msgid "High"
+msgstr "高"
+
+msgid "Urgent"
+msgstr "紧急"
+
+msgid "Critical"
+msgstr "严重"
+
+# --- Model TextChoices: Reply.Type ---
+msgid "Reply"
+msgstr "回复"
+
+msgid "Internal Note"
+msgstr "内部备注"
+
+msgid "System"
+msgstr "系统"
+
+# --- Model TextChoices: TicketActivity.ActivityType ---
+msgid "Created"
+msgstr "已创建"
+
+msgid "Status Changed"
+msgstr "状态变更"
+
+msgid "Priority Changed"
+msgstr "优先级变更"
+
+msgid "Assigned"
+msgstr "已分配"
+
+msgid "Unassigned"
+msgstr "未分配"
+
+msgid "Reply Added"
+msgstr "回复已添加"
+
+msgid "Note Added"
+msgstr "备注已添加"
+
+msgid "Tag Added"
+msgstr "标签已添加"
+
+msgid "Tag Removed"
+msgstr "标签已移除"
+
+msgid "Department Changed"
+msgstr "部门变更"
+
+msgid "SLA Breached"
+msgstr "SLA已违反"
+
+msgid "Attachment Added"
+msgstr "附件已添加"
+
+msgid "Merged"
+msgstr "已合并"
+
+# --- Model TextChoices: EscalationRule.TriggerType ---
+msgid "SLA Breach"
+msgstr "SLA违规"
+
+msgid "Priority Change"
+msgstr "Priority Change"
+
+msgid "No Response"
+msgstr "No Response"
+
+msgid "Customer Reply"
+msgstr "Customer Reply"
+
+msgid "Time Based"
+msgstr "Time Based"
+
+# --- Model TextChoices: InboundEmail.Status ---
+msgid "Pending"
+msgstr "Pending"
+
+msgid "Processed"
+msgstr "Processed"
+
+msgid "Failed"
+msgstr "Failed"
+
+msgid "Spam"
+msgstr "Spam"
+
+# --- Model verbose_name / help_text ---
+msgid "SLA Policy"
+msgstr "SLA策略"
+
+msgid "SLA Policies"
+msgstr "SLA策略"
+
+msgid "Ticket activities"
+msgstr "Ticket activities"
+
+msgid "Map of priority to hours, e.g. {\"low\": 24, \"medium\": 8, \"high\": 4, \"urgent\": 1, \"critical\": 0.5}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 24, \\"medium\\": 8, \\"high\\": 4, \\"urgent\\": 1, \\"critical\\": 0.5}"
+
+msgid "Map of priority to hours, e.g. {\"low\": 72, \"medium\": 24, \"high\": 8, \"urgent\": 4, \"critical\": 2}"
+msgstr "Map of priority to hours, e.g. {\\"low\\": 72, \\"medium\\": 24, \\"high\\": 8, \\"urgent\\": 4, \\"critical\\": 2}"
+
+msgid "Unique token for guest ticket access"
+msgstr "Unique token for guest ticket access"
+
+msgid "JSON conditions that must be met for the rule to fire"
+msgstr "JSON conditions that must be met for the rule to fire"
+
+msgid "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+msgstr "JSON actions to take when the rule fires (e.g., assign, notify, change priority)"
+
+msgid "File size in bytes"
+msgstr "File size in bytes"
+
+msgid "JSON array of actions, e.g. [{\"type\": \"set_status\", \"value\": \"open\"}]"
+msgstr "JSON array of actions, e.g. [{\\"type\\": \\"set_status\\", \\"value\\": \\"open\\"}]"
+
+msgid "Rating from 1 to 5"
+msgstr "Rating from 1 to 5"
+
+# --- Middleware messages ---
+msgid "You do not have permission to access the agent dashboard."
+msgstr "You do not have permission to access the agent dashboard."
+
+msgid "You do not have permission to access the admin area."
+msgstr "You do not have permission to access the admin area."
+
+# --- View messages: common ---
+msgid "Method not allowed"
+msgstr "Method not allowed"
+
+msgid "Ticket not found"
+msgstr "工单未找到"
+
+msgid "Agent access required."
+msgstr "Agent access required."
+
+msgid "Admin access required."
+msgstr "Admin access required."
+
+# --- View messages: customer.py ---
+msgid "Subject is required."
+msgstr "主题为必填项。"
+
+msgid "Description is required."
+msgstr "描述为必填项。"
+
+msgid "You cannot view this ticket."
+msgstr "You cannot view this ticket."
+
+msgid "You cannot reply to this ticket."
+msgstr "You cannot reply to this ticket."
+
+msgid "You cannot close this ticket."
+msgstr "You cannot close this ticket."
+
+msgid "You cannot reopen this ticket."
+msgstr "You cannot reopen this ticket."
+
+msgid "You can only rate resolved or closed tickets."
+msgstr "You can only rate resolved or closed tickets."
+
+msgid "This ticket has already been rated."
+msgstr "This ticket has already been rated."
+
+msgid "Rating must be between 1 and 5."
+msgstr "Rating must be between 1 and 5."
+
+msgid "Invalid rating value."
+msgstr "Invalid rating value."
+
+# --- View messages: agent.py ---
+msgid "You cannot update this ticket."
+msgstr "You cannot update this ticket."
+
+msgid "Agent not found"
+msgstr "Agent not found"
+
+msgid "Invalid status."
+msgstr "Invalid status."
+
+msgid "Invalid priority."
+msgstr "Invalid priority."
+
+msgid "Only internal notes can be pinned."
+msgstr "Only internal notes can be pinned."
+
+msgid "Macro not found"
+msgstr "Macro not found"
+
+msgid "Reply not found"
+msgstr "Reply not found"
+
+# --- View messages: guest.py ---
+msgid "Guest tickets are not enabled."
+msgstr "Guest tickets are not enabled."
+
+msgid "Name is required."
+msgstr "姓名为必填项。"
+
+msgid "Email is required."
+msgstr "电子邮件为必填项。"
+
+msgid "Ticket not found."
+msgstr "工单未找到。"
+
+msgid "This ticket is closed."
+msgstr "此工单已关闭。"
+
+# --- View messages: admin.py ---
+msgid "Department not found"
+msgstr "Department not found"
+
+msgid "SLA Policy not found"
+msgstr "SLA Policy not found"
+
+msgid "Escalation rule not found"
+msgstr "Escalation rule not found"
+
+msgid "Tag not found"
+msgstr "Tag not found"
+
+msgid "Canned response not found"
+msgstr "Canned response not found"
+
+msgid "Title is required."
+msgstr "标题为必填项。"
+
+# --- View messages: inbound.py ---
+msgid "Inbound email processing is disabled."
+msgstr "Inbound email processing is disabled."
+
+msgid "Request verification failed."
+msgstr "Request verification failed."
+
+# --- Notification service: email subjects ---
+msgid "New ticket: %(subject)s"
+msgstr "新工单：%(subject)s"
+
+msgid "New reply on: %(subject)s"
+msgstr "New reply on: %(subject)s"
+
+msgid "Customer reply on: %(subject)s"
+msgstr "Customer reply on: %(subject)s"
+
+msgid "Ticket assigned to you: %(subject)s"
+msgstr "Ticket assigned to you: %(subject)s"
+
+msgid "Status updated: %(subject)s"
+msgstr "Status updated: %(subject)s"
+
+msgid "%(breach_type)s: %(subject)s"
+msgstr "%(breach_type)s：%(subject)s"
+
+# --- Management command: check_sla ---
+msgid "Check all open tickets for SLA breaches and send warnings."
+msgstr "Check all open tickets for SLA breaches and send warnings."
+
+msgid "Minutes before SLA deadline to trigger warning (default: 30)"
+msgstr "Minutes before SLA deadline to trigger warning (default: 30)"
+
+msgid "Checking SLA deadlines for all open tickets..."
+msgstr "Checking SLA deadlines for all open tickets..."
+
+msgid "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+msgstr "SLA check complete: %(breached)d breaches detected, %(warned)d warnings sent."
+
+# --- Management command: close_resolved ---
+msgid "Auto-close tickets that have been resolved for a configurable number of days."
+msgstr "Auto-close tickets that have been resolved for a configurable number of days."
+
+msgid "Days after resolution to auto-close (overrides setting)"
+msgstr "Days after resolution to auto-close (overrides setting)"
+
+msgid "Show what would be closed without making changes"
+msgstr "Show what would be closed without making changes"
+
+msgid "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+msgstr "[DRY RUN] Would close %(count)d tickets resolved more than %(days)d days ago."
+
+msgid "No resolved tickets to auto-close."
+msgstr "No resolved tickets to auto-close."
+
+msgid "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+msgstr "Auto-closed %(count)d tickets that were resolved more than %(days)d days ago."
+
+# --- Management command: evaluate_escalations ---
+msgid "Evaluate all active escalation rules against open tickets."
+msgstr "Evaluate all active escalation rules against open tickets."
+
+msgid "Evaluating escalation rules..."
+msgstr "Evaluating escalation rules..."
+
+msgid "Escalation evaluation complete: %(count)d actions taken."
+msgstr "Escalation evaluation complete: %(count)d actions taken."
+
+# --- Email templates ---
+msgid "New Support Ticket Created"
+msgstr "新支持工单已创建"
+
+msgid "Your support ticket has been created successfully."
+msgstr "Your support ticket has been created successfully."
+
+msgid "Reference:"
+msgstr "参考："
+
+msgid "Subject:"
+msgstr "主题："
+
+msgid "Priority:"
+msgstr "优先级："
+
+msgid "Status:"
+msgstr "状态："
+
+msgid "Description:"
+msgstr "描述："
+
+msgid "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+msgstr "Our team will review your ticket shortly. You will receive updates as your ticket progresses."
+
+msgid "This is an automated message from the support system. Please do not reply directly to this email."
+msgstr "This is an automated message from the support system. Please do not reply directly to this email."
+
+msgid "New Reply on Ticket"
+msgstr "New Reply on Ticket"
+
+msgid "A new reply has been added:"
+msgstr "A new reply has been added:"
+
+msgid "Log in to your account to view the full conversation and respond."
+msgstr "Log in to your account to view the full conversation and respond."
+
+msgid "Ticket Assigned to You"
+msgstr "工单已分配给您"
+
+msgid "A support ticket has been assigned to you."
+msgstr "一个支持工单已分配给您。"
+
+msgid "Department:"
+msgstr "部门："
+
+msgid "Please review and respond to this ticket at your earliest convenience."
+msgstr "Please review and respond to this ticket at your earliest convenience."
+
+msgid "This is an automated message from the support system."
+msgstr "This is an automated message from the support system."
+
+msgid "Ticket Status Updated"
+msgstr "工单状态已更新"
+
+msgid "Log in to your account to view the full details of your ticket."
+msgstr "Log in to your account to view the full details of your ticket."
+
+msgid "SLA Breach Alert"
+msgstr "SLA违规警报"
+
+msgid "Breach Type:"
+msgstr "违规类型："
+
+msgid "Assigned To:"
+msgstr "分配给："
+
+msgid "Immediate action is required."
+msgstr "Immediate action is required."
+
+msgid "Please review this ticket and take appropriate action."
+msgstr "Please review this ticket and take appropriate action."
+
+msgid "This is an automated SLA monitoring alert from the support system."
+msgstr "This is an automated SLA monitoring alert from the support system."
+
+msgid "Ticket Escalated"
+msgstr "工单已升级"
+
+msgid "Reason:"
+msgstr "原因："
+
+msgid "This ticket requires immediate attention. Please review and take action."
+msgstr "This ticket requires immediate attention. Please review and take action."
+
+msgid "This is an automated escalation alert from the support system."
+msgstr "This is an automated escalation alert from the support system."
+
+msgid "Ticket Resolved"
+msgstr "工单已解决"
+
+msgid "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+msgstr "If you believe this issue is not fully resolved, you can reopen the ticket by logging into your account."
+
+msgid "Thank you for reaching out to us. We hope we were able to help!"
+msgstr "Thank you for reaching out to us. We hope we were able to help!"
+
+# --- Escalated Support (app verbose name) ---
+msgid "Escalated Support"
+msgstr "Escalated支持"


### PR DESCRIPTION
## Summary
- Add .po locale files for ar, it, ja, ko, nl, pl, pt-BR, ru, tr, zh-CN
- Translations cover model choices, view messages, email templates, management commands

## Test plan
- [ ] Verify .po file syntax
- [ ] Spot-check translations