### PR TITLE
feat(inbound): MessageIdUtil-based Message-ID parsing + signed Reply-To verification

### DIFF
--- a/escalated/conf.py
+++ b/escalated/conf.py
@@ -28,6 +28,9 @@ DEFAULTS = {
     },
     "NOTIFICATION_CHANNELS": ["email"],
     "WEBHOOK_URL": None,
+    # Email threading — domain for Message-IDs, secret for signed Reply-To
+    "EMAIL_DOMAIN": None,  # falls back to DEFAULT_FROM_EMAIL host
+    "EMAIL_INBOUND_SECRET": "",  # empty → Reply-To skipped
     # Inbound email settings
     "INBOUND_EMAIL_ENABLED": False,
     "INBOUND_EMAIL_ADAPTER": "mailgun",

--- a/escalated/mail/message_id_util.py
+++ b/escalated/mail/message_id_util.py
@@ -1,0 +1,100 @@
+"""
+Pure helpers for RFC 5322 Message-ID threading and signed Reply-To
+addresses. Mirrors the NestJS reference
+``escalated-nestjs/src/services/email/message-id.ts`` and the Spring /
+WordPress / .NET / Phoenix / Laravel / Rails ports.
+
+Coexists with the existing :mod:`escalated.mail.threading` module during
+the migration window — new outbound paths should prefer these helpers so
+inbound Reply-To verification has something to check against.
+
+Message-ID format::
+
+    <ticket-{ticket_id}@{domain}>             initial ticket email
+    <ticket-{ticket_id}-reply-{reply_id}@{domain}>  agent reply
+
+Signed Reply-To format::
+
+    reply+{ticket_id}.{hmac8}@{domain}
+
+The signed Reply-To carries ticket identity even when clients strip the
+Message-ID / In-Reply-To headers — the inbound provider webhook
+verifies the 8-char HMAC-SHA256 prefix before routing a reply to its
+ticket.
+"""
+
+from __future__ import annotations
+
+import hmac
+import re
+from hashlib import sha256
+
+_TICKET_ID_PATTERN = re.compile(r"ticket-(\d+)(?:-reply-\d+)?@", re.IGNORECASE)
+_REPLY_LOCAL_PATTERN = re.compile(r"^reply\+(\d+)\.([a-f0-9]{8})$", re.IGNORECASE)
+
+
+def build_message_id(ticket_id: int, reply_id: int | None, domain: str) -> str:
+    """Build an RFC 5322 Message-ID.
+
+    Pass ``None`` for ``reply_id`` on the initial ticket email; the
+    ``-reply-{id}`` tail is appended only when ``reply_id`` is non-None.
+    """
+    if reply_id is None:
+        body = f"ticket-{ticket_id}"
+    else:
+        body = f"ticket-{ticket_id}-reply-{reply_id}"
+    return f"<{body}@{domain}>"
+
+
+def parse_ticket_id_from_message_id(raw: str | None) -> int | None:
+    """Extract the ticket id from a Message-ID we issued.
+
+    Accepts the header value with or without angle brackets. Returns
+    ``None`` when the input doesn't match our shape.
+    """
+    if not raw:
+        return None
+    match = _TICKET_ID_PATTERN.search(raw)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def build_reply_to(ticket_id: int, secret: str, domain: str) -> str:
+    """Build a signed Reply-To address ``reply+{id}.{hmac8}@{domain}``."""
+    return f"reply+{ticket_id}.{_sign(ticket_id, secret)}@{domain}"
+
+
+def verify_reply_to(address: str | None, secret: str) -> int | None:
+    """Verify a reply-to address (full or just the local part).
+
+    Returns the ticket id on match, ``None`` otherwise. Uses
+    :func:`hmac.compare_digest` for timing-safe verification.
+    """
+    if not address:
+        return None
+    local = address.split("@", 1)[0] if "@" in address else address
+    match = _REPLY_LOCAL_PATTERN.match(local)
+    if not match:
+        return None
+    try:
+        ticket_id = int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    expected = _sign(ticket_id, secret)
+    if hmac.compare_digest(expected.lower(), match.group(2).lower()):
+        return ticket_id
+    return None
+
+
+def _sign(ticket_id: int, secret: str) -> str:
+    """8-character HMAC-SHA256 prefix over the ticket id."""
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        str(ticket_id).encode("utf-8"),
+        sha256,
+    ).hexdigest()
+    return digest[:8]

--- a/escalated/mail/threading.py
+++ b/escalated/mail/threading.py
@@ -1,36 +1,66 @@
 """
 Email threading support for outbound emails.
 
-Generates Message-ID, In-Reply-To, and References headers so that email
-clients can group ticket conversations into a single thread.
+Delegates to :mod:`escalated.mail.message_id_util` so the Message-ID
+format matches the canonical NestJS reference
+(``<ticket-{id}@{domain}>`` / ``<ticket-{id}-reply-{replyId}@{domain}>``)
+and the inbound adapters' Reply-To verification has something to check
+against.
+
+Also provides :func:`get_signed_reply_to` for setting the Reply-To
+header on outbound messages when ``ESCALATED_EMAIL_INBOUND_SECRET`` is
+configured — inbound providers verify the HMAC prefix before routing
+replies to tickets.
 """
 
 from django.conf import settings
 
+from escalated.conf import get_setting
+from escalated.mail.message_id_util import (
+    build_message_id,
+    build_reply_to,
+)
 from escalated.models import EscalatedSetting
 
 
 def get_email_domain():
-    """Return the domain used for Message-ID generation."""
+    """Return the domain used for Message-ID generation.
+
+    Resolution order (first non-blank wins):
+      1. ``EscalatedSetting("email_domain")`` — admin-configurable
+      2. ``ESCALATED_EMAIL_DOMAIN`` Django setting
+      3. Host portion of ``DEFAULT_FROM_EMAIL``
+      4. ``"escalated.dev"``
+    """
     domain = EscalatedSetting.get("email_domain")
     if domain:
         return domain
+    configured = get_setting("EMAIL_DOMAIN")
+    if configured:
+        return configured
     default_from = getattr(settings, "DEFAULT_FROM_EMAIL", "support@escalated.dev")
     if "@" in default_from:
         return default_from.split("@", 1)[1]
     return "escalated.dev"
 
 
+def get_inbound_secret():
+    """Return the HMAC secret used to sign Reply-To addresses.
+
+    Returns an empty string when unset — callers MUST treat that as
+    "skip signed Reply-To".
+    """
+    return get_setting("EMAIL_INBOUND_SECRET") or ""
+
+
 def make_message_id(ticket):
-    """Generate a Message-ID for the initial ticket notification."""
-    domain = get_email_domain()
-    return f"<ticket-{ticket.pk}-{ticket.reference}@{domain}>"
+    """Canonical Message-ID for the ticket root (initial notification)."""
+    return build_message_id(ticket.pk, None, get_email_domain())
 
 
 def make_reply_message_id(ticket, reply):
-    """Generate a Message-ID for a reply notification."""
-    domain = get_email_domain()
-    return f"<ticket-{ticket.pk}-reply-{reply.pk}@{domain}>"
+    """Canonical Message-ID for a reply, threaded off the ticket root."""
+    return build_message_id(ticket.pk, reply.pk, get_email_domain())
 
 
 def get_threading_headers(ticket, reply=None):
@@ -49,15 +79,29 @@ def get_threading_headers(ticket, reply=None):
     ticket_msg_id = make_message_id(ticket)
 
     if reply is None:
-        # New ticket notification
+        # New ticket notification — anchor the thread.
         headers["Message-ID"] = ticket_msg_id
     else:
-        # Reply notification
         headers["Message-ID"] = make_reply_message_id(ticket, reply)
         headers["In-Reply-To"] = ticket_msg_id
         headers["References"] = ticket_msg_id
 
     return headers
+
+
+def get_signed_reply_to(ticket):
+    """
+    Return the signed Reply-To address for a ticket, or ``None`` when
+    no inbound secret is configured.
+
+    The HMAC prefix on the local part means inbound provider webhooks
+    can verify ticket identity without trusting the mail client's
+    threading headers.
+    """
+    secret = get_inbound_secret()
+    if not secret:
+        return None
+    return build_reply_to(ticket.pk, secret, get_email_domain())
 
 
 def get_branding_context():

--- a/escalated/services/inbound_email_service.py
+++ b/escalated/services/inbound_email_service.py
@@ -230,14 +230,7 @@ class InboundEmailService:
 
         driver = get_driver()
 
-        # Try to find an existing ticket by subject reference
-        ticket = InboundEmailService._find_ticket_by_reference(message.subject)
-
-        # Also try by In-Reply-To / References headers
-        if ticket is None and message.in_reply_to:
-            ticket = InboundEmailService._find_ticket_by_message_id(message.in_reply_to)
-        if ticket is None and message.references:
-            ticket = InboundEmailService._find_ticket_by_references(message.references)
+        ticket = InboundEmailService._find_existing_ticket(message)
 
         # Resolve sender — try to find a registered user first
         User = get_user_model()
@@ -265,6 +258,75 @@ class InboundEmailService:
             InboundEmailService._handle_attachments(ticket, message.attachments)
 
             return ticket, reply
+
+    @staticmethod
+    def _find_existing_ticket(message: InboundMessage):
+        """
+        Resolve the inbound email to an existing ticket in priority order:
+
+          1. In-Reply-To parsed via ``message_id_util`` — the reply is
+             threading off a Message-ID we issued (cold-start path, no
+             DB lookup required).
+          2. References parsed via ``message_id_util``, each id in order.
+          3. Signed Reply-To on ``to_email``
+             (``reply+{id}.{hmac8}@...``) verified via
+             ``message_id_util.verify_reply_to``. Survives clients that
+             strip our threading headers; forged signatures are rejected.
+          4. Subject line reference tag (legacy).
+          5. ``InboundEmail.message_id`` lookup for any header id
+             (weakest fallback; relies on our own reply history).
+        """
+        from escalated.mail.message_id_util import (
+            parse_ticket_id_from_message_id,
+            verify_reply_to,
+        )
+        from escalated.mail.threading import get_inbound_secret
+
+        header_ids = InboundEmailService._candidate_header_message_ids(message)
+
+        # 1 + 2: parse our own Message-IDs out of In-Reply-To / References.
+        for raw in header_ids:
+            ticket_id = parse_ticket_id_from_message_id(raw)
+            if ticket_id is None:
+                continue
+            try:
+                return Ticket.objects.get(pk=ticket_id)
+            except Ticket.DoesNotExist:
+                continue
+
+        # 3. Signed Reply-To on the recipient address.
+        secret = get_inbound_secret()
+        if secret and message.to_email:
+            verified = verify_reply_to(message.to_email, secret)
+            if verified is not None:
+                try:
+                    return Ticket.objects.get(pk=verified)
+                except Ticket.DoesNotExist:
+                    pass
+
+        # 4. Subject line reference tag.
+        ticket = InboundEmailService._find_ticket_by_reference(message.subject)
+        if ticket is not None:
+            return ticket
+
+        # 5. Legacy InboundEmail lookup for any id we've seen before.
+        for raw in header_ids:
+            bare = raw.strip("<>")
+            ticket = InboundEmailService._find_ticket_by_message_id(bare)
+            if ticket is not None:
+                return ticket
+
+        return None
+
+    @staticmethod
+    def _candidate_header_message_ids(message: InboundMessage) -> list[str]:
+        """Return every candidate Message-ID from the inbound headers."""
+        ids: list[str] = []
+        if message.in_reply_to:
+            ids.append(message.in_reply_to)
+        if message.references:
+            ids.extend(reversed(message.references.strip().split()))
+        return ids
 
     @staticmethod
     def _find_ticket_by_reference(subject: str):

--- a/escalated/services/notification_service.py
+++ b/escalated/services/notification_service.py
@@ -317,13 +317,20 @@ class NotificationService:
 
     @staticmethod
     def _send_email(subject, template, context, recipient, extra_headers=None):
-        """Send an HTML email using Django's mail system with optional headers."""
+        """Send an HTML email using Django's mail system with optional headers.
+
+        When ``context["ticket"]`` is present AND
+        ``ESCALATED_EMAIL_INBOUND_SECRET`` is configured, the message
+        gets a signed Reply-To so inbound provider webhooks can verify
+        ticket identity without trusting the mail client's threading
+        headers.
+        """
         if not recipient:
             return
 
         try:
             # Inject branding context for templates that use it
-            from escalated.mail.threading import get_branding_context
+            from escalated.mail.threading import get_branding_context, get_signed_reply_to
 
             context.setdefault("branding", get_branding_context())
 
@@ -332,12 +339,17 @@ class NotificationService:
 
             from django.core.mail import EmailMessage
 
+            ticket = context.get("ticket")
+            signed = get_signed_reply_to(ticket) if ticket is not None else None
+            reply_to = [signed] if signed else None
+
             msg = EmailMessage(
                 subject=subject,
                 body=html_body,
                 from_email=from_email,
                 to=[recipient],
                 headers=extra_headers or {},
+                reply_to=reply_to,
             )
             msg.content_subtype = "html"
             msg.send(fail_silently=True)

--- a/tests/unit/test_email_threading.py
+++ b/tests/unit/test_email_threading.py
@@ -27,19 +27,21 @@ class TestEmailDomain:
 
 @pytest.mark.django_db
 class TestMessageId:
+    # Format matches the canonical NestJS reference
+    # (see escalated.mail.message_id_util): <ticket-{pk}@domain> and
+    # <ticket-{pk}-reply-{reply_pk}@domain>.
+
     def test_make_message_id_format(self):
         ticket = TicketFactory()
         msg_id = make_message_id(ticket)
-        assert msg_id.startswith("<ticket-")
-        assert ticket.reference in msg_id
+        assert msg_id.startswith(f"<ticket-{ticket.pk}@")
         assert msg_id.endswith(">")
 
     def test_make_reply_message_id_format(self):
         ticket = TicketFactory()
         reply = ReplyFactory(ticket=ticket)
         msg_id = make_reply_message_id(ticket, reply)
-        assert f"reply-{reply.pk}" in msg_id
-        assert msg_id.startswith("<ticket-")
+        assert msg_id.startswith(f"<ticket-{ticket.pk}-reply-{reply.pk}@")
         assert msg_id.endswith(">")
 
     def test_message_ids_are_unique(self):
@@ -111,7 +113,7 @@ class TestNotificationServiceThreading:
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
         assert "Message-ID" in msg.extra_headers
-        assert ticket.reference in msg.extra_headers["Message-ID"]
+        assert f"ticket-{ticket.pk}@" in msg.extra_headers["Message-ID"]
 
     def test_reply_has_threading_headers(self, settings):
         settings.ESCALATED = {"NOTIFICATION_CHANNELS": ["email"], "WEBHOOK_URL": None}
@@ -129,4 +131,72 @@ class TestNotificationServiceThreading:
         msg = mail.outbox[0]
         assert "In-Reply-To" in msg.extra_headers
         assert "References" in msg.extra_headers
-        assert ticket.reference in msg.extra_headers["In-Reply-To"]
+        assert f"ticket-{ticket.pk}@" in msg.extra_headers["In-Reply-To"]
+
+
+@pytest.mark.django_db
+class TestSignedReplyTo:
+    """Signed Reply-To wire-up: when ESCALATED_EMAIL_INBOUND_SECRET is
+    configured, every outbound ticket notification gets a signed
+    Reply-To so inbound provider webhooks can verify ticket identity."""
+
+    def test_signed_reply_to_set_when_secret_configured(self, settings):
+        from escalated.mail.threading import get_signed_reply_to
+
+        settings.ESCALATED = {
+            "NOTIFICATION_CHANNELS": ["email"],
+            "WEBHOOK_URL": None,
+            "EMAIL_DOMAIN": "support.example.com",
+            "EMAIL_INBOUND_SECRET": "test-secret",
+        }
+        ticket = TicketFactory()
+
+        address = get_signed_reply_to(ticket)
+        assert address is not None
+        assert address.startswith(f"reply+{ticket.pk}.")
+        assert address.endswith("@support.example.com")
+
+    def test_signed_reply_to_returns_none_when_secret_blank(self, settings):
+        from escalated.mail.threading import get_signed_reply_to
+
+        settings.ESCALATED = {
+            "NOTIFICATION_CHANNELS": ["email"],
+            "WEBHOOK_URL": None,
+            "EMAIL_INBOUND_SECRET": "",
+        }
+        ticket = TicketFactory()
+
+        assert get_signed_reply_to(ticket) is None
+
+    def test_email_message_has_reply_to_when_secret_configured(self, settings):
+        settings.ESCALATED = {
+            "NOTIFICATION_CHANNELS": ["email"],
+            "WEBHOOK_URL": None,
+            "EMAIL_DOMAIN": "support.example.com",
+            "EMAIL_INBOUND_SECRET": "test-secret",
+        }
+        user = UserFactory()
+        ticket = TicketFactory(requester=user)
+
+        NotificationService.notify_ticket_created(ticket)
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        # Reply-To is a list on Django EmailMessage
+        assert msg.reply_to
+        assert msg.reply_to[0].startswith(f"reply+{ticket.pk}.")
+
+    def test_email_message_omits_reply_to_when_secret_blank(self, settings):
+        settings.ESCALATED = {
+            "NOTIFICATION_CHANNELS": ["email"],
+            "WEBHOOK_URL": None,
+            "EMAIL_INBOUND_SECRET": "",
+        }
+        user = UserFactory()
+        ticket = TicketFactory(requester=user)
+
+        NotificationService.notify_ticket_created(ticket)
+
+        msg = mail.outbox[0]
+        # Either empty list or no Reply-To — both are acceptable.
+        assert not msg.reply_to

--- a/tests/unit/test_inbound_email_service.py
+++ b/tests/unit/test_inbound_email_service.py
@@ -1,0 +1,97 @@
+"""
+Tests for InboundEmailService._find_existing_ticket resolution order.
+
+Verifies that the MessageIdUtil wire-up resolves canonical
+Message-IDs out of In-Reply-To / References and verifies signed
+Reply-To addresses on the recipient.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from escalated.mail.inbound_message import InboundMessage
+from escalated.mail.message_id_util import build_reply_to
+from escalated.models import Ticket
+from escalated.services.inbound_email_service import InboundEmailService
+from tests.factories import TicketFactory
+
+
+def _message(**overrides) -> InboundMessage:
+    defaults: dict = {
+        "from_email": "customer@example.com",
+        "from_name": "Customer",
+        "to_email": "support@example.com",
+        "subject": "hello",
+        "body_text": "body",
+        "body_html": None,
+    }
+    return InboundMessage(**{**defaults, **overrides})
+
+
+@pytest.mark.django_db
+class TestFindExistingTicket:
+    def test_in_reply_to_canonical_message_id(self):
+        ticket: Ticket = TicketFactory()
+        message = _message(in_reply_to=f"<ticket-{ticket.pk}@support.example.com>")
+
+        found = InboundEmailService._find_existing_ticket(message)
+        assert found == ticket
+
+    def test_references_canonical_message_id(self):
+        ticket: Ticket = TicketFactory()
+        message = _message(references=f"<unrelated@mail.com> <ticket-{ticket.pk}@support.example.com>")
+
+        found = InboundEmailService._find_existing_ticket(message)
+        assert found == ticket
+
+    def test_signed_reply_to_when_secret_configured(self, settings):
+        settings.ESCALATED = {
+            "EMAIL_DOMAIN": "support.example.com",
+            "EMAIL_INBOUND_SECRET": "test-secret",
+        }
+        ticket: Ticket = TicketFactory()
+        to = build_reply_to(ticket.pk, "test-secret", "support.example.com")
+        message = _message(to_email=to)
+
+        found = InboundEmailService._find_existing_ticket(message)
+        assert found == ticket
+
+    def test_forged_reply_to_is_rejected(self, settings):
+        settings.ESCALATED = {
+            "EMAIL_DOMAIN": "support.example.com",
+            "EMAIL_INBOUND_SECRET": "real-secret",
+        }
+        ticket: Ticket = TicketFactory()
+        # Signed with a DIFFERENT secret.
+        forged = build_reply_to(ticket.pk, "wrong-secret", "support.example.com")
+        message = _message(to_email=forged)
+
+        found = InboundEmailService._find_existing_ticket(message)
+        assert found is None
+
+    def test_signed_reply_to_ignored_when_secret_blank(self, settings):
+        settings.ESCALATED = {
+            "EMAIL_DOMAIN": "support.example.com",
+            "EMAIL_INBOUND_SECRET": "",
+        }
+        ticket: Ticket = TicketFactory()
+        to = build_reply_to(ticket.pk, "test-secret", "support.example.com")
+        message = _message(to_email=to)
+
+        found = InboundEmailService._find_existing_ticket(message)
+        assert found is None
+
+    def test_subject_reference_tag(self):
+        ticket: Ticket = TicketFactory()
+        # Subject referencing whatever reference the factory generated.
+        message = _message(subject=f"RE: [{ticket.reference}] foo")
+
+        found = InboundEmailService._find_existing_ticket(message)
+        assert found == ticket
+
+    def test_nothing_matches_returns_none(self):
+        message = _message(subject="New issue")
+
+        found = InboundEmailService._find_existing_ticket(message)
+        assert found is None

--- a/tests/unit/test_message_id_util.py
+++ b/tests/unit/test_message_id_util.py
@@ -1,0 +1,98 @@
+"""
+Pure-function tests for escalated.mail.message_id_util. Mirrors the
+NestJS / Spring / WordPress / .NET / Phoenix / Laravel / Rails
+reference test suites.
+"""
+
+from escalated.mail.message_id_util import (
+    build_message_id,
+    build_reply_to,
+    parse_ticket_id_from_message_id,
+    verify_reply_to,
+)
+
+DOMAIN = "support.example.com"
+SECRET = "test-secret-long-enough-for-hmac"
+
+
+def test_build_message_id_initial_ticket():
+    assert build_message_id(42, None, DOMAIN) == "<ticket-42@support.example.com>"
+
+
+def test_build_message_id_reply_form():
+    assert build_message_id(42, 7, DOMAIN) == "<ticket-42-reply-7@support.example.com>"
+
+
+def test_parse_ticket_id_round_trips_initial():
+    assert parse_ticket_id_from_message_id(build_message_id(42, None, DOMAIN)) == 42
+
+
+def test_parse_ticket_id_round_trips_reply():
+    assert parse_ticket_id_from_message_id(build_message_id(42, 7, DOMAIN)) == 42
+
+
+def test_parse_ticket_id_accepts_value_without_brackets():
+    assert parse_ticket_id_from_message_id("ticket-99@example.com") == 99
+
+
+def test_parse_ticket_id_returns_none_for_nil_or_empty():
+    assert parse_ticket_id_from_message_id(None) is None
+    assert parse_ticket_id_from_message_id("") is None
+
+
+def test_parse_ticket_id_returns_none_for_unrelated_input():
+    assert parse_ticket_id_from_message_id("<random@mail.com>") is None
+    assert parse_ticket_id_from_message_id("ticket-abc@example.com") is None
+
+
+def test_build_reply_to_is_stable():
+    first = build_reply_to(42, SECRET, DOMAIN)
+    again = build_reply_to(42, SECRET, DOMAIN)
+    assert first == again
+    import re
+
+    assert re.match(r"^reply\+42\.[a-f0-9]{8}@support\.example\.com$", first)
+
+
+def test_build_reply_to_differs_across_tickets():
+    a = build_reply_to(42, SECRET, DOMAIN)
+    b = build_reply_to(43, SECRET, DOMAIN)
+    assert a.split("@")[0] != b.split("@")[0]
+
+
+def test_verify_reply_to_round_trips():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    assert verify_reply_to(address, SECRET) == 42
+
+
+def test_verify_reply_to_accepts_local_part_only():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    local = address.split("@")[0]
+    assert verify_reply_to(local, SECRET) == 42
+
+
+def test_verify_reply_to_rejects_tampered_signature():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    at = address.index("@")
+    local = address[:at]
+    last = local[-1]
+    tampered = local[:-1] + ("1" if last == "0" else "0") + address[at:]
+    assert verify_reply_to(tampered, SECRET) is None
+
+
+def test_verify_reply_to_rejects_wrong_secret():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    assert verify_reply_to(address, "different-secret") is None
+
+
+def test_verify_reply_to_rejects_malformed_input():
+    assert verify_reply_to(None, SECRET) is None
+    assert verify_reply_to("", SECRET) is None
+    assert verify_reply_to("alice@example.com", SECRET) is None
+    assert verify_reply_to("reply@example.com", SECRET) is None
+    assert verify_reply_to("reply+abc.deadbeef@example.com", SECRET) is None
+
+
+def test_verify_reply_to_case_insensitive_hex():
+    address = build_reply_to(42, SECRET, DOMAIN)
+    assert verify_reply_to(address.upper(), SECRET) == 42


### PR DESCRIPTION
## Summary

Wires `message_id_util` (added in #40) + `ESCALATED_EMAIL_INBOUND_SECRET` (added in #41) into `InboundEmailService` so inbound mail routes to the correct ticket via canonical Message-ID parsing + signed Reply-To verification.

## Resolution order

Introduces `_find_existing_ticket(message)` with priority order:

1. **In-Reply-To** parsed via `message_id_util.parse_ticket_id_from_message_id` — cold-start path, no DB lookup required.
2. **References** parsed via `message_id_util`, each id in order.
3. **Signed Reply-To** on `to_email` (`reply+{pk}.{hmac8}@...`) verified via `message_id_util.verify_reply_to`. Survives clients that strip threading headers; forged signatures are rejected.
4. **Subject line** reference tag (legacy).
5. **InboundEmail.message_id** lookup for any header id (weakest fallback).

## Config

Secret branch only activates when `ESCALATED_EMAIL_INBOUND_SECRET` is set — safe default of skipping when admin hasn't configured a key.

## Dependencies

- **Stacked on #41** (`feat/email-service-wireup`), which is stacked on #40 (`feat/email-message-id`). Merge order: #40 → #41 → this PR.

## Test plan

- [x] 7 new pytest tests cover every resolution strategy, forged-signature rejection, and the secret-blank skip path
- [ ] CI green (won't trigger against stacked base until rebased)