### PR TITLE
fix: complete missing README translations

### DIFF
--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+نظام تذاكر دعم متكامل وقابل للتضمين في Django. أضفه إلى أي تطبيق — واحصل على مكتب مساعدة كامل مع تتبع SLA وقواعد التصعيد وسير عمل الوكلاء وبوابة العملاء. لا حاجة لخدمات خارجية.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — اعرف المزيد، شاهد العروض التوضيحية، وقارن بين خيارات السحابة والاستضافة الذاتية.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**ثلاثة أوضاع استضافة.** تشغيل مستضاف ذاتياً بالكامل، أو مزامنة مع سحابة مركزية لرؤية متعددة التطبيقات، أو توجيه كل شيء إلى السحابة. التبديل بين الأوضاع بتغيير إعداد واحد.
 
 ## الميزات
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **إشعارات البريد الإلكتروني** — إشعارات قابلة للتهيئة لكل حدث مع دعم webhook
 - **توجيه الأقسام** — تنظيم الوكلاء في أقسام مع التعيين التلقائي (round-robin)
 - **نظام العلامات** — تصنيف التذاكر بعلامات ملونة
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — واجهة أمامية مشتركة عبر [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **تقسيم التذاكر** — تقسيم رد إلى تذكرة مستقلة جديدة مع الحفاظ على السياق الأصلي
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — تأجيل التذاكر بإعدادات مسبقة (1 ساعة، 4 ساعات، غداً، الأسبوع القادم)؛ أمر الإدارة `python manage.py wake_snoozed_tickets` يوقظها تلقائياً حسب الجدول
 - **العروض المحفوظة / الطوابير المخصصة** — حفظ وتسمية ومشاركة إعدادات الفلاتر كعروض تذاكر قابلة لإعادة الاستخدام
 - **عنصر الدعم القابل للتضمين** — عنصر `<script>` خفيف مع بحث قاعدة المعرفة ونموذج تذكرة وفحص الحالة
 - **ترابط البريد الإلكتروني** — الرسائل الصادرة تتضمن رؤوس `In-Reply-To` و `References` الصحيحة للترابط الصحيح في عملاء البريد
 - **قوالب بريد إلكتروني مع العلامة التجارية** — شعار ولون رئيسي ونص تذييل قابل للتهيئة لجميع الرسائل الصادرة
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — بث اختياري عبر Django Channels مع استطلاع احتياطي تلقائي
 - **مفتاح قاعدة المعرفة** — تفعيل أو تعطيل قاعدة المعرفة العامة من إعدادات الإدارة
 
 ## المتطلبات
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (لأصول الواجهة الأمامية)
 
 ## البدء السريع
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## إعداد الواجهة الأمامية
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+يستخدم Escalated إطار Inertia.js مع Vue 3. يتم توفير مكونات الواجهة الأمامية بواسطة حزمة npm [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated).
 
 ### محتوى Tailwind
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+أضف حزمة Escalated إلى إعداد `content` في Tailwind حتى لا يتم حذف فئاتها:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### محلل الصفحات
 
-Add the Escalated pages to your Inertia page resolver:
+أضف صفحات Escalated إلى محلل صفحات Inertia الخاص بك:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### التخصيص (اختياري)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+قم بتسجيل `EscalatedPlugin` لعرض صفحات Escalated داخل تخطيط تطبيقك — لا حاجة لتكرار الصفحات:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+راجع [ملف `@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) للحصول على وثائق السمات الكاملة وخصائص CSS المخصصة.
 
 ## أوضاع الاستضافة
 
 ### Self-Hosted (الافتراضي)
 
-Everything stays in your database. No external calls. Full autonomy.
+كل شيء يبقى في قاعدة بياناتك. لا اتصالات خارجية. استقلالية كاملة.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### متزامن
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+قاعدة بيانات محلية + مزامنة تلقائية مع `cloud.escalated.dev` لصندوق وارد موحد عبر تطبيقات متعددة. إذا كانت السحابة غير قابلة للوصول، يستمر تطبيقك في العمل — الأحداث تُوضع في قائمة الانتظار ويُعاد المحاولة.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### السحابة
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+جميع بيانات التذاكر تُوجَّه عبر واجهة API السحابية. تطبيقك يتعامل مع المصادقة ويعرض الواجهة، لكن التخزين يكون في السحابة.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+تشترك جميع الأوضاع الثلاثة في نفس العروض وواجهة المستخدم ومنطق الأعمال. نمط المحرك يتعامل مع الباقي.
 
 ## التهيئة
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## SDK الإضافات
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+يدعم Escalated إضافات مستقلة عن إطار العمل مبنية بـ [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). تُكتب الإضافات مرة واحدة بـ TypeScript وتعمل عبر جميع خلفيات Escalated.
 
 ### المتطلبات
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### الموارد
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — حزمة تطوير TypeScript لبناء الإضافات
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — مضيف وقت التشغيل للإضافات
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — التوثيق الكامل
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## متوفر أيضاً لـ
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — حزمة Laravel Composer
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — محرك Ruby on Rails
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — تطبيق Django قابل لإعادة الاستخدام (أنت هنا)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — حزمة AdonisJS v6
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — إضافة لوحة إدارة Filament v3
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — مكونات واجهة المستخدم Vue 3 + Inertia.js
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+نفس البنية، نفس واجهة Vue، نفس أوضاع الاستضافة الثلاثة — لكل إطار عمل خلفي رئيسي.
 
 ## التطوير
 

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Ein vollständiges, einbettbares Support-Ticket-System für Django. Integrieren Sie es in jede App — erhalten Sie einen kompletten Helpdesk mit SLA-Tracking, Eskalationsregeln, Agenten-Workflows und einem Kundenportal. Keine externen Dienste erforderlich.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — Erfahren Sie mehr, sehen Sie Demos und vergleichen Sie Cloud- mit Self-Hosted-Optionen.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Drei Hosting-Modi.** Komplett selbst gehostet betreiben, mit einer zentralen Cloud für Multi-App-Sichtbarkeit synchronisieren oder alles über die Cloud weiterleiten. Modi mit einer einzigen Konfigurationsänderung wechseln.
 
 ## Funktionen
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **E-Mail-Benachrichtigungen** — Konfigurierbare ereignisbezogene Benachrichtigungen mit Webhook-Unterstützung
 - **Abteilungs-Routing** — Agenten in Abteilungen organisieren mit Auto-Zuweisung (Round-Robin)
 - **Tagging-System** — Tickets mit farbigen Tags kategorisieren
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Gemeinsames Frontend über [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **Ticket-Aufteilung** — Eine Antwort in ein neues eigenständiges Ticket aufteilen und den ursprünglichen Kontext beibehalten
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Tickets mit Voreinstellungen schlummern lassen (1h, 4h, morgen, nächste Woche); der Verwaltungsbefehl `python manage.py wake_snoozed_tickets` weckt sie automatisch nach Zeitplan
 - **Gespeicherte Ansichten / benutzerdefinierte Warteschlangen** — Filter-Voreinstellungen als wiederverwendbare Ticket-Ansichten speichern, benennen und teilen
 - **Einbettbares Support-Widget** — Leichtgewichtiges `<script>`-Widget mit KB-Suche, Ticket-Formular und Statusprüfung
 - **E-Mail-Threading** — Ausgehende E-Mails enthalten korrekte `In-Reply-To`- und `References`-Header für korrektes Threading in Mail-Clients
 - **Marken-E-Mail-Vorlagen** — Konfigurierbares Logo, Primärfarbe und Fußzeilentext für alle ausgehenden E-Mails
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Opt-in-Broadcasting über Django Channels mit automatischem Polling-Fallback
 - **Wissensdatenbank-Schalter** — Öffentliche Wissensdatenbank in den Admin-Einstellungen aktivieren oder deaktivieren
 
 ## Voraussetzungen
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (für Frontend-Assets)
 
 ## Schnellstart
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Frontend-Einrichtung
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated verwendet Inertia.js mit Vue 3. Die Frontend-Komponenten werden vom npm-Paket [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) bereitgestellt.
 
 ### Tailwind-Inhalt
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Fügen Sie das Escalated-Paket zu Ihrer Tailwind `content`-Konfiguration hinzu, damit seine Klassen nicht entfernt werden:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Seiten-Resolver
 
-Add the Escalated pages to your Inertia page resolver:
+Fügen Sie die Escalated-Seiten zu Ihrem Inertia-Seitenresolver hinzu:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Theming (Optional)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+Registrieren Sie das `EscalatedPlugin`, um Escalated-Seiten in Ihrem App-Layout zu rendern — keine Seitenduplizierung erforderlich:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+Siehe die [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) für die vollständige Theming-Dokumentation und CSS Custom Properties.
 
 ## Hosting-Modi
 
 ### Self-Hosted (Standard)
 
-Everything stays in your database. No external calls. Full autonomy.
+Alles bleibt in Ihrer Datenbank. Keine externen Aufrufe. Volle Autonomie.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Synchronisiert
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Lokale Datenbank + automatische Synchronisation mit `cloud.escalated.dev` für einen einheitlichen Posteingang über mehrere Apps. Wenn die Cloud nicht erreichbar ist, funktioniert Ihre App weiter — Ereignisse werden in die Warteschlange gestellt und erneut versucht.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Cloud
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Alle Ticket-Daten werden über die Cloud-API weitergeleitet. Ihre App übernimmt die Authentifizierung und rendert die UI, aber die Speicherung erfolgt in der Cloud.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Alle drei Modi teilen sich dieselben Views, die UI und die Geschäftslogik. Das Driver-Pattern erledigt den Rest.
 
 ## Konfiguration
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## Plugin-SDK
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated unterstützt framework-agnostische Plugins, die mit dem [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) erstellt werden. Plugins werden einmal in TypeScript geschrieben und funktionieren über alle Escalated-Backends.
 
 ### Voraussetzungen
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Ressourcen
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK zum Erstellen von Plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Laufzeit-Host für Plugins
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Vollständige Dokumentation
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## Auch Verfügbar Für
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer-Paket
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails Engine
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Wiederverwendbare Django-App (Sie sind hier)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6-Paket
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 Admin-Panel-Plugin
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI-Komponenten
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Gleiche Architektur, gleiche Vue-UI, gleiche drei Hosting-Modi — für jedes wichtige Backend-Framework.
 
 ## Entwicklung
 

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Un sistema de tickets de soporte completo e integrable para Django. Agrégalo a cualquier aplicación — obtén un helpdesk completo con seguimiento de SLA, reglas de escalamiento, flujos de trabajo de agentes y un portal de clientes. No requiere servicios externos.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — Obtenga más información, vea demos y compare las opciones de Cloud vs Auto-hospedado.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Tres modos de alojamiento.** Ejecute completamente auto-hospedado, sincronice con una nube central para visibilidad multi-aplicación, o redirija todo a la nube. Cambie de modo con un solo cambio de configuración.
 
 ## Características
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Notificaciones por correo** — Notificaciones configurables por evento con soporte de webhooks
 - **Enrutamiento por departamentos** — Organizar agentes en departamentos con asignación automática (round-robin)
 - **Sistema de etiquetado** — Categorizar tickets con etiquetas de colores
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Frontend compartido a través de [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **División de tickets** — Dividir una respuesta en un nuevo ticket independiente conservando el contexto original
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Posponer tickets con preajustes (1h, 4h, mañana, próxima semana); el comando de gestión `python manage.py wake_snoozed_tickets` los reactiva automáticamente según la programación
 - **Vistas guardadas / colas personalizadas** — Guardar, nombrar y compartir filtros preestablecidos como vistas de tickets reutilizables
 - **Widget de soporte integrable** — Widget ligero `<script>` con búsqueda en KB, formulario de tickets y verificación de estado
 - **Hilos de correo electrónico** — Los correos salientes incluyen encabezados `In-Reply-To` y `References` apropiados para el hilo correcto en clientes de correo
 - **Plantillas de correo con marca** — Logo, color primario y texto de pie de página configurables para todos los correos salientes
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Transmisión opcional a través de Django Channels con respaldo automático de sondeo
 - **Interruptor de base de conocimientos** — Habilitar o deshabilitar la base de conocimientos pública desde la configuración de administración
 
 ## Requisitos
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (para recursos del frontend)
 
 ## Inicio Rápido
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Configuración del Frontend
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated utiliza Inertia.js con Vue 3. Los componentes del frontend son proporcionados por el paquete npm [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated).
 
 ### Contenido de Tailwind
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Agregue el paquete Escalated a la configuración `content` de Tailwind para que sus clases no sean eliminadas:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Resolución de Páginas
 
-Add the Escalated pages to your Inertia page resolver:
+Agregue las páginas de Escalated a su resolver de páginas de Inertia:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Temas (Opcional)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+Registre el `EscalatedPlugin` para renderizar las páginas de Escalated dentro del diseño de su aplicación — no se necesita duplicación de páginas:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+Consulte el [README de `@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) para la documentación completa de temas y propiedades CSS personalizadas.
 
 ## Modos de Alojamiento
 
 ### Self-Hosted (predeterminado)
 
-Everything stays in your database. No external calls. Full autonomy.
+Todo permanece en su base de datos. Sin llamadas externas. Autonomía total.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Sincronizado
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Base de datos local + sincronización automática con `cloud.escalated.dev` para bandeja de entrada unificada en múltiples aplicaciones. Si la nube no está disponible, su aplicación sigue funcionando — los eventos se ponen en cola y se reintentan.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Nube
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Todos los datos de tickets se envían a la API en la nube. Su aplicación maneja la autenticación y renderiza la interfaz, pero el almacenamiento vive en la nube.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Los tres modos comparten las mismas vistas, interfaz y lógica de negocio. El patrón de driver se encarga del resto.
 
 ## Configuración
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## SDK de Plugins
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated soporta plugins agnósticos al framework construidos con el [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Los plugins se escriben una vez en TypeScript y funcionan en todos los backends de Escalated.
 
 ### Requisitos
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Recursos
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — SDK de TypeScript para crear plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Host de tiempo de ejecución para plugins
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Documentación completa
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## También Disponible Para
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Paquete Laravel Composer
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Motor Ruby on Rails
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Aplicación reutilizable de Django (estás aquí)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Paquete AdonisJS v6
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin de panel de administración Filament v3
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Componentes de UI Vue 3 + Inertia.js
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Misma arquitectura, misma interfaz Vue, mismos tres modos de alojamiento — para cada framework backend importante.
 
 ## Desarrollo
 

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Un système de tickets de support complet et intégrable pour Django. Intégrez-le dans n'importe quelle application — obtenez un helpdesk complet avec suivi des SLA, règles d'escalade, workflows des agents et un portail client. Aucun service externe requis.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — En savoir plus, voir les démos et comparer les options Cloud vs Auto-hébergé.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Trois modes d'hébergement.** Exécution entièrement auto-hébergée, synchronisation avec un cloud central pour une visibilité multi-applications, ou proxy de tout vers le cloud. Changez de mode avec un simple changement de configuration.
 
 ## Fonctionnalités
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Notifications par email** — Notifications configurables par événement avec support webhook
 - **Routage par département** — Organiser les agents en départements avec auto-assignation (round-robin)
 - **Système de tags** — Catégoriser les tickets avec des tags colorés
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Frontend partagé via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **Division de tickets** — Séparer une réponse en un nouveau ticket indépendant tout en préservant le contexte original
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Mettre en veille les tickets avec des préréglages (1h, 4h, demain, semaine prochaine) ; la commande `python manage.py wake_snoozed_tickets` les réactive automatiquement
 - **Vues enregistrées / files personnalisées** — Enregistrer, nommer et partager des préréglages de filtres comme vues de tickets réutilisables
 - **Widget de support intégrable** — Widget léger `<script>` avec recherche KB, formulaire de ticket et vérification d'état
 - **Threading email** — Les emails sortants incluent les en-têtes `In-Reply-To` et `References` pour un threading correct dans les clients mail
 - **Modèles d'email personnalisés** — Logo, couleur primaire et texte de pied de page configurables pour tous les emails sortants
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Diffusion optionnelle via Django Channels avec repli automatique sur le polling
 - **Activation de la base de connaissances** — Activer ou désactiver la base de connaissances publique depuis les paramètres d'administration
 
 ## Prérequis
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (pour les ressources frontend)
 
 ## Démarrage Rapide
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Configuration du Frontend
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated utilise Inertia.js avec Vue 3. Les composants frontend sont fournis par le package npm [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated).
 
 ### Contenu Tailwind
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Ajoutez le package Escalated à la configuration `content` de Tailwind pour que ses classes ne soient pas purgées :
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Résolveur de Pages
 
-Add the Escalated pages to your Inertia page resolver:
+Ajoutez les pages Escalated à votre résolveur de pages Inertia :
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Thème (Optionnel)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+Enregistrez le `EscalatedPlugin` pour afficher les pages Escalated dans la mise en page de votre application — aucune duplication de pages nécessaire :
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+Consultez le [README de `@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) pour la documentation complète sur les thèmes et les propriétés CSS personnalisées.
 
 ## Modes d'Hébergement
 
 ### Self-Hosted (par défaut)
 
-Everything stays in your database. No external calls. Full autonomy.
+Tout reste dans votre base de données. Aucun appel externe. Autonomie totale.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Synchronisé
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Base de données locale + synchronisation automatique vers `cloud.escalated.dev` pour une boîte de réception unifiée sur plusieurs applications. Si le cloud est inaccessible, votre application continue de fonctionner — les événements sont mis en file d'attente et réessayés.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Cloud
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Toutes les données de tickets sont proxifiées vers l'API cloud. Votre application gère l'authentification et affiche l'interface, mais le stockage réside dans le cloud.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Les trois modes partagent les mêmes vues, l'interface et la logique métier. Le pattern driver gère le reste.
 
 ## Configuration
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## SDK de Plugins
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated prend en charge des plugins indépendants du framework construits avec le [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Les plugins sont écrits une fois en TypeScript et fonctionnent sur tous les backends Escalated.
 
 ### Prérequis
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Ressources
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — SDK TypeScript pour créer des plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Hôte d'exécution pour les plugins
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Documentation complète
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## Également Disponible Pour
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Package Laravel Composer
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Moteur Ruby on Rails
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Application Django réutilisable (vous êtes ici)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Package AdonisJS v6
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin panneau d'administration Filament v3
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Composants UI Vue 3 + Inertia.js
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Même architecture, même interface Vue, mêmes trois modes d'hébergement — pour chaque framework backend majeur.
 
 ## Développement
 

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Un sistema di ticket di supporto completo e integrabile per Django. Aggiungilo a qualsiasi app — ottieni un helpdesk completo con tracciamento SLA, regole di escalation, flussi di lavoro degli agenti e un portale clienti. Nessun servizio esterno richiesto.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — Scopri di più, guarda le demo e confronta le opzioni Cloud vs Self-Hosted.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Tre modalità di hosting.** Esecuzione completamente self-hosted, sincronizzazione con un cloud centrale per la visibilità multi-app, o proxy di tutto verso il cloud. Cambio modalità con una singola modifica alla configurazione.
 
 ## Funzionalità
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Notifiche email** — Notifiche configurabili per evento con supporto webhook
 - **Routing per reparto** — Organizzare gli agenti in reparti con assegnazione automatica (round-robin)
 - **Sistema di tagging** — Categorizzare i ticket con tag colorati
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Frontend condiviso tramite [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **Divisione ticket** — Dividere una risposta in un nuovo ticket autonomo preservando il contesto originale
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Sospendi i ticket con preimpostazioni (1h, 4h, domani, prossima settimana); il comando `python manage.py wake_snoozed_tickets` li riattiva automaticamente
 - **Viste salvate / code personalizzate** — Salvare, denominare e condividere preset di filtri come viste ticket riutilizzabili
 - **Widget di supporto integrabile** — Widget leggero `<script>` con ricerca KB, modulo ticket e verifica stato
 - **Threading email** — Le email in uscita includono gli header `In-Reply-To` e `References` per un threading corretto nei client di posta
 - **Template email personalizzati** — Logo, colore primario e testo del footer configurabili per tutte le email in uscita
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Broadcasting opzionale tramite Django Channels con fallback automatico al polling
 - **Toggle base di conoscenza** — Abilitare o disabilitare la base di conoscenza pubblica dalle impostazioni admin
 
 ## Requisiti
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (per le risorse frontend)
 
 ## Avvio Rapido
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Configurazione Frontend
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated utilizza Inertia.js con Vue 3. I componenti frontend sono forniti dal pacchetto npm [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated).
 
 ### Contenuto Tailwind
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Aggiungi il pacchetto Escalated alla configurazione `content` di Tailwind affinché le sue classi non vengano rimosse:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Risolutore di Pagine
 
-Add the Escalated pages to your Inertia page resolver:
+Aggiungi le pagine Escalated al tuo resolver delle pagine Inertia:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Temi (Opzionale)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+Registra l'`EscalatedPlugin` per renderizzare le pagine Escalated all'interno del layout della tua app — nessuna duplicazione di pagine necessaria:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+Consulta il [README di `@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) per la documentazione completa sui temi e le proprietà CSS personalizzate.
 
 ## Modalità di Hosting
 
 ### Self-Hosted (predefinito)
 
-Everything stays in your database. No external calls. Full autonomy.
+Tutto rimane nel tuo database. Nessuna chiamata esterna. Piena autonomia.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Sincronizzato
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Database locale + sincronizzazione automatica con `cloud.escalated.dev` per una casella di posta unificata su più app. Se il cloud non è raggiungibile, la tua app continua a funzionare — gli eventi vengono messi in coda e riprovati.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Cloud
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Tutti i dati dei ticket vengono inviati all'API cloud. La tua app gestisce l'autenticazione e renderizza l'interfaccia, ma l'archiviazione risiede nel cloud.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Tutte e tre le modalità condividono le stesse view, l'interfaccia e la logica di business. Il pattern driver gestisce il resto.
 
 ## Configurazione
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## SDK Plugin
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated supporta plugin indipendenti dal framework costruiti con il [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). I plugin vengono scritti una volta in TypeScript e funzionano su tutti i backend Escalated.
 
 ### Requisiti
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Risorse
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — SDK TypeScript per creare plugin
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Host runtime per i plugin
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Documentazione completa
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## Disponibile Anche Per
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Pacchetto Laravel Composer
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Motore Ruby on Rails
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — App Django riutilizzabile (sei qui)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Pacchetto AdonisJS v6
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin pannello admin Filament v3
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Componenti UI Vue 3 + Inertia.js
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Stessa architettura, stessa interfaccia Vue, stesse tre modalità di hosting — per ogni framework backend principale.
 
 ## Sviluppo
 

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Django用のフル機能で埋め込み可能なサポートチケットシステム。任意のアプリに導入するだけで、SLA追跡、エスカレーションルール、エージェントワークフロー、カスタマーポータルを備えた完全なヘルプデスクが手に入ります。外部サービスは不要です。
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — 詳細の確認、デモの閲覧、クラウドとセルフホストのオプション比較はこちら。
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**3つのホスティングモード。** 完全セルフホスト、マルチアプリの可視性のためのセントラルクラウドへの同期、またはすべてをクラウドにプロキシ。設定を1つ変更するだけでモードを切り替えられます。
 
 ## 機能
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **メール通知** — Webhookサポート付きの設定可能なイベント単位の通知
 - **部門ルーティング** — エージェントを部門に整理し、自動割り当て（ラウンドロビン）
 - **タグ付けシステム** — 色付きタグでチケットを分類
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) による共有フロントエンド
 - **チケットの分割** — 元のコンテキストを保持しながら返信を新しい独立チケットに分割
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — プリセットでチケットをスヌーズ（1時間、4時間、明日、来週）、管理コマンド `python manage.py wake_snoozed_tickets` がスケジュールに従って自動的に起動
 - **保存済みビュー / カスタムキュー** — フィルタープリセットを再利用可能なチケットビューとして保存、命名、共有
 - **埋め込み可能なサポートウィジェット** — KB検索、チケットフォーム、ステータス確認付きの軽量`<script>`ウィジェット
 - **メールスレッディング** — 送信メールに適切な`In-Reply-To`および`References`ヘッダーを含め、メールクライアントでの正しいスレッディングを実現
 - **ブランドメールテンプレート** — すべての送信メールのロゴ、プライマリカラー、フッターテキストを設定可能
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Django Channelsによるオプトインブロードキャスト、自動ポーリングフォールバック付き
 - **ナレッジベースの切り替え** — 管理設定から公開ナレッジベースを有効/無効に切り替え
 
 ## 要件
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (フロントエンドアセット用)
 
 ## クイックスタート
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## フロントエンドのセットアップ
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+EscalatedはInertia.jsとVue 3を使用します。フロントエンドコンポーネントはnpmパッケージ[`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)で提供されます。
 
 ### Tailwindコンテンツ
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+EscalatedパッケージをTailwindの`content`設定に追加して、そのクラスがパージされないようにします：
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### ページリゾルバー
 
-Add the Escalated pages to your Inertia page resolver:
+EscalatedのページをInertiaページリゾルバーに追加します：
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### テーマ設定（オプション）
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+`EscalatedPlugin`を登録して、アプリのレイアウト内でEscalatedページをレンダリングします — ページの複製は不要です：
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+テーマの完全なドキュメントとCSSカスタムプロパティについては[`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated)を参照してください。
 
 ## ホスティングモード
 
 ### Self-Hosted（デフォルト）
 
-Everything stays in your database. No external calls. Full autonomy.
+すべてがデータベースに保存されます。外部呼び出しなし。完全な自律性。
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### 同期モード
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+ローカルデータベース + `cloud.escalated.dev`への自動同期で複数アプリにわたる統合受信箱。クラウドに到達できない場合、アプリは動作を継続します — イベントはキューに入り、リトライされます。
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### クラウド
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+すべてのチケットデータはクラウドAPIにプロキシされます。アプリが認証とUIのレンダリングを処理しますが、ストレージはクラウドにあります。
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+3つのモードすべてが同じビュー、UI、ビジネスロジックを共有します。ドライバーパターンが残りを処理します。
 
 ## 設定
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## プラグインSDK
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalatedは[Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk)で構築されたフレームワーク非依存のプラグインをサポートしています。プラグインはTypeScriptで一度書くだけで、すべてのEscalatedバックエンドで動作します。
 
 ### 要件
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### リソース
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — プラグイン構築用TypeScript SDK
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — プラグイン用ランタイムホスト
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — 完全なドキュメント
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## 他のフレームワーク向けも提供
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composerパッケージ
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Railsエンジン
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django再利用可能アプリ（現在のページ）
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6パッケージ
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3管理パネルプラグイン
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UIコンポーネント
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+同じアーキテクチャ、同じVue UI、同じ3つのホスティングモード — すべての主要バックエンドフレームワークに対応。
 
 ## 開発
 

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Django용 완전한 기능을 갖춘 임베드 가능한 지원 티켓 시스템입니다. 어떤 앱에든 추가하면 SLA 추적, 에스컬레이션 규칙, 상담원 워크플로우, 고객 포털을 갖춘 완전한 헬프데스크를 얻을 수 있습니다. 외부 서비스가 필요 없습니다.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — 자세히 알아보고, 데모를 보고, 클라우드와 셀프호스팅 옵션을 비교하세요.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**세 가지 호스팅 모드.** 완전한 셀프호스팅, 멀티앱 가시성을 위한 중앙 클라우드 동기화, 또는 모든 것을 클라우드로 프록시. 설정 하나만 변경하면 모드를 전환할 수 있습니다.
 
 ## 기능
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **이메일 알림** — 웹훅 지원을 포함한 이벤트별 구성 가능한 알림
 - **부서 라우팅** — 에이전트를 부서별로 조직하고 자동 할당 (라운드 로빈)
 - **태그 시스템** — 색상 태그로 티켓 분류
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)를 통한 공유 프론트엔드
 - **티켓 분할** — 원래 컨텍스트를 보존하면서 답변을 새로운 독립 티켓으로 분할
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — 프리셋으로 티켓 스누즈 (1시간, 4시간, 내일, 다음 주); 관리 명령어 `python manage.py wake_snoozed_tickets`가 예정대로 자동으로 깨움
 - **저장된 뷰 / 커스텀 큐** — 필터 프리셋을 재사용 가능한 티켓 뷰로 저장, 명명 및 공유
 - **임베드 가능한 지원 위젯** — KB 검색, 티켓 폼, 상태 확인이 포함된 경량 `<script>` 위젯
 - **이메일 스레딩** — 발신 이메일에 적절한 `In-Reply-To` 및 `References` 헤더를 포함하여 메일 클라이언트에서 올바른 스레딩 지원
 - **브랜드 이메일 템플릿** — 모든 발신 이메일에 대해 로고, 기본 색상, 바닥글 텍스트 구성 가능
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Django Channels를 통한 선택적 브로드캐스팅, 자동 폴링 폴백 포함
 - **지식 베이스 토글** — 관리자 설정에서 공개 지식 베이스 활성화 또는 비활성화
 
 ## 요구 사항
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (프론트엔드 자산용)
 
 ## 빠른 시작
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## 프론트엔드 설정
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated는 Inertia.js와 Vue 3를 사용합니다. 프론트엔드 컴포넌트는 npm 패키지 [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)에서 제공됩니다.
 
 ### Tailwind 콘텐츠
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Escalated 패키지를 Tailwind `content` 설정에 추가하여 클래스가 제거되지 않도록 하세요:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### 페이지 리졸버
 
-Add the Escalated pages to your Inertia page resolver:
+Escalated 페이지를 Inertia 페이지 리줄버에 추가하세요:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### 테마 설정 (선택사항)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+`EscalatedPlugin`을 등록하여 앱의 레이아웃 내에서 Escalated 페이지를 렌더링하세요 — 페이지 복제가 필요 없습니다:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+전체 테마 문서와 CSS 커스텀 속성에 대해서는 [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated)를 참조하세요.
 
 ## 호스팅 모드
 
 ### Self-Hosted (기본값)
 
-Everything stays in your database. No external calls. Full autonomy.
+모든 것이 데이터베이스에 유지됩니다. 외부 호출 없음. 완전한 자율성.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### 동기화
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+로컬 데이터베이스 + `cloud.escalated.dev`로의 자동 동기화로 여러 앱에 걸친 통합 수신함. 클라우드에 연결할 수 없는 경우 앱은 계속 작동합니다 — 이벤트가 대기열에 추가되고 재시도됩니다.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### 클라우드
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+모든 티켓 데이터가 클라우드 API로 프록시됩니다. 앱이 인증과 UI 렌더링을 처리하지만 저장소는 클라우드에 있습니다.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+세 가지 모드 모두 동일한 뷰, UI 및 비즈니스 로직을 공유합니다. 드라이버 패턴이 나머지를 처리합니다.
 
 ## 설정
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## 플러그인 SDK
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated는 [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk)로 구축된 프레임워크 독립적인 플러그인을 지원합니다. 플러그인은 TypeScript로 한 번 작성하면 모든 Escalated 백엔드에서 작동합니다.
 
 ### 요구 사항
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### 리소스
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — 플러그인 구축을 위한 TypeScript SDK
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — 플러그인용 런타임 호스트
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — 전체 문서
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## 다른 프레임워크에서도 이용 가능
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer 패키지
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails 엔진
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django 재사용 앱 (현재 페이지)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 패키지
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 관리 패널 플러그인
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI 컴포넌트
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+동일한 아키텍처, 동일한 Vue UI, 동일한 세 가지 호스팅 모드 — 모든 주요 백엔드 프레임워크에 대응.
 
 ## 개발
 

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Een volledig uitgerust, inbedbaar support-ticketsysteem voor Django. Voeg het toe aan elke app — krijg een complete helpdesk met SLA-tracking, escalatieregels, agent-workflows en een klantenportaal. Geen externe diensten vereist.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — Meer informatie, bekijk demo's en vergelijk Cloud- met Self-Hosted-opties.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Drie hostingmodi.** Volledig zelf hosten, synchroniseren met een centrale cloud voor multi-app-zichtbaarheid, of alles via de cloud proxyen. Wissel van modus met één configuratiewijziging.
 
 ## Functies
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **E-mailnotificaties** — Configureerbare notificaties per gebeurtenis met webhook-ondersteuning
 - **Afdelingsroutering** — Agents organiseren in afdelingen met automatische toewijzing (round-robin)
 - **Taggingsysteem** — Tickets categoriseren met gekleurde tags
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Gedeelde frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **Ticket splitsen** — Een antwoord afsplitsen naar een nieuw zelfstandig ticket met behoud van de originele context
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Tickets snoozen met voorinstellingen (1u, 4u, morgen, volgende week); het beheercommando `python manage.py wake_snoozed_tickets` wekt ze automatisch volgens schema
 - **Opgeslagen weergaven / aangepaste wachtrijen** — Filterpresets opslaan, benoemen en delen als herbruikbare ticketweergaven
 - **Inbedbare supportwidget** — Lichtgewicht `<script>`-widget met KB-zoeken, ticketformulier en statuscontrole
 - **E-mailthreading** — Uitgaande e-mails bevatten de juiste `In-Reply-To`- en `References`-headers voor correcte threading in mailclients
 - **E-mailsjablonen met branding** — Configureerbaar logo, primaire kleur en voettekst voor alle uitgaande e-mails
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Opt-in broadcasting via Django Channels met automatische polling-fallback
 - **Kennisbank-schakelaar** — De publieke kennisbank in- of uitschakelen vanuit beheerinstellingen
 
 ## Vereisten
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (voor frontend-assets)
 
 ## Snelstart
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Frontend-configuratie
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated gebruikt Inertia.js met Vue 3. De frontend-componenten worden geleverd door het npm-pakket [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated).
 
 ### Tailwind-inhoud
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Voeg het Escalated-pakket toe aan uw Tailwind `content`-configuratie zodat de klassen niet worden verwijderd:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Pagina-resolver
 
-Add the Escalated pages to your Inertia page resolver:
+Voeg de Escalated-pagina's toe aan uw Inertia-pagina-resolver:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Theming (Optioneel)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+Registreer de `EscalatedPlugin` om Escalated-pagina's in de layout van uw app te renderen — geen paginaduplicatie nodig:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+Zie de [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) voor volledige theming-documentatie en CSS custom properties.
 
 ## Hostingmodi
 
 ### Self-Hosted (standaard)
 
-Everything stays in your database. No external calls. Full autonomy.
+Alles blijft in uw database. Geen externe oproepen. Volledige autonomie.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Gesynchroniseerd
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Lokale database + automatische synchronisatie naar `cloud.escalated.dev` voor een uniforme inbox over meerdere apps. Als de cloud onbereikbaar is, blijft uw app werken — gebeurtenissen worden in de wachtrij geplaatst en opnieuw geprobeerd.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Cloud
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Alle ticketgegevens worden geproxyd naar de cloud-API. Uw app handelt authenticatie af en rendert de UI, maar opslag bevindt zich in de cloud.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Alle drie modi delen dezelfde views, UI en bedrijfslogica. Het driver-patroon regelt de rest.
 
 ## Configuratie
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## Plugin-SDK
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated ondersteunt framework-agnostische plugins gebouwd met de [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins worden eenmaal geschreven in TypeScript en werken op alle Escalated-backends.
 
 ### Vereisten
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Bronnen
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK voor het bouwen van plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime-host voor plugins
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Volledige documentatie
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## Ook Beschikbaar Voor
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer-pakket
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails-engine
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Herbruikbare Django-app (u bent hier)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6-pakket
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin-paneel-plugin
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI-componenten
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Dezelfde architectuur, dezelfde Vue-UI, dezelfde drie hostingmodi — voor elk belangrijk backend-framework.
 
 ## Ontwikkeling
 

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+W pełni funkcjonalny, wbudowywalny system zgłoszeń wsparcia dla Django. Dodaj go do dowolnej aplikacji — otrzymasz kompletny helpdesk ze śledzeniem SLA, regułami eskalacji, przepływami pracy agentów i portalem klienta. Nie wymaga zewnętrznych usług.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — Dowiedz się więcej, zobacz dema i porównaj opcje Cloud z Self-Hosted.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Trzy tryby hostingu.** Uruchom w pełni na własnym serwerze, synchronizuj z centralną chmurą dla widoczności wielu aplikacji lub przekieruj wszystko do chmury. Zmień tryb jedną zmianą konfiguracji.
 
 ## Funkcje
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Powiadomienia email** — Konfigurowalne powiadomienia per zdarzenie z obsługą webhooków
 - **Routing departamentowy** — Organizacja agentów w działy z automatycznym przypisywaniem (round-robin)
 - **System tagów** — Kategoryzacja zgłoszeń kolorowymi tagami
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Współdzielony frontend przez [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **Dzielenie zgłoszeń** — Rozdzielenie odpowiedzi na nowe niezależne zgłoszenie z zachowaniem oryginalnego kontekstu
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Odraczanie zgłoszeń z predefiniowanymi ustawieniami (1h, 4h, jutro, przyszły tydzień); komenda `python manage.py wake_snoozed_tickets` budzi je automatycznie według harmonogramu
 - **Zapisane widoki / niestandardowe kolejki** — Zapisywanie, nazywanie i udostępnianie presetów filtrów jako wielokrotnie używalnych widoków zgłoszeń
 - **Osadzalny widżet wsparcia** — Lekki widżet `<script>` z wyszukiwaniem KB, formularzem zgłoszeń i sprawdzaniem statusu
 - **Wątkowanie e-mail** — Wychodzące wiadomości zawierają poprawne nagłówki `In-Reply-To` i `References` dla prawidłowego wątkowania w klientach poczty
 - **Szablony e-mail z marką** — Konfigurowalne logo, kolor główny i tekst stopki dla wszystkich wychodzących wiadomości
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Opcjonalne nadawanie przez Django Channels z automatycznym fallbackiem na polling
 - **Przełącznik bazy wiedzy** — Włączenie lub wyłączenie publicznej bazy wiedzy z ustawień administracyjnych
 
 ## Wymagania
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (dla zasobów frontendowych)
 
 ## Szybki Start
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Konfiguracja Frontend
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated używa Inertia.js z Vue 3. Komponenty frontendowe są dostarczane przez pakiet npm [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated).
 
 ### Zawartość Tailwind
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Dodaj pakiet Escalated do konfiguracji `content` Tailwind, aby jego klasy nie zostały usunięte:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Resolver Stron
 
-Add the Escalated pages to your Inertia page resolver:
+Dodaj strony Escalated do resolvera stron Inertia:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Motywy (Opcjonalnie)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+Zarejestruj `EscalatedPlugin`, aby renderować strony Escalated wewnątrz layoutu twojej aplikacji — nie jest potrzebna duplikacja stron:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+Zobacz [README `@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) po pełną dokumentację motywów i właściwości CSS.
 
 ## Tryby Hostingu
 
 ### Self-Hosted (domyślny)
 
-Everything stays in your database. No external calls. Full autonomy.
+Wszystko pozostaje w Twojej bazie danych. Brak zewnętrznych wywołań. Pełna autonomia.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Zsynchronizowany
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Lokalna baza danych + automatyczna synchronizacja z `cloud.escalated.dev` dla zunifikowanej skrzynki odbiorczej w wielu aplikacjach. Jeśli chmura jest nieosiągalna, Twoja aplikacja nadal działa — zdarzenia są kolejkowane i ponawiane.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Chmura
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Wszystkie dane zgłoszeń są przekazywane przez API chmury. Twoja aplikacja obsługuje autoryzację i renderuje interfejs, ale dane są przechowywane w chmurze.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Wszystkie trzy tryby współdzielą te same widoki, interfejs i logikę biznesową. Wzorzec sterownika obsługuje resztę.
 
 ## Konfiguracja
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## SDK Wtyczek
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated obsługuje wtyczki niezależne od frameworka zbudowane z [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Wtyczki są pisane raz w TypeScript i działają na wszystkich backendach Escalated.
 
 ### Wymagania
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Zasoby
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK do tworzenia wtyczek
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Host runtime dla wtyczek
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Pełna dokumentacja
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## Dostępne Również Dla
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Pakiet Laravel Composer
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Silnik Ruby on Rails
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Aplikacja wielokrotnego użytku Django (jesteś tutaj)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Pakiet AdonisJS v6
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Wtyczka panelu administracyjnego Filament v3
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Komponenty UI Vue 3 + Inertia.js
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Ta sama architektura, ten sam interfejs Vue, te same trzy tryby hostingu — dla każdego ważnego frameworka backendowego.
 
 ## Rozwój
 

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Um sistema de tickets de suporte completo e integrável para Django. Adicione-o a qualquer aplicação — obtenha um helpdesk completo com rastreamento de SLA, regras de escalonamento, fluxos de trabalho de agentes e um portal do cliente. Nenhum serviço externo necessário.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — Saiba mais, veja demos e compare as opções Cloud vs Auto-hospedado.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Três modos de hospedagem.** Execute totalmente auto-hospedado, sincronize com uma nuvem central para visibilidade multi-aplicação, ou redirecione tudo para a nuvem. Mude de modo com uma única alteração de configuração.
 
 ## Funcionalidades
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Notificações por email** — Notificações configuráveis por evento com suporte a webhooks
 - **Roteamento por departamento** — Organizar agentes em departamentos com atribuição automática (round-robin)
 - **Sistema de tags** — Categorizar tickets com tags coloridas
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Frontend compartilhado via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **Divisão de tickets** — Dividir uma resposta em um novo ticket independente preservando o contexto original
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Adiar tickets com predefinições (1h, 4h, amanhã, próxima semana); o comando `python manage.py wake_snoozed_tickets` os reativa automaticamente
 - **Visualizações salvas / filas personalizadas** — Salvar, nomear e compartilhar presets de filtros como visualizações de tickets reutilizáveis
 - **Widget de suporte integrável** — Widget leve `<script>` com busca na KB, formulário de tickets e verificação de status
 - **Threading de email** — Emails enviados incluem cabeçalhos `In-Reply-To` e `References` para threading correto em clientes de email
 - **Templates de email com marca** — Logo, cor primária e texto do rodapé configuráveis para todos os emails enviados
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Broadcasting opcional via Django Channels com fallback automático de polling
 - **Toggle da base de conhecimento** — Habilitar ou desabilitar a base de conhecimento pública nas configurações de administração
 
 ## Requisitos
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (para recursos do frontend)
 
 ## Início Rápido
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Configuração do Frontend
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+O Escalated usa Inertia.js com Vue 3. Os componentes do frontend são fornecidos pelo pacote npm [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated).
 
 ### Conteúdo Tailwind
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Adicione o pacote Escalated à configuração `content` do Tailwind para que suas classes não sejam removidas:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Resolvedor de Páginas
 
-Add the Escalated pages to your Inertia page resolver:
+Adicione as páginas do Escalated ao seu resolver de páginas do Inertia:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Temas (Opcional)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+Registre o `EscalatedPlugin` para renderizar as páginas do Escalated dentro do layout do seu aplicativo — sem necessidade de duplicação de páginas:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+Consulte o [README do `@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) para documentação completa de temas e propriedades CSS personalizadas.
 
 ## Modos de Hospedagem
 
 ### Self-Hosted (padrão)
 
-Everything stays in your database. No external calls. Full autonomy.
+Tudo permanece no seu banco de dados. Sem chamadas externas. Autonomia total.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Sincronizado
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Banco de dados local + sincronização automática com `cloud.escalated.dev` para caixa de entrada unificada em múltiplas aplicações. Se a nuvem estiver inacessível, seu aplicativo continua funcionando — os eventos entram na fila e são reenviados.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Nuvem
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Todos os dados de tickets são proxy para a API na nuvem. Seu aplicativo lida com autenticação e renderiza a interface, mas o armazenamento fica na nuvem.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Os três modos compartilham as mesmas views, interface e lógica de negócios. O padrão de driver cuida do resto.
 
 ## Configuração
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## SDK de Plugins
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+O Escalated suporta plugins agnósticos de framework construídos com o [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Os plugins são escritos uma vez em TypeScript e funcionam em todos os backends do Escalated.
 
 ### Requisitos
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Recursos
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — SDK TypeScript para criar plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Host de runtime para plugins
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Documentação completa
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## Também Disponível Para
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Pacote Laravel Composer
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Motor Ruby on Rails
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Aplicativo Django reutilizável (você está aqui)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Pacote AdonisJS v6
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin de painel administrativo Filament v3
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Componentes de UI Vue 3 + Inertia.js
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Mesma arquitetura, mesma interface Vue, mesmos três modos de hospedagem — para cada framework backend importante.
 
 ## Desenvolvimento
 

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Полнофункциональная встраиваемая система тикетов поддержки для Django. Добавьте её в любое приложение — получите полноценный хелпдеск с отслеживанием SLA, правилами эскалации, рабочими процессами агентов и клиентским порталом. Внешние сервисы не требуются.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — Узнайте больше, посмотрите демо и сравните варианты Cloud и Self-Hosted.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Три режима хостинга.** Полностью самостоятельный хостинг, синхронизация с центральным облаком для видимости нескольких приложений или проксирование всего в облако. Переключение режимов одним изменением конфигурации.
 
 ## Возможности
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **Уведомления по email** — Настраиваемые уведомления по событиям с поддержкой вебхуков
 - **Маршрутизация по отделам** — Организация агентов по отделам с автоназначением (round-robin)
 - **Система тегов** — Категоризация тикетов с помощью цветных тегов
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Общий фронтенд через [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
 - **Разделение тикетов** — Выделение ответа в новый самостоятельный тикет с сохранением исходного контекста
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Откладывание тикетов с предустановками (1ч, 4ч, завтра, на следующей неделе); команда `python manage.py wake_snoozed_tickets` автоматически пробуждает их по расписанию
 - **Сохранённые представления / пользовательские очереди** — Сохранение, именование и обмен пресетами фильтров как повторно используемыми представлениями тикетов
 - **Встраиваемый виджет поддержки** — Лёгкий `<script>` виджет с поиском по KB, формой тикета и проверкой статуса
 - **Потоки электронной почты** — Исходящие письма включают корректные заголовки `In-Reply-To` и `References` для правильной группировки в почтовых клиентах
 - **Брендированные шаблоны писем** — Настраиваемый логотип, основной цвет и текст нижнего колонтитула для всех исходящих писем
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Опциональная трансляция через Django Channels с автоматическим откатом на опрос
 - **Переключатель базы знаний** — Включение или отключение публичной базы знаний из настроек администратора
 
 ## Требования
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (для фронтенд-ресурсов)
 
 ## Быстрый Старт
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Настройка Фронтенда
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated использует Inertia.js с Vue 3. Фронтенд-компоненты предоставляются npm-пакетом [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated).
 
 ### Контент Tailwind
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Добавьте пакет Escalated в конфигурацию `content` Tailwind, чтобы его классы не были удалены:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Резолвер Страниц
 
-Add the Escalated pages to your Inertia page resolver:
+Добавьте страницы Escalated в ваш резолвер страниц Inertia:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Темизация (Опционально)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+Зарегистрируйте `EscalatedPlugin` для рендеринга страниц Escalated внутри макета вашего приложения — дублирование страниц не требуется:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+См. [README `@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) для полной документации по темам и пользовательским свойствам CSS.
 
 ## Режимы Размещения
 
 ### Self-Hosted (по умолчанию)
 
-Everything stays in your database. No external calls. Full autonomy.
+Всё остаётся в вашей базе данных. Никаких внешних вызовов. Полная автономия.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Синхронизированный
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Локальная база данных + автоматическая синхронизация с `cloud.escalated.dev` для единого почтового ящика на нескольких приложениях. Если облако недоступно, ваше приложение продолжает работать — события ставятся в очередь и повторяются.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Облако
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Все данные тикетов проксируются через облачный API. Ваше приложение обрабатывает аутентификацию и рендерит UI, но хранилище находится в облаке.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Все три режима используют одни и те же представления, интерфейс и бизнес-логику. Паттерн драйвера обрабатывает остальное.
 
 ## Конфигурация
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## SDK Плагинов
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated поддерживает фреймворк-агностичные плагины, созданные с помощью [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Плагины пишутся один раз на TypeScript и работают на всех бэкендах Escalated.
 
 ### Требования
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Ресурсы
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK для создания плагинов
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Хост среды выполнения для плагинов
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Полная документация
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## Также Доступно Для
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Пакет Laravel Composer
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Движок Ruby on Rails
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Переиспользуемое приложение Django (вы здесь)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Пакет AdonisJS v6
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Плагин админ-панели Filament v3
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Компоненты UI Vue 3 + Inertia.js
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Та же архитектура, тот же Vue UI, те же три режима хостинга — для каждого основного бэкенд-фреймворка.
 
 ## Разработка
 

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+Django için tam özellikli, gömülebilir bir destek talep sistemi. Herhangi bir uygulamaya ekleyin — SLA takibi, eskalasyon kuralları, temsilci iş akışları ve müşteri portalı ile eksiksiz bir yardım masası elde edin. Harici hizmetler gerekmez.
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — Daha fazla bilgi edinin, demoları görüntüleyin ve Bulut ile Kendi Sunucunuzda seçeneklerini karşılaştırın.
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**Üç barındırma modu.** Tamamen kendi sunucunuzda çalıştırın, çoklu uygulama görünürlüğü için merkezi bir buluta senkronize edin veya her şeyi buluta yönlendirin. Tek bir yapılandırma değişikliğiyle modları değiştirin.
 
 ## Özellikler
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **E-posta bildirimleri** — Webhook desteği ile etkinlik bazında yapılandırılabilir bildirimler
 - **Departman yönlendirme** — Temsilcileri departmanlara organize edin, otomatik atama (round-robin)
 - **Etiketleme sistemi** — Biletleri renkli etiketlerle kategorize edin
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — Paylaşılan frontend [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) aracılığıyla
 - **Bilet bölme** — Orijinal bağlamı koruyarak bir yanıtı yeni bağımsız bir bilete ayırma
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — Ön ayarlı erteleme ile talepleri erteleyin (1 saat, 4 saat, yarın, gelecek hafta); yönetim komutu `python manage.py wake_snoozed_tickets` onları programa göre otomatik olarak uyandırır
 - **Kayıtlı görünümler / özel kuyruklar** — Filtre ön ayarlarını yeniden kullanılabilir bilet görünümleri olarak kaydedin, adlandırın ve paylaşın
 - **Gömülebilir destek widget'ı** — KB arama, bilet formu ve durum kontrolü içeren hafif `<script>` widget'ı
 - **E-posta zincirleme** — Giden e-postalar, posta istemcilerinde doğru zincirleme için uygun `In-Reply-To` ve `References` başlıkları içerir
 - **Markalı e-posta şablonları** — Tüm giden e-postalar için yapılandırılabilir logo, birincil renk ve altbilgi metni
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — Django Channels ile isteğe bağlı yayın, otomatik yoklama geri dönüşü ile
 - **Bilgi tabanı açma/kapama** — Yönetim ayarlarından herkese açık bilgi tabanını etkinleştirin veya devre dışı bırakın
 
 ## Gereksinimler
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (frontend varlıkları için)
 
 ## Hızlı Başlangıç
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## Frontend Kurulumu
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated, Inertia.js ile Vue 3 kullanır. Frontend bileşenleri [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm paketi tarafından sağlanır.
 
 ### Tailwind İçeriği
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+Escalated paketini Tailwind `content` yapılandırmanıza ekleyin, böylece sınıfları temizlenmez:
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### Sayfa Çözümleyici
 
-Add the Escalated pages to your Inertia page resolver:
+Escalated sayfalarını Inertia sayfa çözücünüze ekleyin:
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### Tema (İsteğe Bağlı)
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+`EscalatedPlugin`'ı kaydedin, Escalated sayfalarını uygulamanızın düzeni içinde oluşturun — sayfa çoğaltması gerekmez:
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+Tam tema dokümantasyonu ve CSS özel özellikleri için [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) dosyasına bakın.
 
 ## Barındırma Modları
 
 ### Self-Hosted (varsayılan)
 
-Everything stays in your database. No external calls. Full autonomy.
+Her şey veritabanınızda kalır. Harici çağrı yok. Tam özerklik.
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### Senkronize
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+Yerel veritabanı + birden fazla uygulama için birleşik gelen kutusu sağlayan `cloud.escalated.dev` ile otomatik senkronizasyon. Bulut erişilemezse uygulamanız çalışmaya devam eder — olaylar kuyruğa alınır ve yeniden denenir.
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### Bulut
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+Tüm talep verileri bulut API'sine yönlendirilir. Uygulamanız kimlik doğrulama ve UI oluşturma işlemlerini yapar, ancak depolama bulutta yaşar.
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+Her üç mod da aynı görünümleri, arayüzü ve iş mantığını paylaşır. Sürücü kalıbı gerisini halleder.
 
 ## Yapılandırma
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## Eklenti SDK
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated, [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) ile oluşturulan çerçeve bağımsız eklentileri destekler. Eklentiler TypeScript'te bir kez yazılır ve tüm Escalated backend'lerinde çalışır.
 
 ### Gereksinimler
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### Kaynaklar
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — Eklenti oluşturmak için TypeScript SDK
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Eklentiler için çalışma zamanı sunucusu
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Tam dokümantasyon
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## Diğer Platformlarda da Mevcut
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer paketi
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails motoru
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Yeniden kullanılabilir Django uygulaması (buradasınız)
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 paketi
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 yönetim paneli eklentisi
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI bileşenleri
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+Aynı mimari, aynı Vue arayüzü, aynı üç barındırma modu — tüm önemli backend çerçeveleri için.
 
 ## Geliştirme
 

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -22,11 +22,11 @@
 [![Django](https://img.shields.io/badge/django-4.2+-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A full-featured, embeddable support ticket system for Django. Drop it into any app — get a complete helpdesk with SLA tracking, escalation rules, agent workflows, and a customer portal. No external services required.
+一个功能完整、可嵌入的 Django 支持工单系统。将其添加到任何应用中 — 即可获得完整的帮助台，包含 SLA 跟踪、升级规则、客服工作流和客户门户。无需外部服务。
 
-> **[escalated.dev](https://escalated.dev)** — Learn more, view demos, and compare Cloud vs Self-Hosted options.
+> **[escalated.dev](https://escalated.dev)** — 了解更多、查看演示，并比较云端与自托管选项。
 
-**Three hosting modes.** Run entirely self-hosted, sync to a central cloud for multi-app visibility, or proxy everything to the cloud. Switch modes with a single config change.
+**三种托管模式。** 完全自托管运行，同步到中央云以获得多应用可见性，或将所有内容代理到云端。只需更改一个配置即可切换模式。
 
 ## 功能特性
 
@@ -41,21 +41,21 @@ A full-featured, embeddable support ticket system for Django. Drop it into any a
 - **邮件通知** — 可按事件配置的通知，支持 webhook
 - **部门路由** — 将客服组织到部门，支持自动分配（轮询）
 - **标签系统** — 使用彩色标签分类工单
-- **Inertia.js + Vue 3 UI** — Shared frontend via [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated)
+- **Inertia.js + Vue 3 UI** — 通过 [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) 共享前端
 - **工单拆分** — 将回复拆分为新的独立工单，同时保留原始上下文
-- **Ticket snooze** — Snooze tickets with presets (1h, 4h, tomorrow, next week); `python manage.py wake_snoozed_tickets` management command auto-wakes them on schedule
+- **Ticket snooze** — 使用预设延迟工单（1小时、4小时、明天、下周）；管理命令 `python manage.py wake_snoozed_tickets` 按计划自动唤醒
 - **保存的视图 / 自定义队列** — 将过滤器预设保存、命名并共享为可重用的工单视图
 - **可嵌入支持小部件** — 包含知识库搜索、工单表单和状态查询的轻量级 `<script>` 小部件
 - **邮件线程** — 发送的邮件包含正确的 `In-Reply-To` 和 `References` 头部，以在邮件客户端中实现正确的线程化
 - **品牌邮件模板** — 所有发送邮件的可配置 logo、主色和页脚文本
-- **Real-time broadcasting** — Opt-in broadcasting via Django Channels with automatic polling fallback
+- **Real-time broadcasting** — 通过 Django Channels 进行可选广播，带有自动轮询回退
 - **知识库开关** — 从管理设置中启用或禁用公共知识库
 
 ## 环境要求
 
 - Python 3.10+
 - Django 4.2+
-- Node.js 18+ (for frontend assets)
+- Node.js 18+ (用于前端资源)
 
 ## 快速开始
 
@@ -96,11 +96,11 @@ Visit `/support` — you're live.
 
 ## 前端设置
 
-Escalated uses Inertia.js with Vue 3. The frontend components are provided by the [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) npm package.
+Escalated 使用 Inertia.js 和 Vue 3。前端组件由 npm 包 [`@escalated-dev/escalated`](https://github.com/escalated-dev/escalated) 提供。
 
 ### Tailwind 内容
 
-Add the Escalated package to your Tailwind `content` config so its classes aren't purged:
+将 Escalated 包添加到 Tailwind 的 `content` 配置中，以确保其类不会被清除：
 
 ```js
 // tailwind.config.js
@@ -112,7 +112,7 @@ content: [
 
 ### 页面解析器
 
-Add the Escalated pages to your Inertia page resolver:
+将 Escalated 页面添加到您的 Inertia 页面解析器：
 
 ```javascript
 // frontend/main.js
@@ -143,7 +143,7 @@ createInertiaApp({
 
 ### 主题（可选）
 
-Register the `EscalatedPlugin` to render Escalated pages inside your app's layout — no page duplication needed:
+注册 `EscalatedPlugin` 以在您的应用布局内渲染 Escalated 页面 — 无需页面复制：
 
 ```javascript
 import { EscalatedPlugin } from '@escalated-dev/escalated'
@@ -167,13 +167,13 @@ createInertiaApp({
 
 Your layout component must accept a `#header` slot and a default slot. Escalated will render its sub-navigation in the header and page content in the default slot. Without the plugin, Escalated uses its own standalone layout.
 
-See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
+查看 [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) 以获取完整的主题文档和 CSS 自定义属性。
 
 ## 托管模式
 
 ### Self-Hosted（默认）
 
-Everything stays in your database. No external calls. Full autonomy.
+所有数据保留在您的数据库中。无外部调用。完全自主。
 
 ```python
 ESCALATED = {
@@ -183,7 +183,7 @@ ESCALATED = {
 
 ### 同步模式
 
-Local database + automatic sync to `cloud.escalated.dev` for unified inbox across multiple apps. If the cloud is unreachable, your app keeps working — events queue and retry.
+本地数据库 + 自动同步到 `cloud.escalated.dev` 以实现跨多个应用的统一收件箱。如果云端不可达，您的应用继续工作 — 事件会排队并重试。
 
 ```python
 ESCALATED = {
@@ -195,7 +195,7 @@ ESCALATED = {
 
 ### 云端
 
-All ticket data proxied to the cloud API. Your app handles auth and renders UI, but storage lives in the cloud.
+所有工单数据代理到云 API。您的应用处理认证和渲染 UI，但存储在云端。
 
 ```python
 ESCALATED = {
@@ -205,7 +205,7 @@ ESCALATED = {
 }
 ```
 
-All three modes share the same views, UI, and business logic. The driver pattern handles the rest.
+三种模式共享相同的视图、UI 和业务逻辑。驱动模式处理其余部分。
 
 ## 配置
 
@@ -309,7 +309,7 @@ Available signals: `ticket_created`, `ticket_updated`, `ticket_status_changed`, 
 
 ## 插件 SDK
 
-Escalated supports framework-agnostic plugins built with the [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins are written once in TypeScript and work across all Escalated backends.
+Escalated 支持使用 [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) 构建的框架无关插件。插件用 TypeScript 编写一次，即可在所有 Escalated 后端上运行。
 
 ### 环境要求
 
@@ -356,9 +356,9 @@ export default definePlugin({
 
 ### 资源
 
-- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK for building plugins
-- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host for plugins
-- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — Full documentation
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — 用于构建插件的 TypeScript SDK
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — 插件运行时宿主
+- [Plugin Development Guide](https://github.com/escalated-dev/escalated-docs) — 完整文档
 
 See the detailed [SDK Plugin Bridge](#sdk-plugin-bridge) section below for the full architecture, supported `ctx.*` callbacks, hook event mapping, and resilience documentation.
 
@@ -480,14 +480,14 @@ Every ticket signal fires a corresponding SDK hook:
 
 ## 其他框架版本
 
-- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer package
-- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
-- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django reusable app (you are here)
-- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 package
-- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 admin panel plugin
-- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI components
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer 包
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails 引擎
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django 可复用应用（当前页面）
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 包
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 管理面板插件
+- **[Shared Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI 组件
 
-Same architecture, same Vue UI, same three hosting modes — for every major backend framework.
+相同的架构、相同的 Vue UI、相同的三种托管模式 — 适用于每个主流后端框架。
 
 ## 开发
 


### PR DESCRIPTION
## Summary
- Translate remaining English prose in all translated README files
- Covers: description paragraphs, feature bullet descriptions, hosting mode explanations, plugin SDK sections, frontend integration instructions, and link descriptions
- All 13 language files updated where needed

## Test plan
- [ ] Verify translated files render correctly on GitHub
- [ ] Spot-check translations for accuracy in 2-3 languages