### PR TITLE
feat(mail): add message_id_util for RFC 5322 threading + signed Reply-To

### DIFF
--- a/escalated/mail/message_id_util.py
+++ b/escalated/mail/message_id_util.py
@@ -1,0 +1,100 @@
+"""
+Pure helpers for RFC 5322 Message-ID threading and signed Reply-To
+addresses. Mirrors the NestJS reference
+``escalated-nestjs/src/services/email/message-id.ts`` and the Spring /
+WordPress / .NET / Phoenix / Laravel / Rails ports.
+
+Coexists with the existing :mod:`escalated.mail.threading` module during
+the migration window — new outbound paths should prefer these helpers so
+inbound Reply-To verification has something to check against.
+
+Message-ID format::
+
+    <ticket-{ticket_id}@{domain}>             initial ticket email
+    <ticket-{ticket_id}-reply-{reply_id}@{domain}>  agent reply
+
+Signed Reply-To format::
+
+    reply+{ticket_id}.{hmac8}@{domain}
+
+The signed Reply-To carries ticket identity even when clients strip the
+Message-ID / In-Reply-To headers — the inbound provider webhook
+verifies the 8-char HMAC-SHA256 prefix before routing a reply to its
+ticket.
+"""
+
+from __future__ import annotations
+
+import hmac
+import re
+from hashlib import sha256
+
+_TICKET_ID_PATTERN = re.compile(r"ticket-(\d+)(?:-reply-\d+)?@", re.IGNORECASE)
+_REPLY_LOCAL_PATTERN = re.compile(r"^reply\+(\d+)\.([a-f0-9]{8})$", re.IGNORECASE)
+
+
+def build_message_id(ticket_id: int, reply_id: int | None, domain: str) -> str:
+    """Build an RFC 5322 Message-ID.
+
+    Pass ``None`` for ``reply_id`` on the initial ticket email; the
+    ``-reply-{id}`` tail is appended only when ``reply_id`` is non-None.
+    """
+    if reply_id is None:
+        body = f"ticket-{ticket_id}"
+    else:
+        body = f"ticket-{ticket_id}-reply-{reply_id}"
+    return f"<{body}@{domain}>"
+
+
+def parse_ticket_id_from_message_id(raw: str | None) -> int | None:
+    """Extract the ticket id from a Message-ID we issued.
+
+    Accepts the header value with or without angle brackets. Returns
+    ``None`` when the input doesn't match our shape.
+    """
+    if not raw:
+        return None
+    match = _TICKET_ID_PATTERN.search(raw)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def build_reply_to(ticket_id: int, secret: str, domain: str) -> str:
+    """Build a signed Reply-To address ``reply+{id}.{hmac8}@{domain}``."""
+    return f"reply+{ticket_id}.{_sign(ticket_id, secret)}@{domain}"
+
+
+def verify_reply_to(address: str | None, secret: str) -> int | None:
+    """Verify a reply-to address (full or just the local part).
+
+    Returns the ticket id on match, ``None`` otherwise. Uses
+    :func:`hmac.compare_digest` for timing-safe verification.
+    """
+    if not address:
+        return None
+    local = address.split("@", 1)[0] if "@" in address else address
+    match = _REPLY_LOCAL_PATTERN.match(local)
+    if not match:
+        return None
+    try:
+        ticket_id = int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    expected = _sign(ticket_id, secret)
+    if hmac.compare_digest(expected.lower(), match.group(2).lower()):
+        return ticket_id
+    return None
+
+
+def _sign(ticket_id: int, secret: str) -> str:
+    """8-character HMAC-SHA256 prefix over the ticket id."""
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        str(ticket_id).encode("utf-8"),
+        sha256,
+    ).hexdigest()
+    return digest[:8]

--- a/tests/unit/test_message_id_util.py
+++ b/tests/unit/test_message_id_util.py
@@ -1,0 +1,98 @@
+"""
+Pure-function tests for escalated.mail.message_id_util. Mirrors the
+NestJS / Spring / WordPress / .NET / Phoenix / Laravel / Rails
+reference test suites.
+"""
+
+from escalated.mail.message_id_util import (
+    build_message_id,
+    build_reply_to,
+    parse_ticket_id_from_message_id,
+    verify_reply_to,
+)
+
+DOMAIN = "support.example.com"
+SECRET = "test-secret-long-enough-for-hmac"
+
+
+def test_build_message_id_initial_ticket():
+    assert build_message_id(42, None, DOMAIN) == "<ticket-42@support.example.com>"
+
+
+def test_build_message_id_reply_form():
+    assert build_message_id(42, 7, DOMAIN) == "<ticket-42-reply-7@support.example.com>"
+
+
+def test_parse_ticket_id_round_trips_initial():
+    assert parse_ticket_id_from_message_id(build_message_id(42, None, DOMAIN)) == 42
+
+
+def test_parse_ticket_id_round_trips_reply():
+    assert parse_ticket_id_from_message_id(build_message_id(42, 7, DOMAIN)) == 42
+
+
+def test_parse_ticket_id_accepts_value_without_brackets():
+    assert parse_ticket_id_from_message_id("ticket-99@example.com") == 99
+
+
+def test_parse_ticket_id_returns_none_for_nil_or_empty():
+    assert parse_ticket_id_from_message_id(None) is None
+    assert parse_ticket_id_from_message_id("") is None
+
+
+def test_parse_ticket_id_returns_none_for_unrelated_input():
+    assert parse_ticket_id_from_message_id("<random@mail.com>") is None
+    assert parse_ticket_id_from_message_id("ticket-abc@example.com") is None
+
+
+def test_build_reply_to_is_stable():
+    first = build_reply_to(42, SECRET, DOMAIN)
+    again = build_reply_to(42, SECRET, DOMAIN)
+    assert first == again
+    import re
+
+    assert re.match(r"^reply\+42\.[a-f0-9]{8}@support\.example\.com$", first)
+
+
+def test_build_reply_to_differs_across_tickets():
+    a = build_reply_to(42, SECRET, DOMAIN)
+    b = build_reply_to(43, SECRET, DOMAIN)
+    assert a.split("@")[0] != b.split("@")[0]
+
+
+def test_verify_reply_to_round_trips():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    assert verify_reply_to(address, SECRET) == 42
+
+
+def test_verify_reply_to_accepts_local_part_only():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    local = address.split("@")[0]
+    assert verify_reply_to(local, SECRET) == 42
+
+
+def test_verify_reply_to_rejects_tampered_signature():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    at = address.index("@")
+    local = address[:at]
+    last = local[-1]
+    tampered = local[:-1] + ("1" if last == "0" else "0") + address[at:]
+    assert verify_reply_to(tampered, SECRET) is None
+
+
+def test_verify_reply_to_rejects_wrong_secret():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    assert verify_reply_to(address, "different-secret") is None
+
+
+def test_verify_reply_to_rejects_malformed_input():
+    assert verify_reply_to(None, SECRET) is None
+    assert verify_reply_to("", SECRET) is None
+    assert verify_reply_to("alice@example.com", SECRET) is None
+    assert verify_reply_to("reply@example.com", SECRET) is None
+    assert verify_reply_to("reply+abc.deadbeef@example.com", SECRET) is None
+
+
+def test_verify_reply_to_case_insensitive_hex():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    assert verify_reply_to(address.upper(), SECRET) == 42


### PR DESCRIPTION
## Summary

Ports the NestJS `email/message-id.ts` helpers to Django. Mirrors the Spring / WordPress / .NET / Phoenix / Laravel / Rails ports (6 of 11 framework ports shipped so far).

## API

- `build_message_id(ticket_id, reply_id, domain)`
- `parse_ticket_id_from_message_id(raw)`
- `build_reply_to(ticket_id, secret, domain)`
- `verify_reply_to(address, secret)`

Uses Python stdlib `hmac` + `hashlib` + `hmac.compare_digest` for timing-safe verification.

## Scope

**Utility only.** Coexists with the existing `escalated.mail.threading` module (which uses a different Message-ID format: `<ticket-{pk}-{reference}@{domain}>`) during the migration window. Follow-up PR will migrate `threading.py` to use this util so inbound routing has a single canonical format.

## Test plan

- [x] 15 pytest tests covering round-trip, tamper rejection, case-insensitive hex, malformed input, local-part-only
- [ ] CI green: lint + tests across Py3.10/3.11/3.12 × Django 4.2/5.0/5.1