### PR TITLE
fix(public-tickets): honor guest_policy_mode on widget + guest submissions

### DIFF
--- a/escalated/views/guest.py
+++ b/escalated/views/guest.py
@@ -82,26 +82,33 @@ def ticket_store(request):
             },
         )
 
-    # Generate a unique guest token
+    # Generate a unique guest token — always set so the guest-view
+    # redirect below works regardless of whether the ticket also
+    # gets attributed to a host user (guest_user mode).
     guest_token = secrets.token_hex(32)  # 64-character hex string
 
     # Dedupe repeat guests by email (Pattern B). Inline guest_* fields
     # remain set for the backwards-compat dual-read period.
     contact = Contact.find_or_create_by_email(email, name)
 
-    # Create ticket without requester (guest mode)
-    ticket = Ticket.objects.create(
-        requester_content_type=None,
-        requester_object_id=None,
-        guest_name=name,
-        guest_email=email,
-        guest_token=guest_token,
-        contact=contact,
-        subject=subject,
-        description=description,
-        priority=priority,
-        department_id=department_id,
+    # Apply the admin-configured guest policy. See
+    # escalated.views.widget._apply_guest_policy for the mode reference.
+    from escalated.views.widget import _apply_guest_policy
+
+    attrs = _apply_guest_policy(
+        {
+            "guest_name": name,
+            "guest_email": email,
+            "guest_token": guest_token,
+            "subject": subject,
+            "description": description,
+            "priority": priority,
+            "department_id": department_id,
+            "contact": contact,
+        }
     )
+
+    ticket = Ticket.objects.create(**attrs)
 
     # Handle file attachments
     files = request.FILES.getlist("attachments")

--- a/escalated/views/widget.py
+++ b/escalated/views/widget.py
@@ -190,18 +190,20 @@ def widget_create_ticket(request):
     # Dedupe repeat guests by email (Pattern B).
     contact = Contact.find_or_create_by_email(email, name)
 
-    ticket = Ticket.objects.create(
-        requester_content_type=None,
-        requester_object_id=None,
-        guest_name=name,
-        guest_email=email,
-        guest_token=guest_token,
-        contact=contact,
-        subject=subject,
-        description=description,
-        priority=priority,
-        channel="widget",
+    attrs = _apply_guest_policy(
+        {
+            "guest_name": name,
+            "guest_email": email,
+            "guest_token": guest_token,
+            "subject": subject,
+            "description": description,
+            "priority": priority,
+            "channel": "widget",
+            "contact": contact,
+        }
     )
+
+    ticket = Ticket.objects.create(**attrs)
 
     return JsonResponse(
         {
@@ -245,3 +247,43 @@ def widget_lookup_ticket(request):
             }
         }
     )
+
+
+def _apply_guest_policy(attrs):
+    """Layer the admin-configured guest policy onto a ticket-create attrs dict.
+
+    Persisted by the admin settings page under three EscalatedSetting keys
+    (guest_policy_mode / guest_policy_user_id / guest_policy_signup_url_template).
+    Modes:
+
+      * ``unassigned`` (default): ``requester_*`` left null, ``guest_*`` preserved.
+      * ``guest_user``: route to the configured host-app user via the generic
+        (ContentType, object_id) FK. Still records ``guest_name`` / ``guest_email``
+        so agents see who submitted. Falls through to ``unassigned`` behavior if
+        ``guest_policy_user_id`` is zero or missing.
+      * ``prompt_signup``: same ticket-create path as ``unassigned`` today;
+        signup-invite emission is a listener-level follow-up.
+
+    Returns the modified attrs dict.
+    """
+    from django.contrib.auth import get_user_model
+    from django.contrib.contenttypes.models import ContentType
+
+    mode = EscalatedSetting.get("guest_policy_mode", "unassigned") or "unassigned"
+
+    if mode == "guest_user":
+        raw_id = EscalatedSetting.get("guest_policy_user_id", "") or ""
+        try:
+            user_id = int(raw_id)
+        except (TypeError, ValueError):
+            user_id = 0
+        if user_id > 0:
+            user_model = get_user_model()
+            attrs["requester_content_type"] = ContentType.objects.get_for_model(user_model)
+            attrs["requester_object_id"] = user_id
+            return attrs
+
+    # unassigned + prompt_signup + misconfigured guest_user all land here.
+    attrs["requester_content_type"] = None
+    attrs["requester_object_id"] = None
+    return attrs

--- a/tests/unit/test_widget.py
+++ b/tests/unit/test_widget.py
@@ -176,6 +176,100 @@ class TestWidgetCreateTicket:
         )
         assert response.status_code == 403
 
+    def test_guest_policy_unassigned_default_path(self, client):
+        """Default mode leaves requester_* null and records guest_* fields."""
+        EscalatedSetting.set("guest_policy_mode", "unassigned")
+        response = client.post(
+            "/support/widget/tickets/create/",
+            data=json.dumps(
+                {
+                    "name": "Alice",
+                    "email": "alice@example.com",
+                    "subject": "Hi",
+                    "description": "Question.",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        ticket = Ticket.objects.get(reference=response.json()["ticket"]["reference"])
+        assert ticket.requester_content_type_id is None
+        assert ticket.requester_object_id is None
+        assert ticket.guest_email == "alice@example.com"
+
+    def test_guest_policy_guest_user_routes_to_host_user(self, client):
+        """guest_user mode sets requester to the configured host user id."""
+        from django.contrib.auth import get_user_model
+        from django.contrib.contenttypes.models import ContentType
+
+        User = get_user_model()
+        shared = User.objects.create(username="support_bot", email="bot@example.com")
+
+        EscalatedSetting.set("guest_policy_mode", "guest_user")
+        EscalatedSetting.set("guest_policy_user_id", str(shared.pk))
+
+        response = client.post(
+            "/support/widget/tickets/create/",
+            data=json.dumps(
+                {
+                    "name": "Bob",
+                    "email": "bob@example.com",
+                    "subject": "Hi",
+                    "description": "Another question.",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        ticket = Ticket.objects.get(reference=response.json()["ticket"]["reference"])
+        assert ticket.requester_object_id == shared.pk
+        assert ticket.requester_content_type_id == ContentType.objects.get_for_model(User).id
+        # Agents still see who actually submitted via guest_email:
+        assert ticket.guest_email == "bob@example.com"
+
+    def test_guest_policy_guest_user_with_no_id_falls_through(self, client):
+        """Misconfigured guest_user (empty / zero id) falls through to unassigned."""
+        EscalatedSetting.set("guest_policy_mode", "guest_user")
+        EscalatedSetting.set("guest_policy_user_id", "")
+
+        response = client.post(
+            "/support/widget/tickets/create/",
+            data=json.dumps(
+                {
+                    "name": "Charlie",
+                    "email": "charlie@example.com",
+                    "subject": "Hi",
+                    "description": "Misconfig scenario.",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        ticket = Ticket.objects.get(reference=response.json()["ticket"]["reference"])
+        assert ticket.requester_content_type_id is None
+        assert ticket.requester_object_id is None
+
+    def test_guest_policy_prompt_signup_uses_unassigned_path(self, client):
+        """prompt_signup mode behaves like unassigned for ticket creation today."""
+        EscalatedSetting.set("guest_policy_mode", "prompt_signup")
+
+        response = client.post(
+            "/support/widget/tickets/create/",
+            data=json.dumps(
+                {
+                    "name": "Dana",
+                    "email": "dana@example.com",
+                    "subject": "Hi",
+                    "description": "Signup prompt scenario.",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        ticket = Ticket.objects.get(reference=response.json()["ticket"]["reference"])
+        assert ticket.requester_content_type_id is None
+        assert ticket.guest_email == "dana@example.com"
+
 
 @pytest.mark.django_db
 class TestWidgetLookupTicket:


### PR DESCRIPTION
## Summary

Same bug as [escalated-laravel#72](https://github.com/escalated-dev/escalated-laravel/pull/72) and [escalated-rails#47](https://github.com/escalated-dev/escalated-rails/pull/47). The admin settings page (escalated-django#43) persists \`guest_policy_mode\` / \`guest_policy_user_id\` / \`guest_policy_signup_url_template\` to \`EscalatedSetting\`, but both public submission paths — \`widget.widget_create_ticket\` and \`guest.guest_create_ticket\` — wrote \`requester_content_type=None\`, \`requester_object_id=None\`, \`guest_*\` unconditionally regardless of mode. **Result: the admin settings page had zero behavioral effect.**

## What changed

Factored a \`_apply_guest_policy\` helper in \`escalated/views/widget.py\` that layers the admin-configured policy onto a ticket-create attrs dict. Both entry points wire through it:

| Mode | Behavior |
|---|---|
| \`unassigned\` (default) | Existing behavior — \`requester_*\` null, \`guest_*\` set. |
| \`guest_user\` | \`requester_content_type\` = \`ContentType\` for \`get_user_model()\`, \`requester_object_id\` = \`guest_policy_user_id\`. Still records \`guest_name\` / \`guest_email\` so agents see who submitted. |
| \`prompt_signup\` | Same ticket-create path as unassigned. Signup-invite emission is a listener-level follow-up. |

Misconfigured \`guest_user\` mode (empty / zero / non-numeric user id) falls through to unassigned so bad admin input can't 500 public submissions.

## Test plan

- [x] 4 new Pytest cases covering: unassigned path regression, \`guest_user\` routes to a real User (via \`get_user_model\` + \`ContentType\`), misconfigured \`guest_user\` fallback, \`prompt_signup\` path.
- [x] Full \`tests/\` suite: 682 passed (up from 678).
- [x] \`ruff check\` + \`ruff format\` clean on all modified files.

## Related

- [escalated-laravel#72](https://github.com/escalated-dev/escalated-laravel/pull/72), [escalated-rails#47](https://github.com/escalated-dev/escalated-rails/pull/47), [escalated-nestjs#27](https://github.com/escalated-dev/escalated-nestjs/pull/27).
- Adonis and WordPress still likely need the same fix — each has its own widget controller that writes guest_* unconditionally.