### PR TITLE
feat(workflow): subscribe WorkflowEngine to Django signal stream

### DIFF
--- a/escalated/apps.py
+++ b/escalated/apps.py
@@ -13,6 +13,7 @@ class EscalatedConfig(AppConfig):
 
     def ready(self):
         import escalated.handlers  # noqa: F401 - connects signal handlers
+        import escalated.workflow_handlers  # noqa: F401 - connects WorkflowEngine to signals
 
         # Load active plugins on startup
         self._load_plugins()

--- a/escalated/workflow_handlers.py
+++ b/escalated/workflow_handlers.py
@@ -1,0 +1,114 @@
+"""
+Wire the WorkflowEngine to the Django signal stream.
+
+The engine was previously defined but orphaned — nothing invoked
+process_event. Workflows configured in the admin UI didn't fire on
+ticket events. This module adds @receiver handlers that bridge
+each relevant signal to WorkflowEngine.process_event.
+
+Mirrors the pattern used in:
+  - escalated-nestjs WorkflowListener
+  - escalated-laravel ProcessWorkflows
+  - escalated-rails Services::WorkflowSubscriber
+
+Engine errors are caught and warn-logged so a misconfigured
+workflow never blocks the signal chain that may have listeners
+downstream.
+"""
+import logging
+
+from django.dispatch import receiver
+
+from escalated.signals import (
+    reply_created,
+    sla_breached,
+    sla_warning,
+    ticket_assigned,
+    ticket_created,
+    ticket_escalated,
+    ticket_priority_changed,
+    ticket_status_changed,
+    ticket_updated,
+)
+from escalated.support.import_context import ImportContext
+
+logger = logging.getLogger("escalated")
+
+
+def _process(trigger, ticket, **context):
+    """Invoke the WorkflowEngine for one trigger + ticket; swallow errors."""
+    if ImportContext.is_importing():
+        return
+    if ticket is None:
+        return
+    try:
+        from escalated.services.workflow_engine import WorkflowEngine
+
+        WorkflowEngine().process_event(trigger, ticket, context or None)
+    except Exception as exc:  # pragma: no cover — defensive log-only path
+        logger.warning(
+            "WorkflowEngine.%s failed for ticket %s: %s",
+            trigger,
+            getattr(ticket, "pk", "?"),
+            exc,
+        )
+
+
+@receiver(ticket_created)
+def _workflow_ticket_created(sender, ticket, user=None, **kwargs):
+    _process("ticket.created", ticket, user=user)
+
+
+@receiver(ticket_updated)
+def _workflow_ticket_updated(sender, ticket, user=None, changes=None, **kwargs):
+    _process("ticket.updated", ticket, user=user, changes=changes)
+
+
+@receiver(ticket_status_changed)
+def _workflow_status_changed(sender, ticket, old_status=None, new_status=None, **kwargs):
+    _process(
+        "ticket.status_changed",
+        ticket,
+        old_status=old_status,
+        new_status=new_status,
+    )
+
+
+@receiver(ticket_assigned)
+def _workflow_ticket_assigned(sender, ticket, agent=None, **kwargs):
+    _process("ticket.assigned", ticket, agent=agent)
+
+
+@receiver(ticket_priority_changed)
+def _workflow_priority_changed(sender, ticket, old_priority=None, new_priority=None, **kwargs):
+    _process(
+        "ticket.priority_changed",
+        ticket,
+        old_priority=old_priority,
+        new_priority=new_priority,
+    )
+
+
+@receiver(ticket_escalated)
+def _workflow_ticket_escalated(sender, ticket, reason=None, **kwargs):
+    _process("ticket.escalated", ticket, reason=reason)
+
+
+@receiver(reply_created)
+def _workflow_reply_created(sender, reply=None, ticket=None, **kwargs):
+    _process("ticket.replied", ticket, reply=reply)
+
+
+@receiver(sla_breached)
+def _workflow_sla_breached(sender, ticket, breach_type=None, **kwargs):
+    _process("sla.breached", ticket, breach_type=breach_type)
+
+
+@receiver(sla_warning)
+def _workflow_sla_warning(sender, ticket, warning_type=None, remaining=None, **kwargs):
+    _process(
+        "sla.warning",
+        ticket,
+        warning_type=warning_type,
+        remaining=remaining,
+    )

--- a/escalated/workflow_handlers.py
+++ b/escalated/workflow_handlers.py
@@ -15,6 +15,7 @@ Engine errors are caught and warn-logged so a misconfigured
 workflow never blocks the signal chain that may have listeners
 downstream.
 """
+
 import logging
 
 from django.dispatch import receiver

--- a/tests/unit/test_workflow_subscriber.py
+++ b/tests/unit/test_workflow_subscriber.py
@@ -2,6 +2,7 @@
 Tests for the WorkflowEngine signal wire-up in
 escalated/workflow_handlers.py.
 """
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/unit/test_workflow_subscriber.py
+++ b/tests/unit/test_workflow_subscriber.py
@@ -1,0 +1,88 @@
+"""
+Tests for the WorkflowEngine signal wire-up in
+escalated/workflow_handlers.py.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from escalated import signals as esc_signals
+from escalated.models import Ticket
+
+
+@pytest.mark.django_db
+class TestWorkflowSubscriber:
+    @pytest.fixture
+    def ticket(self, request):
+        from tests.factories import TicketFactory
+
+        return TicketFactory()
+
+    @patch("escalated.services.workflow_engine.WorkflowEngine")
+    def test_ticket_created_signal_fires_workflow_engine(self, engine_cls, ticket):
+        engine = MagicMock()
+        engine_cls.return_value = engine
+
+        esc_signals.ticket_created.send(sender=Ticket, ticket=ticket, user=None)
+
+        engine.process_event.assert_called_once()
+        assert engine.process_event.call_args[0][0] == "ticket.created"
+        assert engine.process_event.call_args[0][1] is ticket
+
+    @patch("escalated.services.workflow_engine.WorkflowEngine")
+    def test_status_changed_maps_to_ticket_status_changed(self, engine_cls, ticket):
+        engine = MagicMock()
+        engine_cls.return_value = engine
+
+        esc_signals.ticket_status_changed.send(
+            sender=Ticket,
+            ticket=ticket,
+            user=None,
+            old_status="open",
+            new_status="resolved",
+        )
+
+        # Find our mapping among all subscribers that fired
+        calls = [c for c in engine.process_event.call_args_list]
+        assert any(c.args[0] == "ticket.status_changed" for c in calls)
+
+    @patch("escalated.services.workflow_engine.WorkflowEngine")
+    def test_reply_created_maps_to_ticket_replied(self, engine_cls, ticket):
+        """Call our handler directly so we don't trigger other subscribers
+        that would try to JSON-serialize a MagicMock reply."""
+        engine = MagicMock()
+        engine_cls.return_value = engine
+        reply = MagicMock()
+
+        from escalated.workflow_handlers import _workflow_reply_created
+
+        _workflow_reply_created(sender=type(reply), reply=reply, ticket=ticket)
+
+        engine.process_event.assert_called_once()
+        assert engine.process_event.call_args[0][0] == "ticket.replied"
+
+    @patch("escalated.services.workflow_engine.WorkflowEngine")
+    def test_missing_ticket_is_noop(self, engine_cls, ticket):
+        """When ticket is None our workflow handler should skip the engine.
+
+        (Other unrelated handlers for the same signal may still fire but
+        they don't touch our mocked WorkflowEngine.)
+        """
+        engine = MagicMock()
+        engine_cls.return_value = engine
+
+        # Call our handler directly to isolate from other subscribers
+        from escalated.workflow_handlers import _workflow_reply_created
+
+        _workflow_reply_created(sender=object, reply=None, ticket=None)
+
+        engine.process_event.assert_not_called()
+
+    @patch("escalated.services.workflow_engine.WorkflowEngine")
+    def test_engine_error_is_swallowed(self, engine_cls, ticket):
+        engine = MagicMock()
+        engine.process_event.side_effect = RuntimeError("boom")
+        engine_cls.return_value = engine
+
+        # Should not raise; the signal chain continues.
+        esc_signals.ticket_created.send(sender=Ticket, ticket=ticket, user=None)


### PR DESCRIPTION
## Summary

Django parity with escalated-nestjs#17, escalated-laravel ProcessWorkflows, and escalated-rails#42: the WorkflowEngine was defined but orphaned — nothing invoked \`process_event\`. Workflows configured in the admin UI didn't fire on ticket events.

This PR adds \`escalated/workflow_handlers.py\` — nine @receiver handlers bridging Django signals to WorkflowEngine.process_event. Module is imported from AppConfig.ready() so receivers are installed at startup.

## Signal mapping

| Signal | Workflow trigger |
|---|---|
| \`ticket_created\` | \`ticket.created\` |
| \`ticket_updated\` | \`ticket.updated\` |
| \`ticket_status_changed\` | \`ticket.status_changed\` |
| \`ticket_assigned\` | \`ticket.assigned\` |
| \`ticket_priority_changed\` | \`ticket.priority_changed\` |
| \`ticket_escalated\` | \`ticket.escalated\` |
| \`reply_created\` | \`ticket.replied\` |
| \`sla_breached\` | \`sla.breached\` |
| \`sla_warning\` | \`sla.warning\` |

## Safety

- Skips during ImportContext.is_importing()
- Catches all exceptions and warn-logs
- No-op when ticket is None

## Tests

5 pytest cases (dispatch, mappings, no-op, error swallowing) — all green. Full suite: 683 pass.

## Companion context

Rollout doc: https://github.com/escalated-dev/escalated/blob/feat/public-ticket-system/docs/superpowers/plans/2026-04-24-public-tickets-rollout-status.md