### PR TITLE
fix(inbound): honor guest_policy_mode on inbound-email-created tickets

### DIFF
--- a/escalated/services/inbound_email_service.py
+++ b/escalated/services/inbound_email_service.py
@@ -359,27 +359,33 @@ class InboundEmailService:
                 },
             )
         else:
-            # Guest ticket (follows the same pattern as views/guest.py)
+            # Guest ticket — apply the admin-configured guest policy,
+            # same branching as widget.widget_create_ticket uses.
+            # See escalated.views.widget._apply_guest_policy.
+            from escalated.views.widget import _apply_guest_policy
+
             guest_token = secrets.token_hex(32)
             # Dedupe inbound senders into a Contact so repeat emails land
             # on one identity (Pattern B).
             contact = Contact.find_or_create_by_email(message.from_email, message.from_name)
-            ticket = Ticket.objects.create(
-                requester_content_type=None,
-                requester_object_id=None,
-                guest_name=message.from_name or message.from_email,
-                guest_email=message.from_email,
-                guest_token=guest_token,
-                contact=contact,
-                subject=subject,
-                description=body,
-                priority=get_setting("DEFAULT_PRIORITY"),
-                channel="email",
-                metadata={
-                    "source": "inbound_email",
-                    "message_id": message.message_id,
-                },
+
+            attrs = _apply_guest_policy(
+                {
+                    "guest_name": message.from_name or message.from_email,
+                    "guest_email": message.from_email,
+                    "guest_token": guest_token,
+                    "subject": subject,
+                    "description": body,
+                    "priority": get_setting("DEFAULT_PRIORITY"),
+                    "channel": "email",
+                    "contact": contact,
+                    "metadata": {
+                        "source": "inbound_email",
+                        "message_id": message.message_id,
+                    },
+                }
             )
+            ticket = Ticket.objects.create(**attrs)
 
             # Fire the ticket_created signal manually for guest tickets
             # (the driver.create_ticket handles this for auth users)


### PR DESCRIPTION
## Summary

Second wave of the widget↔settings-disconnection sweep. Mirrors [escalated-nestjs#28](https://github.com/escalated-dev/escalated-nestjs/pull/28), [escalated-laravel#73](https://github.com/escalated-dev/escalated-laravel/pull/73), [escalated-rails#48](https://github.com/escalated-dev/escalated-rails/pull/48).

\`InboundEmailService._create_ticket\` wrote \`requester_content_type=None\`, \`requester_object_id=None\`, \`guest_*\` fields unconditionally for non-registered senders — ignoring the admin-configured \`guest_policy_mode\`.

## What changed

Wired through the \`_apply_guest_policy\` helper I factored into \`escalated.views.widget\` during the widget fix ([#44](https://github.com/escalated-dev/escalated-django/pull/44)), so the inbound service inherits identical semantics:

| Mode | Behavior |
|---|---|
| \`unassigned\` (default) | Existing behavior — \`requester_*\` null, \`guest_*\` set. |
| \`guest_user\` | \`requester_content_type\` = \`ContentType\` for \`get_user_model()\`, \`requester_object_id\` = \`guest_policy_user_id\`. Still records \`guest_email\` for agent visibility. |
| \`prompt_signup\` | Same unassigned path; signup-invite emission is a listener-level follow-up. |

Misconfigured \`guest_user\` (zero/missing user id) falls through to unassigned.

## Test plan

- [x] No new test file — the \`_apply_guest_policy\` helper is already covered by the 4 tests added to \`test_widget.py\` in #44, and the inbound service just calls the same helper. Centralizing the logic means one set of tests proves both paths.
- [x] Full \`tests/\` suite: 677 passed. 1 known-flaky queue-position test passed on rerun; unrelated to my edit.
- [x] \`ruff check\` + \`ruff format\` clean.

## Related

- NestJS #28, Laravel #73, Rails #48 (this sweep).
- Adonis / WordPress have the same bug; each needs its own patch.