### PR TITLE
feat(mail): wire message_id_util into threading.py + signed Reply-To

### DIFF
--- a/escalated/conf.py
+++ b/escalated/conf.py
@@ -28,6 +28,9 @@ DEFAULTS = {
     },
     "NOTIFICATION_CHANNELS": ["email"],
     "WEBHOOK_URL": None,
+    # Email threading — domain for Message-IDs, secret for signed Reply-To
+    "EMAIL_DOMAIN": None,  # falls back to DEFAULT_FROM_EMAIL host
+    "EMAIL_INBOUND_SECRET": "",  # empty → Reply-To skipped
     # Inbound email settings
     "INBOUND_EMAIL_ENABLED": False,
     "INBOUND_EMAIL_ADAPTER": "mailgun",

--- a/escalated/mail/threading.py
+++ b/escalated/mail/threading.py
@@ -1,36 +1,66 @@
 """
 Email threading support for outbound emails.
 
-Generates Message-ID, In-Reply-To, and References headers so that email
-clients can group ticket conversations into a single thread.
+Delegates to :mod:`escalated.mail.message_id_util` so the Message-ID
+format matches the canonical NestJS reference
+(``<ticket-{id}@{domain}>`` / ``<ticket-{id}-reply-{replyId}@{domain}>``)
+and the inbound adapters' Reply-To verification has something to check
+against.
+
+Also provides :func:`get_signed_reply_to` for setting the Reply-To
+header on outbound messages when ``ESCALATED_EMAIL_INBOUND_SECRET`` is
+configured — inbound providers verify the HMAC prefix before routing
+replies to tickets.
 """
 
 from django.conf import settings
 
+from escalated.conf import get_setting
+from escalated.mail.message_id_util import (
+    build_message_id,
+    build_reply_to,
+)
 from escalated.models import EscalatedSetting
 
 
 def get_email_domain():
-    """Return the domain used for Message-ID generation."""
+    """Return the domain used for Message-ID generation.
+
+    Resolution order (first non-blank wins):
+      1. ``EscalatedSetting("email_domain")`` — admin-configurable
+      2. ``ESCALATED_EMAIL_DOMAIN`` Django setting
+      3. Host portion of ``DEFAULT_FROM_EMAIL``
+      4. ``"escalated.dev"``
+    """
     domain = EscalatedSetting.get("email_domain")
     if domain:
         return domain
+    configured = get_setting("EMAIL_DOMAIN")
+    if configured:
+        return configured
     default_from = getattr(settings, "DEFAULT_FROM_EMAIL", "support@escalated.dev")
     if "@" in default_from:
         return default_from.split("@", 1)[1]
     return "escalated.dev"
 
 
+def get_inbound_secret():
+    """Return the HMAC secret used to sign Reply-To addresses.
+
+    Returns an empty string when unset — callers MUST treat that as
+    "skip signed Reply-To".
+    """
+    return get_setting("EMAIL_INBOUND_SECRET") or ""
+
+
 def make_message_id(ticket):
-    """Generate a Message-ID for the initial ticket notification."""
-    domain = get_email_domain()
-    return f"<ticket-{ticket.pk}-{ticket.reference}@{domain}>"
+    """Canonical Message-ID for the ticket root (initial notification)."""
+    return build_message_id(ticket.pk, None, get_email_domain())
 
 
 def make_reply_message_id(ticket, reply):
-    """Generate a Message-ID for a reply notification."""
-    domain = get_email_domain()
-    return f"<ticket-{ticket.pk}-reply-{reply.pk}@{domain}>"
+    """Canonical Message-ID for a reply, threaded off the ticket root."""
+    return build_message_id(ticket.pk, reply.pk, get_email_domain())
 
 
 def get_threading_headers(ticket, reply=None):
@@ -49,15 +79,29 @@ def get_threading_headers(ticket, reply=None):
     ticket_msg_id = make_message_id(ticket)
 
     if reply is None:
-        # New ticket notification
+        # New ticket notification — anchor the thread.
         headers["Message-ID"] = ticket_msg_id
     else:
-        # Reply notification
         headers["Message-ID"] = make_reply_message_id(ticket, reply)
         headers["In-Reply-To"] = ticket_msg_id
         headers["References"] = ticket_msg_id
 
     return headers
+
+
+def get_signed_reply_to(ticket):
+    """
+    Return the signed Reply-To address for a ticket, or ``None`` when
+    no inbound secret is configured.
+
+    The HMAC prefix on the local part means inbound provider webhooks
+    can verify ticket identity without trusting the mail client's
+    threading headers.
+    """
+    secret = get_inbound_secret()
+    if not secret:
+        return None
+    return build_reply_to(ticket.pk, secret, get_email_domain())
 
 
 def get_branding_context():

--- a/escalated/services/notification_service.py
+++ b/escalated/services/notification_service.py
@@ -317,13 +317,20 @@ class NotificationService:
 
     @staticmethod
     def _send_email(subject, template, context, recipient, extra_headers=None):
-        """Send an HTML email using Django's mail system with optional headers."""
+        """Send an HTML email using Django's mail system with optional headers.
+
+        When ``context["ticket"]`` is present AND
+        ``ESCALATED_EMAIL_INBOUND_SECRET`` is configured, the message
+        gets a signed Reply-To so inbound provider webhooks can verify
+        ticket identity without trusting the mail client's threading
+        headers.
+        """
         if not recipient:
             return
 
         try:
             # Inject branding context for templates that use it
-            from escalated.mail.threading import get_branding_context
+            from escalated.mail.threading import get_branding_context, get_signed_reply_to
 
             context.setdefault("branding", get_branding_context())
 
@@ -332,12 +339,17 @@ class NotificationService:
 
             from django.core.mail import EmailMessage
 
+            ticket = context.get("ticket")
+            signed = get_signed_reply_to(ticket) if ticket is not None else None
+            reply_to = [signed] if signed else None
+
             msg = EmailMessage(
                 subject=subject,
                 body=html_body,
                 from_email=from_email,
                 to=[recipient],
                 headers=extra_headers or {},
+                reply_to=reply_to,
             )
             msg.content_subtype = "html"
             msg.send(fail_silently=True)

--- a/tests/unit/test_email_threading.py
+++ b/tests/unit/test_email_threading.py
@@ -27,19 +27,21 @@ class TestEmailDomain:
 
 @pytest.mark.django_db
 class TestMessageId:
+    # Format matches the canonical NestJS reference
+    # (see escalated.mail.message_id_util): <ticket-{pk}@domain> and
+    # <ticket-{pk}-reply-{reply_pk}@domain>.
+
     def test_make_message_id_format(self):
         ticket = TicketFactory()
         msg_id = make_message_id(ticket)
-        assert msg_id.startswith("<ticket-")
-        assert ticket.reference in msg_id
+        assert msg_id.startswith(f"<ticket-{ticket.pk}@")
         assert msg_id.endswith(">")
 
     def test_make_reply_message_id_format(self):
         ticket = TicketFactory()
         reply = ReplyFactory(ticket=ticket)
         msg_id = make_reply_message_id(ticket, reply)
-        assert f"reply-{reply.pk}" in msg_id
-        assert msg_id.startswith("<ticket-")
+        assert msg_id.startswith(f"<ticket-{ticket.pk}-reply-{reply.pk}@")
         assert msg_id.endswith(">")
 
     def test_message_ids_are_unique(self):
@@ -111,7 +113,7 @@ class TestNotificationServiceThreading:
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
         assert "Message-ID" in msg.extra_headers
-        assert ticket.reference in msg.extra_headers["Message-ID"]
+        assert f"ticket-{ticket.pk}@" in msg.extra_headers["Message-ID"]
 
     def test_reply_has_threading_headers(self, settings):
         settings.ESCALATED = {"NOTIFICATION_CHANNELS": ["email"], "WEBHOOK_URL": None}
@@ -129,4 +131,72 @@ class TestNotificationServiceThreading:
         msg = mail.outbox[0]
         assert "In-Reply-To" in msg.extra_headers
         assert "References" in msg.extra_headers
-        assert ticket.reference in msg.extra_headers["In-Reply-To"]
+        assert f"ticket-{ticket.pk}@" in msg.extra_headers["In-Reply-To"]
+
+
+@pytest.mark.django_db
+class TestSignedReplyTo:
+    """Signed Reply-To wire-up: when ESCALATED_EMAIL_INBOUND_SECRET is
+    configured, every outbound ticket notification gets a signed
+    Reply-To so inbound provider webhooks can verify ticket identity."""
+
+    def test_signed_reply_to_set_when_secret_configured(self, settings):
+        from escalated.mail.threading import get_signed_reply_to
+
+        settings.ESCALATED = {
+            "NOTIFICATION_CHANNELS": ["email"],
+            "WEBHOOK_URL": None,
+            "EMAIL_DOMAIN": "support.example.com",
+            "EMAIL_INBOUND_SECRET": "test-secret",
+        }
+        ticket = TicketFactory()
+
+        address = get_signed_reply_to(ticket)
+        assert address is not None
+        assert address.startswith(f"reply+{ticket.pk}.")
+        assert address.endswith("@support.example.com")
+
+    def test_signed_reply_to_returns_none_when_secret_blank(self, settings):
+        from escalated.mail.threading import get_signed_reply_to
+
+        settings.ESCALATED = {
+            "NOTIFICATION_CHANNELS": ["email"],
+            "WEBHOOK_URL": None,
+            "EMAIL_INBOUND_SECRET": "",
+        }
+        ticket = TicketFactory()
+
+        assert get_signed_reply_to(ticket) is None
+
+    def test_email_message_has_reply_to_when_secret_configured(self, settings):
+        settings.ESCALATED = {
+            "NOTIFICATION_CHANNELS": ["email"],
+            "WEBHOOK_URL": None,
+            "EMAIL_DOMAIN": "support.example.com",
+            "EMAIL_INBOUND_SECRET": "test-secret",
+        }
+        user = UserFactory()
+        ticket = TicketFactory(requester=user)
+
+        NotificationService.notify_ticket_created(ticket)
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        # Reply-To is a list on Django EmailMessage
+        assert msg.reply_to
+        assert msg.reply_to[0].startswith(f"reply+{ticket.pk}.")
+
+    def test_email_message_omits_reply_to_when_secret_blank(self, settings):
+        settings.ESCALATED = {
+            "NOTIFICATION_CHANNELS": ["email"],
+            "WEBHOOK_URL": None,
+            "EMAIL_INBOUND_SECRET": "",
+        }
+        user = UserFactory()
+        ticket = TicketFactory(requester=user)
+
+        NotificationService.notify_ticket_created(ticket)
+
+        msg = mail.outbox[0]
+        # Either empty list or no Reply-To — both are acceptable.
+        assert not msg.reply_to


### PR DESCRIPTION
## Summary

Wires the just-merged `message_id_util` into Django's threading helper so outbound ticket emails carry stable RFC-5322 `Message-ID` + `Reply-To` headers.

Recovers from auto-closed [#41](https://github.com/escalated-dev/escalated-django/pull/41) (closed when its stacked base `feat/email-message-id` was squash-merged via [#40](https://github.com/escalated-dev/escalated-django/pull/40)). Rebased onto current `main`.

## Test plan
- [x] Existing email tests pass
- [ ] Verify outbound email shows `Message-ID: <ticket-{id}@{domain}>` header