### PR TITLE
fix(users): support UUID/string host user keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,17 @@ ESCALATED = {
 }
 ```
 
+### UUID / string user keys
+
+Escalated works with any `AUTH_USER_MODEL` primary key type — integer, UUID, or
+string. References to your users via `ForeignKey(AUTH_USER_MODEL)` (assignee,
+follower, author, etc.) already match your user PK automatically. The remaining
+host-user references — `Contact.user_id` and the generic-relation `object_id`
+columns for ticket requester, activity causer, satisfaction `rated_by`, and API
+token owner — are stored as `CharField`, so they hold an integer id (as its
+string form) or a UUID/string id transparently. No configuration is required;
+just run migrations.
+
 ## Management Commands
 
 ```bash

--- a/escalated/drivers/local.py
+++ b/escalated/drivers/local.py
@@ -199,7 +199,7 @@ class LocalDriver:
         # Update ticket status based on who is replying
         if not is_internal and user is not None:
             ct = ContentType.objects.get_for_model(user)
-            is_requester = ticket.requester_content_type == ct and ticket.requester_object_id == user.pk
+            is_requester = ticket.requester_content_type == ct and str(ticket.requester_object_id) == str(user.pk)
 
             if is_requester:
                 if ticket.status == Ticket.Status.WAITING_ON_CUSTOMER:

--- a/escalated/migrations/0023_host_user_id_string_keys.py
+++ b/escalated/migrations/0023_host_user_id_string_keys.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("escalated", "0022_skills_management_routing"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="contact",
+            name="user_id",
+            field=models.CharField(
+                blank=True,
+                help_text="Linked host-app user id once the contact creates an account",
+                max_length=255,
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="ticket",
+            name="requester_object_id",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name="ticketactivity",
+            name="causer_object_id",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name="satisfactionrating",
+            name="rated_by_object_id",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name="apitoken",
+            name="tokenable_object_id",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+    ]

--- a/escalated/models.py
+++ b/escalated/models.py
@@ -202,7 +202,8 @@ class Contact(models.Model):
 
     email = models.EmailField(unique=True, max_length=320)
     name = models.CharField(max_length=255, null=True, blank=True)
-    user_id = models.PositiveIntegerField(
+    user_id = models.CharField(
+        max_length=255,
         null=True,
         blank=True,
         help_text=_("Linked host-app user id once the contact creates an account"),
@@ -234,12 +235,12 @@ class Contact(models.Model):
             return existing
         return cls.objects.create(email=normalized, name=name)
 
-    def link_to_user(self, user_id: int) -> "Contact":
+    def link_to_user(self, user_id: str | int) -> "Contact":
         self.user_id = user_id
         self.save(update_fields=["user_id", "updated_at"])
         return self
 
-    def promote_to_user(self, user_id: int, user_type_model: str = "auth.User") -> "Contact":
+    def promote_to_user(self, user_id: str | int, user_type_model: str = "auth.User") -> "Contact":
         """Link + back-stamp requester on all prior tickets owned by this Contact."""
         self.link_to_user(user_id)
         app_label, model_name = user_type_model.split(".", 1)
@@ -283,7 +284,7 @@ class Ticket(models.Model):
         blank=True,
         related_name="escalated_requester_tickets",
     )
-    requester_object_id = models.PositiveIntegerField(null=True, blank=True)
+    requester_object_id = models.CharField(max_length=255, null=True, blank=True)
     requester = GenericForeignKey("requester_content_type", "requester_object_id")
 
     assigned_to = models.ForeignKey(
@@ -709,7 +710,7 @@ class TicketActivity(models.Model):
         blank=True,
         related_name="escalated_activities",
     )
-    causer_object_id = models.PositiveIntegerField(null=True, blank=True)
+    causer_object_id = models.CharField(max_length=255, null=True, blank=True)
     causer = GenericForeignKey("causer_content_type", "causer_object_id")
 
     type = models.CharField(max_length=30, choices=ActivityType.choices)
@@ -857,7 +858,7 @@ class SatisfactionRating(models.Model):
         blank=True,
         related_name="escalated_satisfaction_ratings",
     )
-    rated_by_object_id = models.PositiveIntegerField(null=True, blank=True)
+    rated_by_object_id = models.CharField(max_length=255, null=True, blank=True)
     rated_by = GenericForeignKey("rated_by_content_type", "rated_by_object_id")
 
     created_at = models.DateTimeField(auto_now_add=True)
@@ -991,7 +992,7 @@ class ApiToken(models.Model):
         blank=True,
         related_name="escalated_api_tokens",
     )
-    tokenable_object_id = models.PositiveIntegerField(null=True, blank=True)
+    tokenable_object_id = models.CharField(max_length=255, null=True, blank=True)
     tokenable = GenericForeignKey("tokenable_content_type", "tokenable_object_id")
 
     name = models.CharField(max_length=255)

--- a/escalated/permissions.py
+++ b/escalated/permissions.py
@@ -39,7 +39,7 @@ def can_view_ticket(user, ticket):
 
     # Check if user is the requester
     ct = ContentType.objects.get_for_model(user)
-    if ticket.requester_content_type == ct and ticket.requester_object_id == user.pk:
+    if ticket.requester_content_type == ct and str(ticket.requester_object_id) == str(user.pk):
         return True
 
     # Check if user is the assigned agent
@@ -90,7 +90,7 @@ def can_reply_ticket(user, ticket):
 
     # Requester can reply
     ct = ContentType.objects.get_for_model(user)
-    if ticket.requester_content_type == ct and ticket.requester_object_id == user.pk:
+    if ticket.requester_content_type == ct and str(ticket.requester_object_id) == str(user.pk):
         return True
 
     if is_agent(user):
@@ -124,7 +124,7 @@ def can_close_ticket(user, ticket):
 
     if get_setting("ALLOW_CUSTOMER_CLOSE"):
         ct = ContentType.objects.get_for_model(user)
-        if ticket.requester_content_type == ct and ticket.requester_object_id == user.pk:
+        if ticket.requester_content_type == ct and str(ticket.requester_object_id) == str(user.pk):
             return True
 
     return False

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -3838,7 +3838,7 @@ def settings_public_tickets(request):
         props={
             "settings": {
                 "guest_policy_mode": _get("guest_policy_mode", "unassigned"),
-                "guest_policy_user_id": int(user_id_raw) if user_id_raw.isdigit() else None,
+                "guest_policy_user_id": user_id_raw or None,
                 "guest_policy_signup_url_template": _get("guest_policy_signup_url_template", ""),
             }
         },

--- a/escalated/views/admin_api_tokens.py
+++ b/escalated/views/admin_api_tokens.py
@@ -103,7 +103,7 @@ def api_tokens_create(request):
         )
 
     try:
-        user = User.objects.get(pk=int(user_id))
+        user = User.objects.get(pk=user_id)
     except (User.DoesNotExist, ValueError, TypeError):
         return JsonResponse({"message": "User not found."}, status=404)
 

--- a/escalated/views/customer.py
+++ b/escalated/views/customer.py
@@ -231,7 +231,7 @@ def ticket_reopen(request, ticket_id):
         return HttpResponseNotFound(_("Ticket not found"))
 
     ct = ContentType.objects.get_for_model(request.user)
-    is_requester = ticket.requester_content_type == ct and ticket.requester_object_id == request.user.pk
+    is_requester = ticket.requester_content_type == ct and str(ticket.requester_object_id) == str(request.user.pk)
     if not is_requester:
         return HttpResponseForbidden(_("You cannot reopen this ticket."))
 

--- a/tests/test_uuid_user_keys.py
+++ b/tests/test_uuid_user_keys.py
@@ -1,0 +1,34 @@
+import pytest
+
+from escalated.models import Contact
+from tests.factories import ContactFactory, TicketFactory
+
+
+@pytest.mark.django_db
+class TestUuidUserKeys:
+    def test_contact_user_id_persists_string(self):
+        contact = ContactFactory(user_id=None)
+        uuid_user_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        contact.user_id = uuid_user_id
+        contact.save(update_fields=["user_id", "updated_at"])
+        contact.refresh_from_db()
+        assert contact.user_id == uuid_user_id
+        assert isinstance(contact.user_id, str)
+
+    def test_ticket_requester_object_id_persists_string(self):
+        ticket = TicketFactory()
+        string_requester_id = "host-user-uuid-42"
+        ticket.requester_object_id = string_requester_id
+        ticket.save(update_fields=["requester_object_id"])
+        ticket.refresh_from_db()
+        assert ticket.requester_object_id == string_requester_id
+        assert isinstance(ticket.requester_object_id, str)
+
+    def test_contact_create_with_string_user_id(self):
+        contact = Contact.objects.create(
+            email="uuid-link@example.com",
+            user_id="550e8400-e29b-41d4-a716-446655440000",
+            metadata={},
+        )
+        contact.refresh_from_db()
+        assert contact.user_id == "550e8400-e29b-41d4-a716-446655440000"

--- a/tests/unit/test_contact_model.py
+++ b/tests/unit/test_contact_model.py
@@ -55,7 +55,7 @@ class TestLinkToUser:
         c = ContactFactory(user_id=None)
         c.link_to_user(555)
         c.refresh_from_db()
-        assert c.user_id == 555
+        assert c.user_id == "555"
 
 
 @pytest.mark.django_db
@@ -70,10 +70,10 @@ class TestPromoteToUser:
         contact.promote_to_user(user.id, "auth.User")
 
         contact.refresh_from_db()
-        assert contact.user_id == user.id
+        assert contact.user_id == str(user.id)
         for t in (t1, t2):
             t.refresh_from_db()
-            assert t.requester_object_id == user.id
+            assert t.requester_object_id == str(user.id)
             assert t.requester_content_type_id == user_ct.id
 
 

--- a/tests/unit/test_widget.py
+++ b/tests/unit/test_widget.py
@@ -222,7 +222,7 @@ class TestWidgetCreateTicket:
         )
         assert response.status_code == 200
         ticket = Ticket.objects.get(reference=response.json()["ticket"]["reference"])
-        assert ticket.requester_object_id == shared.pk
+        assert ticket.requester_object_id == str(shared.pk)
         assert ticket.requester_content_type_id == ContentType.objects.get_for_model(User).id
         # Agents still see who actually submitted via guest_email:
         assert ticket.guest_email == "bob@example.com"


### PR DESCRIPTION
Django is only **partially** affected by the integer-user-id assumption. Most host-user references use `ForeignKey(settings.AUTH_USER_MODEL)`, which Django automatically types to match the host user PK — those were already correct and are left untouched. The bug was in the few places that stored a host user id as a hardcoded `PositiveIntegerField`, plus two `int()` casts. This fixes those so the package works with integer **and** UUID/string `AUTH_USER_MODEL` primary keys.

Mirrors the intent of the fix merged for Laravel/NestJS.

## Changes

- `Contact.user_id` and the generic-relation `object_id` columns `Ticket.requester_object_id`, `TicketActivity.causer_object_id`, `SatisfactionRating.rated_by_object_id`, `ApiToken.tokenable_object_id`: `PositiveIntegerField` → `CharField(max_length=255)` (the standard Django pattern for a `GenericForeignKey` that must support UUID/string PKs; still holds integer ids as their string form).
- Removed `int()` casts on host user ids in `views/admin.py` (guest-policy user id) and `views/admin_api_tokens.py` (token owner lookup).
- `Contact.link_to_user` / `promote_to_user` type hints widened to `str | int`.
- New migration `0023_host_user_id_string_keys` (AlterField for the 5 columns).
- Because `CharField` stores integer PKs as `"1"`, three requester-identity comparisons (`permissions.py`, `views/customer.py`, `drivers/local.py`) now compare with `str(...)` on both sides so they work for integer and UUID hosts alike.

## Backward compatibility

For integer-keyed hosts the migration converts the columns to string and the comparisons use `str()`, so behavior is preserved (an id of `1` matches whether stored as `1` or `"1"`). `AUTH_USER_MODEL` ForeignKeys are unchanged.

## Tests

- New `tests/test_uuid_user_keys.py` (string `Contact.user_id` + `Ticket.requester_object_id` round-trip).
- Full suite: **748 passed** (`pytest`), `ruff` clean. Independently re-run locally on Django 6.0.3 / Python 3.12 — 748 passed. (The pre-existing `makemigrations --check` drift on the `Mention` model and the `AppConfig.ready()` DB-access RuntimeWarning are unrelated to this PR.)
