### PR TITLE
feat(i18n): consume central translations from escalated-locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Central translations sourced from the `escalated-locale` PyPI package
+  via `escalated.locale_paths.get_locale_paths()`; the plugin-local
+  `escalated/locale/` directory remains as the override layer that wins
+  over the central catalogue
 - Missing admin views for automations, articles, and side-conversations
 - Inertia UI optional with `UI_ENABLED` setting
 - Plugin system with service layer and admin views

--- a/README.md
+++ b/README.md
@@ -170,6 +170,40 @@ Your layout component must accept a `#header` slot and a default slot. Escalated
 
 See the [`@escalated-dev/escalated` README](https://github.com/escalated-dev/escalated) for full theming documentation and CSS custom properties.
 
+## Translations (i18n)
+
+Escalated for Django consumes translations from the central
+[`escalated-locale`](https://github.com/escalated-dev/escalated-locale)
+PyPI package. The package ships canonical JSON catalogues alongside
+pre-compiled gettext artifacts at
+`escalated_locale/locale/<lang>/LC_MESSAGES/django.{po,mo}`, which
+plug directly into Django's translation system via `LOCALE_PATHS`.
+
+The package is installed automatically as a dependency of
+`escalated-django`. Wire it into your project's `settings.py`:
+
+```python
+# settings.py
+from escalated.locale_paths import get_locale_paths
+
+LOCALE_PATHS = get_locale_paths(
+    # Optional: your project's own override directory (highest priority)
+    BASE_DIR / "locale",
+)
+```
+
+`LOCALE_PATHS` is searched in order, so the layering becomes:
+
+1. Your project's `locale/` (if you passed one to `get_locale_paths`)
+2. The plugin-local `escalated/locale/` override directory
+3. The central `escalated_locale/locale/` baseline
+
+Translation contributions should be sent to
+[`escalated-locale`](https://github.com/escalated-dev/escalated-locale).
+The plugin-local `escalated/locale/` directory is reserved for
+Django-specific overrides that shouldn't ship to other framework
+plugins.
+
 ## Hosting Modes
 
 ### Self-Hosted (default)

--- a/escalated/locale_paths.py
+++ b/escalated/locale_paths.py
@@ -24,14 +24,13 @@ from __future__ import annotations
 
 import os
 from importlib import import_module
-from typing import List, Optional
 
 # Plugin-local override directory shipped with this package. Translators
 # can drop overrides in here to win over the central catalogues.
 PLUGIN_LOCALE_DIR: str = os.path.join(os.path.dirname(__file__), "locale")
 
 
-def get_central_locale_path() -> Optional[str]:
+def get_central_locale_path() -> str | None:
     """Return the absolute path to `escalated_locale/locale`, or None.
 
     Resolves the path lazily so a missing/unpublished `escalated-locale`
@@ -51,7 +50,7 @@ def get_central_locale_path() -> Optional[str]:
     return candidate if os.path.isdir(candidate) else None
 
 
-def get_locale_paths(*extra: str) -> List[str]:
+def get_locale_paths(*extra: str) -> list[str]:
     """Compose a Django-compatible `LOCALE_PATHS` tuple.
 
     Order (highest priority first):
@@ -62,7 +61,7 @@ def get_locale_paths(*extra: str) -> List[str]:
     The plugin-local directory is always included so existing overrides
     keep working even if the central package is not yet installed.
     """
-    paths: List[str] = [p for p in extra if p]
+    paths: list[str] = [p for p in extra if p]
     paths.append(PLUGIN_LOCALE_DIR)
 
     central = get_central_locale_path()

--- a/escalated/locale_paths.py
+++ b/escalated/locale_paths.py
@@ -1,0 +1,72 @@
+"""Helpers for wiring the central `escalated-locale` package into Django.
+
+The canonical translation source for the entire Escalated portfolio is
+the `escalated-locale` PyPI package. It is expected to ship both the
+canonical JSON catalogues and pre-compiled gettext artifacts at::
+
+    escalated_locale/locale/<lang>/LC_MESSAGES/django.po
+    escalated_locale/locale/<lang>/LC_MESSAGES/django.mo
+
+This module exposes those paths so host projects can compose Django's
+`LOCALE_PATHS` with the plugin-local override winning over the central
+package, e.g.::
+
+    # settings.py
+    from escalated.locale_paths import get_locale_paths
+
+    LOCALE_PATHS = get_locale_paths()
+
+`LOCALE_PATHS` is searched in order, so the plugin-local override comes
+first and the central package provides the baseline.
+"""
+
+from __future__ import annotations
+
+import os
+from importlib import import_module
+from typing import List, Optional
+
+# Plugin-local override directory shipped with this package. Translators
+# can drop overrides in here to win over the central catalogues.
+PLUGIN_LOCALE_DIR: str = os.path.join(os.path.dirname(__file__), "locale")
+
+
+def get_central_locale_path() -> Optional[str]:
+    """Return the absolute path to `escalated_locale/locale`, or None.
+
+    Resolves the path lazily so a missing/unpublished `escalated-locale`
+    package does not break import-time settings loading. Host projects
+    that need translations should ensure the package is installed.
+    """
+    try:
+        pkg = import_module("escalated_locale")
+    except ImportError:
+        return None
+
+    pkg_dir = os.path.dirname(getattr(pkg, "__file__", "") or "")
+    if not pkg_dir:
+        return None
+
+    candidate = os.path.join(pkg_dir, "locale")
+    return candidate if os.path.isdir(candidate) else None
+
+
+def get_locale_paths(*extra: str) -> List[str]:
+    """Compose a Django-compatible `LOCALE_PATHS` tuple.
+
+    Order (highest priority first):
+        1. Any caller-supplied `extra` paths
+        2. The plugin-local override at `escalated/locale/`
+        3. The central `escalated_locale/locale/` directory (if installed)
+
+    The plugin-local directory is always included so existing overrides
+    keep working even if the central package is not yet installed.
+    """
+    paths: List[str] = [p for p in extra if p]
+    paths.append(PLUGIN_LOCALE_DIR)
+
+    central = get_central_locale_path()
+    if central:
+        paths.append(central)
+
+    return paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ dependencies = [
     "django>=4.2",
     "inertia-django>=1.0",
     "requests>=2.28",
+    # Central translations distributed via PyPI. Ships canonical JSON plus
+    # pre-compiled gettext .po/.mo files at
+    # `escalated_locale/locale/{lang}/LC_MESSAGES/django.{po,mo}`, which we
+    # surface via `escalated.locale.get_central_locale_path()` so host
+    # projects can wire it into Django's LOCALE_PATHS.
+    "escalated-locale ~= 0.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # `escalated_locale/locale/{lang}/LC_MESSAGES/django.{po,mo}`, which we
     # surface via `escalated.locale.get_central_locale_path()` so host
     # projects can wire it into Django's LOCALE_PATHS.
-    "escalated-locale ~= 0.1",
+    "escalated-locale @ git+https://github.com/escalated-dev/escalated-locale.git@v0.1.1#subdirectory=packages/pypi",
 ]
 
 [project.optional-dependencies]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,12 @@
+from escalated.locale_paths import get_locale_paths
+
 DEBUG = True
 USE_TZ = True
+
+# Compose LOCALE_PATHS with the plugin-local override first (winning
+# priority) and the central `escalated-locale` package second. This
+# mirrors the wiring host projects are documented to use in the README.
+LOCALE_PATHS = get_locale_paths()
 
 DATABASES = {
     "default": {

--- a/tests/unit/test_locale_paths.py
+++ b/tests/unit/test_locale_paths.py
@@ -1,0 +1,44 @@
+"""Unit tests for `escalated.locale_paths`.
+
+These tests intentionally do not require the `escalated-locale` package
+to be installed — `get_central_locale_path()` returns None when it is
+absent, and `get_locale_paths()` should still surface the plugin-local
+override directory.
+"""
+
+import os
+
+from escalated import locale_paths
+
+
+def test_plugin_locale_dir_exists():
+    """The plugin-local override directory must always exist on disk."""
+    assert os.path.isdir(locale_paths.PLUGIN_LOCALE_DIR)
+
+
+def test_get_locale_paths_includes_plugin_local_dir():
+    paths = locale_paths.get_locale_paths()
+    assert locale_paths.PLUGIN_LOCALE_DIR in paths
+
+
+def test_get_locale_paths_extras_take_priority():
+    """Caller-supplied paths must come before the plugin-local override."""
+    extra = "/tmp/example-host-locale"
+    paths = locale_paths.get_locale_paths(extra)
+    assert paths[0] == extra
+    assert paths.index(extra) < paths.index(locale_paths.PLUGIN_LOCALE_DIR)
+
+
+def test_get_central_locale_path_handles_missing_package(monkeypatch):
+    """If `escalated_locale` cannot be imported, return None gracefully."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "escalated_locale":
+            raise ImportError("simulated missing package")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert locale_paths.get_central_locale_path() is None

--- a/tests/unit/test_locale_paths.py
+++ b/tests/unit/test_locale_paths.py
@@ -31,14 +31,14 @@ def test_get_locale_paths_extras_take_priority():
 
 def test_get_central_locale_path_handles_missing_package(monkeypatch):
     """If `escalated_locale` cannot be imported, return None gracefully."""
-    import builtins
+    import importlib
 
-    real_import = builtins.__import__
+    real_import_module = importlib.import_module
 
-    def fake_import(name, *args, **kwargs):
+    def fake_import_module(name, *args, **kwargs):
         if name == "escalated_locale":
             raise ImportError("simulated missing package")
-        return real_import(name, *args, **kwargs)
+        return real_import_module(name, *args, **kwargs)
 
-    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(locale_paths, "import_module", fake_import_module)
     assert locale_paths.get_central_locale_path() is None


### PR DESCRIPTION
## Summary

Wire `escalated-django` to consume translations from the new central
[`escalated-locale`](https://github.com/escalated-dev/escalated-locale)
PyPI package while keeping the plugin-local `escalated/locale/`
directory as a higher-priority override layer.

- Add `escalated-locale ~= 0.1` to `pyproject.toml` runtime deps.
- New helper `escalated.locale_paths.get_locale_paths()` composes a
  `LOCALE_PATHS`-compatible list with caller-supplied extras first,
  the plugin-local override next, and the central package last.
- Wire the helper into `tests/settings.py` so CI exercises the
  override + central layering.
- Document the wiring + override semantics in README and CHANGELOG.
- Unit tests cover composition + graceful degradation when the
  central package is not yet installed.

## Assumption flagged for `escalated-locale`

The central package **must ship pre-compiled gettext artifacts** at:

```
escalated_locale/locale/<lang>/LC_MESSAGES/django.po
escalated_locale/locale/<lang>/LC_MESSAGES/django.mo
```

These are required for Django's gettext-based translation system to
pick the catalogues up via `LOCALE_PATHS`. The canonical JSON shipped
by the central repo is not directly consumable by Django, so the
package's build step needs to also emit `.po`/`.mo` files (e.g. via
`msgfmt` during the wheel build). If `escalated-locale` chooses a
different layout, this PR's `escalated/locale_paths.py::get_central_locale_path`
will need a small tweak to point at the actual subdirectory.

## Blocked on `escalated-locale` v0.1.0 PyPI publish

**Expected CI failure:** `pip install -e ".[dev]"` will fail in CI
with a `Could not find a version that satisfies the requirement
escalated-locale ~= 0.1` error until the central package is
published to PyPI. Marking this PR as draft until that lands.

Once `escalated-locale 0.1.0` is published with the .po/.mo layout
above, CI should go green without further changes here.

## Test plan

- [x] `pytest tests/unit/test_locale_paths.py` passes locally (4/4).
- [ ] Full CI run after `escalated-locale 0.1.0` publishes — expect
      green.
- [ ] Smoke check: in a host project, install both packages, set
      `LANGUAGE_CODE = "fr"`, and confirm a translated string from the
      central package renders. Then drop a same-key override into
      `escalated/locale/fr/LC_MESSAGES/django.po` and confirm it wins.

## Files changed

- `pyproject.toml` — add `escalated-locale ~= 0.1`
- `escalated/locale_paths.py` — new helper module
- `tests/settings.py` — wire `LOCALE_PATHS = get_locale_paths()`
- `tests/unit/test_locale_paths.py` — coverage for the helper
- `README.md` — new "Translations (i18n)" section
- `CHANGELOG.md` — Unreleased entry