### PR TITLE
fix: include url in attachment serialization

### DIFF
--- a/escalated/api_serializers.py
+++ b/escalated/api_serializers.py
@@ -86,6 +86,7 @@ class ApiTicketDetailSerializer:
                 "resolution_due_at": _format_dt(ticket.resolution_due_at),
                 "resolution_breached": ticket.sla_resolution_breached,
             },
+            "attachments": [ApiAttachmentSerializer.serialize(a) for a in ticket.attachments.all()],
             "resolved_at": _format_dt(ticket.resolved_at),
             "closed_at": _format_dt(ticket.closed_at),
             "created_at": _format_dt(ticket.created_at),

--- a/escalated/serializers.py
+++ b/escalated/serializers.py
@@ -53,9 +53,7 @@ class TicketSerializer:
         }
 
         # Ticket-level attachments
-        data["attachments"] = [
-            AttachmentSerializer.serialize(a) for a in ticket.attachments.all()
-        ]
+        data["attachments"] = [AttachmentSerializer.serialize(a) for a in ticket.attachments.all()]
 
         # Guest ticket fields
         data["is_guest"] = ticket.is_guest

--- a/escalated/serializers.py
+++ b/escalated/serializers.py
@@ -52,6 +52,11 @@ class TicketSerializer:
             "updated_at": _format_dt(ticket.updated_at),
         }
 
+        # Ticket-level attachments
+        data["attachments"] = [
+            AttachmentSerializer.serialize(a) for a in ticket.attachments.all()
+        ]
+
         # Guest ticket fields
         data["is_guest"] = ticket.is_guest
         data["guest_name"] = ticket.guest_name

--- a/escalated/views/api.py
+++ b/escalated/views/api.py
@@ -83,6 +83,7 @@ def _resolve_ticket(reference):
                 "replies__author",
                 "replies__attachments",
                 "activities",
+                "attachments",
             )
             .get(reference=reference)
         )
@@ -100,6 +101,7 @@ def _resolve_ticket(reference):
                 "replies__author",
                 "replies__attachments",
                 "activities",
+                "attachments",
             )
             .get(pk=ticket_id)
         )


### PR DESCRIPTION
## Summary
- Fixes escalated-dev/escalated#26 — attachment `url` was missing from ticket detail responses
- Added `attachments` field (via `AttachmentSerializer`/`ApiAttachmentSerializer`) to both `TicketSerializer` and `ApiTicketDetailSerializer`
- Added `prefetch_related("attachments")` to API ticket queries to prevent N+1

## Test plan
- [ ] Verify ticket attachments render with working download links in Inertia views
- [ ] Verify API ticket detail includes attachments with `url`