### PR TITLE
feat(tickets): custom ticket actions via signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,49 @@ python manage.py purge_activities --days 90
 
 Schedule these with cron, Celery Beat, or django-crontab for automated enforcement.
 
+## Custom Ticket Actions
+
+Host projects can add custom buttons to the agent ticket screen and handle clicks
+with a normal Django signal receiver. Register actions in settings:
+
+```python
+# settings.py
+ESCALATED = {
+    # ...
+    "TICKET_ACTIONS": [
+        {
+            "key": "sync-crm",
+            "label": "Sync CRM",
+            "variant": "primary",                # primary | secondary | danger
+            "confirmation": "Sync this ticket to the CRM?",
+            "metadata": {"icon": "refresh-cw"},
+            # visible / enabled may be a bool or a callable(ticket, user)
+            "enabled": lambda ticket, user: not ticket.metadata.get("crm_synced"),
+        },
+    ],
+}
+```
+
+Visible actions are exposed on the agent ticket page as `customActions` and on the
+API ticket detail response as `custom_actions` (each with a `url` and `method`).
+Triggering one (`POST /support/agent/tickets/<id>/actions/<key>/` or the API route
+`/<prefix>/tickets/<reference>/actions/<key>/`) validates the action is visible
+(404) and enabled (403), then sends the `custom_action_triggered` signal:
+
+```python
+from django.dispatch import receiver
+from escalated.signals import custom_action_triggered
+
+@receiver(custom_action_triggered)
+def on_custom_action(sender, ticket, user, action_key, payload, metadata, **kwargs):
+    if action_key != "sync-crm":
+        return
+    # your handler
+```
+
+Escalated also records an internal note on the ticket whenever an action fires,
+for auditability.
+
 ## Routes
 
 All routes use the configurable prefix (default: `support`).

--- a/escalated/action_registry.py
+++ b/escalated/action_registry.py
@@ -1,0 +1,89 @@
+"""
+Custom ticket action registry.
+
+Host projects register actions via the ``ESCALATED["TICKET_ACTIONS"]`` setting
+(a list of action config dicts). Each visible action renders as a button on the
+agent ticket screen; triggering it sends the ``custom_action_triggered`` signal
+so the host can handle the work in a normal receiver.
+
+Action config shape (all but ``key``/``label`` optional)::
+
+    {
+        "key": "sync-crm",                 # required, stable id
+        "label": "Sync CRM",               # required
+        "variant": "primary",              # primary | secondary | danger
+        "visible": True,                   # bool or callable(ticket, user)
+        "enabled": True,                   # bool or callable(ticket, user)
+        "confirmation": "Are you sure?",   # str/None or callable
+        "metadata": {"icon": "refresh-cw"}, # dict or callable
+    }
+
+Mirrors the Laravel TicketActionRegistry / NestJS reference.
+"""
+
+
+def _resolve(value, ticket, user):
+    """Resolve a value that may be static or a callable(ticket, user)."""
+    return value(ticket, user) if callable(value) else value
+
+
+class TicketActionRegistry:
+    def __init__(self):
+        self._actions = {}
+
+    def register(self, config):
+        key = config.get("key")
+        label = config.get("label")
+        if not key or not label:
+            raise ValueError('Ticket actions require both "key" and "label".')
+        self._actions[key] = config
+
+    def clear(self):
+        self._actions = {}
+
+    def find(self, key):
+        return self._actions.get(key)
+
+    def is_visible(self, config, ticket, user):
+        return bool(_resolve(config.get("visible", True), ticket, user))
+
+    def is_enabled(self, config, ticket, user):
+        return bool(_resolve(config.get("enabled", True), ticket, user))
+
+    def metadata(self, config, ticket, user):
+        value = _resolve(config.get("metadata", {}), ticket, user)
+        return value if isinstance(value, dict) else {}
+
+    def visible_for(self, ticket, user):
+        """
+        Return the visible actions for a ticket/user, serialized for the UI.
+        The view adds the ``url`` and ``method`` before sending to the client.
+        """
+        result = []
+        for config in self._actions.values():
+            if not self.is_visible(config, ticket, user):
+                continue
+            confirmation = _resolve(config.get("confirmation"), ticket, user)
+            result.append(
+                {
+                    "key": config["key"],
+                    "label": str(_resolve(config["label"], ticket, user)),
+                    "variant": config.get("variant", "secondary"),
+                    "confirmation": None if confirmation is None else str(confirmation),
+                    "disabled": not self.is_enabled(config, ticket, user),
+                    "metadata": self.metadata(config, ticket, user),
+                }
+            )
+        return result
+
+    def load_from_settings(self):
+        """(Re)populate the registry from the ``TICKET_ACTIONS`` setting."""
+        from escalated.conf import get_setting
+
+        self.clear()
+        for config in get_setting("TICKET_ACTIONS") or []:
+            self.register(config)
+
+
+# Module-level singleton.
+registry = TicketActionRegistry()

--- a/escalated/api_urls.py
+++ b/escalated/api_urls.py
@@ -28,6 +28,11 @@ api_patterns = [
     path("tickets/<str:reference>/assign/", api.ticket_assign, name="ticket_assign"),
     path("tickets/<str:reference>/follow/", api.ticket_follow, name="ticket_follow"),
     path("tickets/<str:reference>/macro/", api.ticket_apply_macro, name="ticket_macro"),
+    path(
+        "tickets/<str:reference>/actions/<str:action>/",
+        api.ticket_custom_action,
+        name="ticket_custom_action",
+    ),
     path("tickets/<str:reference>/tags/", api.ticket_tags, name="ticket_tags"),
     path("tickets/<str:reference>/delete/", api.ticket_destroy, name="ticket_destroy"),
     # Resources

--- a/escalated/apps.py
+++ b/escalated/apps.py
@@ -15,8 +15,20 @@ class EscalatedConfig(AppConfig):
         import escalated.handlers  # noqa: F401 - connects signal handlers
         import escalated.workflow_handlers  # noqa: F401 - connects WorkflowEngine to signals
 
+        # Populate the custom ticket action registry from settings.
+        self._load_ticket_actions()
+
         # Load active plugins on startup
         self._load_plugins()
+
+    def _load_ticket_actions(self):
+        """Populate the custom ticket action registry from ESCALATED settings."""
+        try:
+            from escalated.action_registry import registry
+
+            registry.load_from_settings()
+        except Exception as exc:
+            logger.debug("Could not load custom ticket actions on startup: %s", exc)
 
         # Boot the SDK plugin bridge (Node.js runtime) if enabled
         self._boot_bridge()

--- a/escalated/conf.py
+++ b/escalated/conf.py
@@ -16,6 +16,11 @@ DEFAULTS = {
     "MAX_ATTACHMENTS": 5,
     "MAX_ATTACHMENT_SIZE_KB": 10240,
     "DEFAULT_PRIORITY": "medium",
+    # Host-defined custom ticket actions. A list of action config dicts:
+    #   {"key", "label", "variant", "visible", "enabled", "confirmation", "metadata"}
+    # where visible/enabled/confirmation/metadata may be values or callables
+    # taking (ticket, user).
+    "TICKET_ACTIONS": [],
     "SLA": {
         "ENABLED": True,
         "BUSINESS_HOURS_ONLY": False,

--- a/escalated/handlers.py
+++ b/escalated/handlers.py
@@ -4,6 +4,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from escalated.signals import (
+    custom_action_triggered,
     reply_created,
     sla_breached,
     ticket_assigned,
@@ -349,5 +350,35 @@ def on_ticket_priority_changed(sender, ticket, user, old_priority, new_priority,
             "old_priority": old_priority,
             "new_priority": new_priority,
             "user_id": getattr(user, "pk", None),
+        },
+    )
+
+
+@receiver(custom_action_triggered)
+def on_custom_action_triggered(sender, ticket, user, action_key, payload=None, metadata=None, **kwargs):
+    """Record an internal note whenever a custom ticket action is triggered.
+
+    Gives an audit trail of who ran which action. The note is authored by the
+    triggering agent, so the body need not repeat their name.
+    """
+    if ImportContext.is_importing():
+        return
+
+    from escalated.services.ticket_service import TicketService
+
+    TicketService().add_note(ticket, user, f'Custom action "{action_key}" was triggered.')
+
+    logger.info(f"Custom action '{action_key}' triggered on ticket {ticket.reference} by {user}")
+
+    # Dual dispatch to SDK plugin bridge
+    _bridge_dispatch(
+        "ticket.custom_action_triggered",
+        {
+            "ticket_id": ticket.pk,
+            "reference": ticket.reference,
+            "action": action_key,
+            "user_id": getattr(user, "pk", None),
+            "payload": payload or {},
+            "metadata": metadata or {},
         },
     )

--- a/escalated/signals.py
+++ b/escalated/signals.py
@@ -27,6 +27,9 @@ tag_removed = django.dispatch.Signal()  # sender=Tag, tag, ticket, user
 # Department signals
 department_changed = django.dispatch.Signal()  # sender=Ticket, ticket, user, old_department, new_department
 
+# Custom ticket action signals
+custom_action_triggered = django.dispatch.Signal()  # sender=Ticket, ticket, user, action_key, payload, metadata
+
 # Live Chat signals
 chat_started = django.dispatch.Signal()  # sender=ChatSession, session, ticket
 chat_message_sent = django.dispatch.Signal()  # sender=ChatSession, session, ticket, message, sender_type

--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -46,6 +46,11 @@ agent_patterns = [
     path("agent/tickets/<int:ticket_id>/tags/", agent.ticket_tags, name="agent_ticket_tags"),
     path("agent/tickets/<int:ticket_id>/department/", agent.ticket_department, name="agent_ticket_department"),
     path("agent/tickets/<int:ticket_id>/macro/", agent.ticket_apply_macro, name="agent_ticket_macro"),
+    path(
+        "agent/tickets/<int:ticket_id>/actions/<str:action>/",
+        agent.ticket_custom_action,
+        name="agent_ticket_custom_action",
+    ),
     path("agent/tickets/<int:ticket_id>/follow/", agent.ticket_follow, name="agent_ticket_follow"),
     path("agent/tickets/<int:ticket_id>/presence/", agent.ticket_presence, name="agent_ticket_presence"),
     path("agent/tickets/<int:ticket_id>/<int:reply_id>/pin/", agent.ticket_pin_reply, name="agent_ticket_pin"),

--- a/escalated/views/agent.py
+++ b/escalated/views/agent.py
@@ -234,6 +234,7 @@ def ticket_show(request, ticket_id):
         "Escalated/Agent/Tickets/Show",
         props={
             "ticket": TicketSerializer.serialize(ticket, include_replies=True, include_activities=True),
+            "customActions": _custom_actions_for(request, ticket),
             "replies": ReplySerializer.serialize_list(replies),
             "activities": [ActivitySerializer.serialize(a) for a in activities],
             "attachments": AttachmentSerializer.serialize_list(ticket.attachments.all()),
@@ -584,6 +585,67 @@ def ticket_apply_macro(request, ticket_id):
 
     macro_service = MacroService()
     macro_service.apply(macro, ticket, request.user)
+
+    return redirect("escalated:agent_ticket_show", ticket_id=ticket_id)
+
+
+def _custom_actions_for(request, ticket):
+    """Serialize the visible custom actions for a ticket, adding url + method."""
+    from django.urls import reverse
+
+    from escalated.action_registry import registry
+
+    result = []
+    for action in registry.visible_for(ticket, request.user):
+        result.append(
+            {
+                **action,
+                "url": reverse("escalated:agent_ticket_custom_action", args=[ticket.pk, action["key"]]),
+                "method": "post",
+            }
+        )
+    return result
+
+
+@login_required
+def ticket_custom_action(request, ticket_id, action):
+    """Trigger a host-defined custom ticket action."""
+    check = _require_agent(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        ticket = Ticket.objects.get(pk=ticket_id)
+    except Ticket.DoesNotExist:
+        return HttpResponseNotFound(_("Ticket not found"))
+
+    from escalated.action_registry import registry
+    from escalated.signals import custom_action_triggered
+
+    config = registry.find(action)
+    if config is None or not registry.is_visible(config, ticket, request.user):
+        return HttpResponseNotFound(_("Custom action not found"))
+    if not registry.is_enabled(config, ticket, request.user):
+        return HttpResponseForbidden(_("Custom action is not enabled"))
+
+    try:
+        payload = (json.loads(request.body or "{}") or {}).get("payload") or {}
+    except (ValueError, TypeError):
+        payload = {}
+    if not payload:
+        payload = request.POST.get("payload") or {}
+
+    custom_action_triggered.send(
+        sender=Ticket,
+        ticket=ticket,
+        user=request.user,
+        action_key=action,
+        payload=payload,
+        metadata=registry.metadata(config, ticket, request.user),
+    )
 
     return redirect("escalated:agent_ticket_show", ticket_id=ticket_id)
 

--- a/escalated/views/api.py
+++ b/escalated/views/api.py
@@ -12,6 +12,7 @@ from django.contrib.auth import get_user_model
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.http import JsonResponse
+from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
@@ -321,11 +322,10 @@ def ticket_show(request, reference):
     if error:
         return error
 
-    return JsonResponse(
-        {
-            "data": ApiTicketDetailSerializer.serialize(ticket),
-        }
-    )
+    data = ApiTicketDetailSerializer.serialize(ticket)
+    data["custom_actions"] = _custom_actions_for(request, ticket)
+
+    return JsonResponse({"data": data})
 
 
 @csrf_exempt
@@ -552,6 +552,58 @@ def ticket_apply_macro(request, reference):
     macro_service.apply(macro, ticket, request.user)
 
     return JsonResponse({"message": f'Macro "{macro.name}" applied.'})
+
+
+def _custom_actions_for(request, ticket):
+    """Serialize the visible custom actions for a ticket, adding url + method."""
+    from escalated.action_registry import registry
+
+    result = []
+    for action in registry.visible_for(ticket, getattr(request, "user", None)):
+        try:
+            url = reverse("escalated_api:ticket_custom_action", args=[ticket.reference, action["key"]])
+        except NoReverseMatch:
+            url = f"tickets/{ticket.reference}/actions/{action['key']}/"
+        result.append({**action, "url": url, "method": "post"})
+    return result
+
+
+@csrf_exempt
+@require_POST
+def ticket_custom_action(request, reference, action):
+    """
+    POST /tickets/<reference>/actions/<action>
+
+    Trigger a host-defined custom ticket action. 404 if the action is unknown
+    or not visible, 403 if it is disabled, otherwise sends the
+    ``custom_action_triggered`` signal.
+    """
+    from escalated.action_registry import registry
+    from escalated.signals import custom_action_triggered
+
+    ticket, error = _resolve_ticket(reference)
+    if error:
+        return error
+
+    config = registry.find(action)
+    if config is None or not registry.is_visible(config, ticket, request.user):
+        return JsonResponse({"message": "Custom action not found."}, status=404)
+    if not registry.is_enabled(config, ticket, request.user):
+        return JsonResponse({"message": "Custom action is not enabled."}, status=403)
+
+    payload = _json_body(request).get("payload") or {}
+    metadata = registry.metadata(config, ticket, request.user)
+
+    custom_action_triggered.send(
+        sender=Ticket,
+        ticket=ticket,
+        user=request.user,
+        action_key=action,
+        payload=payload,
+        metadata=metadata,
+    )
+
+    return JsonResponse({"message": "Custom action dispatched.", "action": action})
 
 
 @csrf_exempt

--- a/tests/integration/test_custom_ticket_actions.py
+++ b/tests/integration/test_custom_ticket_actions.py
@@ -1,0 +1,114 @@
+"""Integration tests for custom ticket actions (host-defined action buttons)."""
+
+import json
+
+import pytest
+
+from escalated.action_registry import registry
+from escalated.signals import custom_action_triggered
+from escalated.views import api
+
+from ..factories import ApiTokenFactory, DepartmentFactory, TicketFactory, UserFactory
+
+
+def _api_post(rf, path, user, api_token, data=None):
+    request = rf.post(path, data=json.dumps(data or {}), content_type="application/json")
+    request.user = user
+    request.api_token = api_token
+    return request
+
+
+def _api_get(rf, path, user, api_token):
+    request = rf.get(path)
+    request.user = user
+    request.api_token = api_token
+    return request
+
+
+@pytest.fixture
+def agent_user():
+    user = UserFactory(username="custom_action_agent")
+    department = DepartmentFactory()
+    department.agents.add(user)
+    return user
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+@pytest.mark.django_db
+class TestCustomTicketActions:
+    def test_detail_response_exposes_visible_actions(self, rf, agent_user):
+        registry.register({"key": "sync-crm", "label": "Sync CRM", "variant": "primary"})
+        token = ApiTokenFactory(user=agent_user, abilities=["agent"])
+        ticket = TicketFactory(requester=agent_user)
+
+        request = _api_get(rf, f"/api/tickets/{ticket.reference}/", agent_user, token)
+        response = api.ticket_show(request, ticket.reference)
+
+        assert response.status_code == 200
+        actions = json.loads(response.content)["data"]["custom_actions"]
+        assert len(actions) == 1
+        assert actions[0]["key"] == "sync-crm"
+        assert actions[0]["method"] == "post"
+        assert "/actions/sync-crm" in actions[0]["url"]
+
+    def test_trigger_sends_signal(self, rf, agent_user):
+        registry.register({"key": "sync-crm", "label": "Sync CRM"})
+        token = ApiTokenFactory(user=agent_user, abilities=["agent"])
+        ticket = TicketFactory(requester=agent_user)
+
+        received = []
+
+        def _receiver(sender, **kwargs):
+            received.append(kwargs)
+
+        custom_action_triggered.connect(_receiver, weak=False)
+        try:
+            request = _api_post(
+                rf,
+                f"/api/tickets/{ticket.reference}/actions/sync-crm/",
+                agent_user,
+                token,
+                {"payload": {"force": True}},
+            )
+            response = api.ticket_custom_action(request, ticket.reference, "sync-crm")
+        finally:
+            custom_action_triggered.disconnect(_receiver)
+
+        assert response.status_code == 200
+        assert len(received) == 1
+        assert received[0]["action_key"] == "sync-crm"
+        assert received[0]["payload"] == {"force": True}
+
+    def test_unknown_action_returns_404(self, rf, agent_user):
+        token = ApiTokenFactory(user=agent_user, abilities=["agent"])
+        ticket = TicketFactory(requester=agent_user)
+
+        request = _api_post(rf, f"/api/tickets/{ticket.reference}/actions/nope/", agent_user, token)
+        response = api.ticket_custom_action(request, ticket.reference, "nope")
+
+        assert response.status_code == 404
+
+    def test_disabled_action_returns_403(self, rf, agent_user):
+        registry.register({"key": "sync-crm", "label": "Sync CRM", "enabled": False})
+        token = ApiTokenFactory(user=agent_user, abilities=["agent"])
+        ticket = TicketFactory(requester=agent_user)
+
+        request = _api_post(rf, f"/api/tickets/{ticket.reference}/actions/sync-crm/", agent_user, token)
+        response = api.ticket_custom_action(request, ticket.reference, "sync-crm")
+
+        assert response.status_code == 403
+
+    def test_registry_visible_for_filters_and_marks_disabled(self):
+        registry.register({"key": "hidden", "label": "Hidden", "visible": False})
+        registry.register({"key": "locked", "label": "Locked", "enabled": False})
+
+        actions = registry.visible_for(ticket=object(), user=object())
+
+        assert [a["key"] for a in actions] == ["locked"]
+        assert actions[0]["disabled"] is True


### PR DESCRIPTION
Ports the **Custom Ticket Actions** feature to the Django package. Backend counterpart to escalated-laravel#107 (reference: escalated-nestjs#57); shared frontend in escalated-dev/escalated#82.

## What
Host projects register actions in `ESCALATED["TICKET_ACTIONS"]`:

```python
ESCALATED = {"TICKET_ACTIONS": [
    {"key": "sync-crm", "label": "Sync CRM", "variant": "primary",
     "confirmation": "Sync this ticket to the CRM?", "metadata": {"icon": "refresh-cw"},
     "enabled": lambda ticket, user: not ticket.metadata.get("crm_synced")},
]}
```

`visible`/`enabled`/`confirmation`/`metadata` may be values or `callable(ticket, user)`. Visible actions appear on the agent page as `customActions` and on the API detail response as `custom_actions` (each with `url` + `method`).

## Pieces
- `action_registry.TicketActionRegistry` — singleton, populated from settings in `AppConfig.ready()`.
- `custom_action_triggered` signal + handler in `handlers.py` (records an internal note).
- **Agent** endpoint `POST /support/agent/tickets/<id>/actions/<key>/` (+ `customActions` Inertia prop) and **API** endpoint `POST /<prefix>/tickets/<reference>/actions/<key>/` (+ `custom_actions` in detail). Both 404 not-visible / 403 disabled.
- `TICKET_ACTIONS` setting default in `conf.py`.
- README "Custom Ticket Actions" section.

## Testing
- `ruff check` + `ruff format --check` — clean
- `pytest` — new `test_custom_ticket_actions.py` (5 tests) pass; existing `test_api_views.py` (38) still pass — no regression.