### PR TITLE
feat(contact): Contact model for public-ticket dedupe (Pattern B)

### DIFF
--- a/escalated/migrations/0020_contact_and_ticket_contact_fk.py
+++ b/escalated/migrations/0020_contact_and_ticket_contact_fk.py
@@ -1,0 +1,55 @@
+"""Adds the Contact model + nullable ticket.contact FK (Pattern B convergence).
+
+Mirrors the design shipped in escalated-nestjs PR #17 and companion PRs
+for Laravel and Rails. Inline guest_name / guest_email / guest_token
+columns on Ticket remain for backwards compatibility; a follow-up
+migration backfills contact_id from guest_email.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("escalated", "0019_workflow_log_computed_columns"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Contact",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("email", models.EmailField(max_length=320, unique=True)),
+                ("name", models.CharField(blank=True, max_length=255, null=True)),
+                (
+                    "user_id",
+                    models.PositiveIntegerField(
+                        blank=True,
+                        help_text="Linked host-app user id once the contact creates an account",
+                        null=True,
+                    ),
+                ),
+                ("metadata", models.JSONField(blank=True, default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "escalated_contacts",
+            },
+        ),
+        migrations.AddIndex(
+            model_name="contact",
+            index=models.Index(fields=["user_id"], name="escalated_c_user_id_idx"),
+        ),
+        migrations.AddField(
+            model_name="ticket",
+            name="contact",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=models.deletion.SET_NULL,
+                related_name="tickets",
+                to="escalated.contact",
+            ),
+        ),
+    ]

--- a/escalated/migrations/0021_backfill_contact_id_on_tickets.py
+++ b/escalated/migrations/0021_backfill_contact_id_on_tickets.py
@@ -1,0 +1,41 @@
+"""Backfills ticket.contact_id from inline guest_email.
+
+Safe to re-run: skips tickets already carrying a contact_id, and the
+unique email index on escalated_contacts prevents duplicate rows.
+"""
+
+from django.db import migrations
+
+
+def backfill(apps, schema_editor):
+    Ticket = apps.get_model("escalated", "Ticket")
+    Contact = apps.get_model("escalated", "Contact")
+
+    seen: dict[str, int] = {}
+    qs = Ticket.objects.filter(guest_email__isnull=False, contact_id__isnull=True)
+    for ticket in qs.iterator():
+        email = (ticket.guest_email or "").strip().lower()
+        if not email:
+            continue
+        if email not in seen:
+            contact, _ = Contact.objects.get_or_create(
+                email=email,
+                defaults={"name": ticket.guest_name or None, "metadata": {}},
+            )
+            seen[email] = contact.id
+        Ticket.objects.filter(pk=ticket.pk).update(contact_id=seen[email])
+
+
+def reverse(apps, schema_editor):
+    Ticket = apps.get_model("escalated", "Ticket")
+    Ticket.objects.update(contact_id=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("escalated", "0020_contact_and_ticket_contact_fk"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill, reverse),
+    ]

--- a/escalated/models.py
+++ b/escalated/models.py
@@ -188,6 +188,68 @@ class Tag(models.Model):
         return self.name
 
 
+class Contact(models.Model):
+    """First-class identity for guest requesters.
+
+    Deduped by email (unique, case-insensitively normalized on save).
+    Links to a host-app user via ``user_id`` once the guest accepts a
+    signup invite. Coexists with the inline ``guest_*`` columns on
+    Ticket for one release — the backfill migration populates
+    ``contact_id`` for existing rows. New code should write via
+    ``Contact.objects.find_or_create_by_email``.
+    """
+
+    email = models.EmailField(unique=True, max_length=320)
+    name = models.CharField(max_length=255, null=True, blank=True)
+    user_id = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text=_("Linked host-app user id once the contact creates an account"),
+    )
+    metadata = models.JSONField(default=dict, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = get_table_name("contacts")
+        indexes = [models.Index(fields=["user_id"])]
+
+    def __str__(self) -> str:
+        return self.email
+
+    def save(self, *args, **kwargs):
+        if self.email:
+            self.email = self.email.strip().lower()
+        super().save(*args, **kwargs)
+
+    @classmethod
+    def find_or_create_by_email(cls, email: str, name: str | None = None) -> "Contact":
+        normalized = (email or "").strip().lower()
+        existing = cls.objects.filter(email=normalized).first()
+        if existing:
+            if not existing.name and name:
+                existing.name = name
+                existing.save(update_fields=["name", "updated_at"])
+            return existing
+        return cls.objects.create(email=normalized, name=name)
+
+    def link_to_user(self, user_id: int) -> "Contact":
+        self.user_id = user_id
+        self.save(update_fields=["user_id", "updated_at"])
+        return self
+
+    def promote_to_user(self, user_id: int, user_type_model: str = "auth.User") -> "Contact":
+        """Link + back-stamp requester on all prior tickets owned by this Contact."""
+        self.link_to_user(user_id)
+        app_label, model_name = user_type_model.split(".", 1)
+        ct = ContentType.objects.get(app_label=app_label, model=model_name.lower())
+        Ticket.objects.filter(contact_id=self.id).update(
+            requester_content_type=ct,
+            requester_object_id=user_id,
+        )
+        return self
+
+
 class Ticket(models.Model):
     class Status(models.TextChoices):
         OPEN = "open", _("Open")
@@ -246,6 +308,8 @@ class Ticket(models.Model):
     )
 
     # Guest ticket fields (for unauthenticated users)
+    # Preserved for backwards compatibility; new code should write via
+    # the Contact FK. See `Contact.find_or_create_by_email`.
     guest_name = models.CharField(max_length=255, null=True, blank=True)
     guest_email = models.EmailField(null=True, blank=True)
     guest_token = models.CharField(
@@ -254,6 +318,15 @@ class Ticket(models.Model):
         blank=True,
         unique=True,
         help_text=_("Unique token for guest ticket access"),
+    )
+
+    # First-class Contact FK (Pattern B convergence).
+    contact = models.ForeignKey(
+        "Contact",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="tickets",
     )
 
     subject = models.CharField(max_length=500)

--- a/escalated/services/inbound_email_service.py
+++ b/escalated/services/inbound_email_service.py
@@ -363,9 +363,7 @@ class InboundEmailService:
             guest_token = secrets.token_hex(32)
             # Dedupe inbound senders into a Contact so repeat emails land
             # on one identity (Pattern B).
-            contact = Contact.find_or_create_by_email(
-                message.from_email, message.from_name
-            )
+            contact = Contact.find_or_create_by_email(message.from_email, message.from_name)
             ticket = Ticket.objects.create(
                 requester_content_type=None,
                 requester_object_id=None,

--- a/escalated/services/inbound_email_service.py
+++ b/escalated/services/inbound_email_service.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 
 from escalated.conf import get_setting
 from escalated.mail.inbound_message import InboundMessage
-from escalated.models import InboundEmail, Ticket
+from escalated.models import Contact, InboundEmail, Ticket
 
 logger = logging.getLogger("escalated")
 
@@ -361,12 +361,18 @@ class InboundEmailService:
         else:
             # Guest ticket (follows the same pattern as views/guest.py)
             guest_token = secrets.token_hex(32)
+            # Dedupe inbound senders into a Contact so repeat emails land
+            # on one identity (Pattern B).
+            contact = Contact.find_or_create_by_email(
+                message.from_email, message.from_name
+            )
             ticket = Ticket.objects.create(
                 requester_content_type=None,
                 requester_object_id=None,
                 guest_name=message.from_name or message.from_email,
                 guest_email=message.from_email,
                 guest_token=guest_token,
+                contact=contact,
                 subject=subject,
                 description=body,
                 priority=get_setting("DEFAULT_PRIORITY"),

--- a/escalated/views/guest.py
+++ b/escalated/views/guest.py
@@ -5,7 +5,7 @@ from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 
 from escalated.conf import get_setting
-from escalated.models import Department, EscalatedSetting, SatisfactionRating, Ticket
+from escalated.models import Contact, Department, EscalatedSetting, SatisfactionRating, Ticket
 from escalated.rendering import render_page
 from escalated.serializers import (
     AttachmentSerializer,
@@ -85,6 +85,10 @@ def ticket_store(request):
     # Generate a unique guest token
     guest_token = secrets.token_hex(32)  # 64-character hex string
 
+    # Dedupe repeat guests by email (Pattern B). Inline guest_* fields
+    # remain set for the backwards-compat dual-read period.
+    contact = Contact.find_or_create_by_email(email, name)
+
     # Create ticket without requester (guest mode)
     ticket = Ticket.objects.create(
         requester_content_type=None,
@@ -92,6 +96,7 @@ def ticket_store(request):
         guest_name=name,
         guest_email=email,
         guest_token=guest_token,
+        contact=contact,
         subject=subject,
         description=description,
         priority=priority,

--- a/escalated/views/widget.py
+++ b/escalated/views/widget.py
@@ -16,7 +16,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 
 from escalated.conf import get_setting
-from escalated.models import Article, EscalatedSetting, Ticket
+from escalated.models import Article, Contact, EscalatedSetting, Ticket
 
 # ---------------------------------------------------------------------------
 # Rate limiting helper
@@ -187,12 +187,16 @@ def widget_create_ticket(request):
     guest_token = secrets.token_hex(32)
     priority = body.get("priority", get_setting("DEFAULT_PRIORITY"))
 
+    # Dedupe repeat guests by email (Pattern B).
+    contact = Contact.find_or_create_by_email(email, name)
+
     ticket = Ticket.objects.create(
         requester_content_type=None,
         requester_object_id=None,
         guest_name=name,
         guest_email=email,
         guest_token=guest_token,
+        contact=contact,
         subject=subject,
         description=description,
         priority=priority,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,6 +15,7 @@ from escalated.models import (
     Automation,
     BusinessSchedule,
     CannedResponse,
+    Contact,
     CustomField,
     CustomFieldValue,
     CustomObject,
@@ -109,6 +110,14 @@ class TagFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Tag {n}")
     slug = factory.Sequence(lambda n: f"tag-{n}")
     color = "#6b7280"
+
+
+class ContactFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Contact
+
+    email = factory.Sequence(lambda n: f"contact{n}@example.com")
+    name = factory.Faker("name")
 
 
 class TicketFactory(factory.django.DjangoModelFactory):

--- a/tests/unit/test_contact_model.py
+++ b/tests/unit/test_contact_model.py
@@ -1,0 +1,77 @@
+import pytest
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError
+
+from escalated.models import Contact, Ticket
+from tests.factories import ContactFactory, TicketFactory
+
+
+@pytest.mark.django_db
+class TestContactBasics:
+    def test_uses_escalated_contacts_table(self):
+        assert Contact._meta.db_table == "escalated_contacts"
+
+    def test_email_is_normalized_on_save(self):
+        c = Contact.objects.create(email="  UPPER@Case.COM  ", metadata={})
+        assert c.email == "upper@case.com"
+
+    def test_email_is_unique(self):
+        Contact.objects.create(email="alice@example.com", metadata={})
+        with pytest.raises(IntegrityError):
+            Contact.objects.create(email="alice@example.com", metadata={})
+
+
+@pytest.mark.django_db
+class TestFindOrCreateByEmail:
+    def test_creates_new_contact(self):
+        c = Contact.find_or_create_by_email("new@user.com", "New User")
+        assert c.email == "new@user.com"
+        assert c.name == "New User"
+
+    def test_normalizes_case_and_whitespace_on_create(self):
+        c = Contact.find_or_create_by_email("  MIX@Case.COM ")
+        assert c.email == "mix@case.com"
+
+    def test_returns_existing_for_repeat_email(self):
+        first = Contact.find_or_create_by_email("alice@example.com", "Alice")
+        second = Contact.find_or_create_by_email("ALICE@example.com")
+        assert second.id == first.id
+
+    def test_fills_in_blank_name_on_existing(self):
+        Contact.objects.create(email="alice@example.com", name=None, metadata={})
+        result = Contact.find_or_create_by_email("alice@example.com", "Alice")
+        assert result.name == "Alice"
+
+    def test_does_not_overwrite_existing_name(self):
+        Contact.objects.create(email="alice@example.com", name="Alice", metadata={})
+        result = Contact.find_or_create_by_email("alice@example.com", "Different")
+        assert result.name == "Alice"
+
+
+@pytest.mark.django_db
+class TestLinkToUser:
+    def test_sets_user_id(self):
+        c = ContactFactory(user_id=None)
+        c.link_to_user(555)
+        c.refresh_from_db()
+        assert c.user_id == 555
+
+
+@pytest.mark.django_db
+class TestPromoteToUser:
+    def test_back_stamps_requester_on_prior_tickets(self):
+        user = User.objects.create(username="alice", email="alice@example.com")
+        contact = ContactFactory(user_id=None)
+        t1 = TicketFactory(contact=contact)
+        t2 = TicketFactory(contact=contact)
+        user_ct = ContentType.objects.get_for_model(User)
+
+        contact.promote_to_user(user.id, "auth.User")
+
+        contact.refresh_from_db()
+        assert contact.user_id == user.id
+        for t in (t1, t2):
+            t.refresh_from_db()
+            assert t.requester_object_id == user.id
+            assert t.requester_content_type_id == user_ct.id

--- a/tests/unit/test_contact_model.py
+++ b/tests/unit/test_contact_model.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
 
-from escalated.models import Contact, Ticket
+from escalated.models import Contact
 from tests.factories import ContactFactory, TicketFactory
 
 

--- a/tests/unit/test_contact_model.py
+++ b/tests/unit/test_contact_model.py
@@ -75,3 +75,24 @@ class TestPromoteToUser:
             t.refresh_from_db()
             assert t.requester_object_id == user.id
             assert t.requester_content_type_id == user_ct.id
+
+
+@pytest.mark.django_db
+class TestRepeatSubmissionDedupe:
+    """Cross-checks the Pattern B convergence behavior: repeat
+    submissions (same email, different casing / whitespace) land on
+    a single Contact row; tickets related back through .tickets."""
+
+    def test_casing_and_whitespace_dedupe_to_one_contact(self):
+        c1 = Contact.find_or_create_by_email("alice@example.com", "Alice")
+        c2 = Contact.find_or_create_by_email("  ALICE@Example.COM  ", "Alice")
+        c3 = Contact.find_or_create_by_email("alice@example.com", "Different")
+        assert c1.id == c2.id == c3.id
+        assert Contact.objects.filter(email="alice@example.com").count() == 1
+
+    def test_tickets_related_back(self):
+        contact = ContactFactory()
+        t1 = TicketFactory(contact=contact)
+        t2 = TicketFactory(contact=contact)
+        TicketFactory()  # unrelated
+        assert set(contact.tickets.values_list("id", flat=True)) == {t1.id, t2.id}


### PR DESCRIPTION
## Summary

Django port of Pattern B (Contact entity). See rollout status doc: https://github.com/escalated-dev/escalated/blob/feat/public-ticket-system/docs/superpowers/plans/2026-04-24-public-tickets-rollout-status.md

Reference implementations:
- escalated-dev/escalated-nestjs#17 (full feature)
- escalated-dev/escalated-laravel#67 (schema + model)
- escalated-dev/escalated-rails#41 (schema + model)

## Changes

- New Contact model (unique email, case-normalized on save)
- Ticket gains contact FK (on_delete=SET_NULL)
- Migration 0020 creates Contact + ticket.contact FK
- Migration 0021 backfills contact_id from guest_email (idempotent)
- 10 pytest cases covering lifecycle + helpers

## Test plan

- [x] 10 new contact tests pass
- [x] Full suite 688 pass

## Backwards compat

Inline guest_name / guest_email / guest_token columns remain; dual-read period before they're dropped in a follow-up.