### PR TITLE
feat(admin): public-tickets (guest policy) settings view

### DIFF
--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -230,6 +230,11 @@ admin_patterns = [
     path("admin/automations/<int:automation_id>/delete/", admin.automations_delete, name="admin_automations_delete"),
     # Settings - CSAT, SSO, 2FA
     path("admin/settings/csat/", admin.settings_csat, name="admin_settings_csat"),
+    path(
+        "admin/settings/public-tickets/",
+        admin.settings_public_tickets,
+        name="admin_settings_public_tickets",
+    ),
     path("admin/settings/sso/", admin.settings_sso, name="admin_settings_sso"),
     path("admin/settings/two-factor/", admin.settings_two_factor, name="admin_settings_two_factor"),
     path("admin/settings/two-factor/setup/", admin.two_factor_setup, name="admin_two_factor_setup"),

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -3485,6 +3485,73 @@ def settings_csat(request):
 
 
 @login_required
+def settings_public_tickets(request):
+    """Public-ticket guest policy settings page (+ update handler).
+
+    Controls the identity assigned to tickets submitted via the public widget
+    or inbound email. Read at request time by the widget controller, so
+    admins can switch modes at runtime without a redeploy.
+    """
+    check = _require_admin(request)
+    if check:
+        return check
+    from escalated.models import EscalatedSetting
+
+    valid_modes = {"unassigned", "guest_user", "prompt_signup"}
+
+    if request.method == "POST":
+        mode = request.POST.get("guest_policy_mode", "unassigned")
+        if mode not in valid_modes:
+            mode = "unassigned"
+
+        EscalatedSetting.objects.update_or_create(
+            key="guest_policy_mode", defaults={"value": mode}
+        )
+
+        user_id_value = ""
+        if mode == "guest_user":
+            raw = request.POST.get("guest_policy_user_id", "").strip()
+            if raw.isdigit() and int(raw) > 0:
+                user_id_value = raw
+        EscalatedSetting.objects.update_or_create(
+            key="guest_policy_user_id", defaults={"value": user_id_value}
+        )
+
+        signup_url_value = ""
+        if mode == "prompt_signup":
+            signup_url_value = request.POST.get(
+                "guest_policy_signup_url_template", ""
+            ).strip()[:500]
+        EscalatedSetting.objects.update_or_create(
+            key="guest_policy_signup_url_template",
+            defaults={"value": signup_url_value},
+        )
+
+        return redirect("escalated:admin_settings_public_tickets")
+
+    def _get(key, default=""):
+        try:
+            return EscalatedSetting.objects.get(key=key).value
+        except EscalatedSetting.DoesNotExist:
+            return default
+
+    user_id_raw = _get("guest_policy_user_id", "")
+    return render_page(
+        request,
+        "Escalated/Admin/Settings/PublicTickets",
+        props={
+            "settings": {
+                "guest_policy_mode": _get("guest_policy_mode", "unassigned"),
+                "guest_policy_user_id": int(user_id_raw) if user_id_raw.isdigit() else None,
+                "guest_policy_signup_url_template": _get(
+                    "guest_policy_signup_url_template", ""
+                ),
+            }
+        },
+    )
+
+
+@login_required
 def settings_sso(request):
     check = _require_admin(request)
     if check:

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -3504,24 +3504,18 @@ def settings_public_tickets(request):
         if mode not in valid_modes:
             mode = "unassigned"
 
-        EscalatedSetting.objects.update_or_create(
-            key="guest_policy_mode", defaults={"value": mode}
-        )
+        EscalatedSetting.objects.update_or_create(key="guest_policy_mode", defaults={"value": mode})
 
         user_id_value = ""
         if mode == "guest_user":
             raw = request.POST.get("guest_policy_user_id", "").strip()
             if raw.isdigit() and int(raw) > 0:
                 user_id_value = raw
-        EscalatedSetting.objects.update_or_create(
-            key="guest_policy_user_id", defaults={"value": user_id_value}
-        )
+        EscalatedSetting.objects.update_or_create(key="guest_policy_user_id", defaults={"value": user_id_value})
 
         signup_url_value = ""
         if mode == "prompt_signup":
-            signup_url_value = request.POST.get(
-                "guest_policy_signup_url_template", ""
-            ).strip()[:500]
+            signup_url_value = request.POST.get("guest_policy_signup_url_template", "").strip()[:500]
         EscalatedSetting.objects.update_or_create(
             key="guest_policy_signup_url_template",
             defaults={"value": signup_url_value},
@@ -3543,9 +3537,7 @@ def settings_public_tickets(request):
             "settings": {
                 "guest_policy_mode": _get("guest_policy_mode", "unassigned"),
                 "guest_policy_user_id": int(user_id_raw) if user_id_raw.isdigit() else None,
-                "guest_policy_signup_url_template": _get(
-                    "guest_policy_signup_url_template", ""
-                ),
+                "guest_policy_signup_url_template": _get("guest_policy_signup_url_template", ""),
             }
         },
     )


### PR DESCRIPTION
## Summary

Django host-adapter side of the new \`Admin/Settings/PublicTickets.vue\` page ([escalated#32](https://github.com/escalated-dev/escalated/pull/32)).

## What's added

- \`settings_public_tickets\` view — GET renders the Vue page with current settings; POST validates + persists via \`EscalatedSetting\`.
- URL: \`/admin/settings/public-tickets/\` named \`admin_settings_public_tickets\`.

## Behavior

- Validates mode against the three supported values (\`unassigned\`, \`guest_user\`, \`prompt_signup\`); unknown modes fall back to \`unassigned\`.
- \`guest_policy_user_id\` is only persisted when mode is \`guest_user\` (and the value is a positive integer).
- \`guest_policy_signup_url_template\` is only persisted when mode is \`prompt_signup\`, capped at 500 chars.
- Switching modes clears the fields that no longer apply so stale values don't leak.

Matches the \`settings_csat\` / \`settings_sso\` view pattern already in \`views/admin.py\`.