### PR TITLE
feat(tickets): ticket subjects (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,62 @@ token owner — are stored as `CharField`, so they hold an integer id (as its
 string form) or a UUID/string id transparently. No configuration is required;
 just run migrations.
 
+### Ticket subjects
+
+A ticket has a **requester** (who raised it) and a **subject line** (free text).
+You can also attach host-app entities the ticket is *about* — a project, customer,
+or asset — so agents see context and can jump back into your app.
+
+Implement the presentation contract on any model (or use the mixin for defaults):
+
+```python
+from django.db import models
+
+from escalated.contracts import TicketSubjectMixin
+
+
+class Project(models.Model, TicketSubjectMixin):
+    name = models.CharField(max_length=255)
+
+    def ticket_subject_subtitle(self):
+        return f"Project · {self.customer.name}"
+
+    def ticket_subject_url(self):
+        return reverse("projects:detail", args=[self.pk])
+```
+
+Attach, detach, or replace subjects on a ticket:
+
+```python
+ticket.attach_subject(project, role="project")
+ticket.attach_subject(customer, role="account")
+ticket.sync_subjects([project, (customer, "account")])
+ticket.detach_subject(project)
+```
+
+Each link is serialized on the ticket as
+`{ type, id, role, title, subtitle, url, color, icon, missing }`.
+`object_id` is stored as a string so integer, UUID, and string primary keys all work.
+
+To allow attaching via the agent or REST API (and block arbitrary model resolution),
+list permitted models in settings:
+
+```python
+ESCALATED = {
+    # ...
+    "TICKET_SUBJECT_TYPES": [
+        "myapp.Project",
+        "myapp.Customer",
+    ],
+},
+```
+
+Leave `TICKET_SUBJECT_TYPES` empty to disable API attach; programmatic
+`attach_subject()` still works for any model when the allowlist is empty.
+
+Agent/admin routes: `POST /…/tickets/<id>/subjects`, `DELETE /…/tickets/<id>/subjects/<link_id>`.
+REST API: `POST /tickets/<reference>/subjects`, `DELETE /tickets/<reference>/subjects/<link_id>`.
+
 ## Management Commands
 
 ```bash

--- a/escalated/api_serializers.py
+++ b/escalated/api_serializers.py
@@ -53,6 +53,13 @@ class ApiTicketDetailSerializer:
     """Full ticket serializer for detail endpoints."""
 
     @staticmethod
+    def _serialize_subjects(ticket):
+        from escalated.ticket_subjects import serialize_ticket_subject_link
+
+        links = ticket.subjects.select_related("content_type").all()
+        return [serialize_ticket_subject_link(link) for link in links]
+
+    @staticmethod
     def serialize(ticket, include_replies=True, include_activities=True):
         assignee = ticket.assigned_to
         department = ticket.department
@@ -83,6 +90,7 @@ class ApiTicketDetailSerializer:
             ),
             "department": ({"id": department.pk, "name": department.name} if department else None),
             "tags": [{"id": tag.pk, "name": tag.name, "color": tag.color} for tag in ticket.tags.all()],
+            "subjects": ApiTicketDetailSerializer._serialize_subjects(ticket),
             "sla": {
                 "first_response_due_at": _format_dt(ticket.first_response_due_at),
                 "first_response_at": _format_dt(ticket.first_response_at),

--- a/escalated/api_urls.py
+++ b/escalated/api_urls.py
@@ -34,6 +34,12 @@ api_patterns = [
         name="ticket_custom_action",
     ),
     path("tickets/<str:reference>/tags/", api.ticket_tags, name="ticket_tags"),
+    path("tickets/<str:reference>/subjects/", api.ticket_subjects_store, name="ticket_subjects_store"),
+    path(
+        "tickets/<str:reference>/subjects/<int:subject_id>/",
+        api.ticket_subjects_destroy,
+        name="ticket_subjects_destroy",
+    ),
     path("tickets/<str:reference>/delete/", api.ticket_destroy, name="ticket_destroy"),
     # Resources
     path("agents/", api.resource_agents, name="agents"),

--- a/escalated/conf.py
+++ b/escalated/conf.py
@@ -21,6 +21,9 @@ DEFAULTS = {
     # where visible/enabled/confirmation/metadata may be values or callables
     # taking (ticket, user).
     "TICKET_ACTIONS": [],
+    # Host models a ticket can be *about* (Project, Customer, asset, …).
+    # Allowlist for agent/API attach; leave empty to disable API attach only.
+    "TICKET_SUBJECT_TYPES": [],
     "SLA": {
         "ENABLED": True,
         "BUSINESS_HOURS_ONLY": False,

--- a/escalated/contracts/__init__.py
+++ b/escalated/contracts/__init__.py
@@ -1,0 +1,3 @@
+from escalated.contracts.ticket_subject import TicketSubjectMixin, TicketSubjectProtocol
+
+__all__ = ["TicketSubjectMixin", "TicketSubjectProtocol"]

--- a/escalated/contracts/ticket_subject.py
+++ b/escalated/contracts/ticket_subject.py
@@ -1,0 +1,48 @@
+"""Contract for host-app models attachable as ticket subjects."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TicketSubjectProtocol(Protocol):
+    """Presentation contract for entities a ticket is *about*."""
+
+    def ticket_subject_title(self) -> str: ...
+
+    def ticket_subject_subtitle(self) -> str | None: ...
+
+    def ticket_subject_url(self) -> str | None: ...
+
+    def ticket_subject_color(self) -> str | None: ...
+
+    def ticket_subject_icon(self) -> str | None: ...
+
+
+class TicketSubjectMixin:
+    """
+    Default presentation for ticket subjects.
+
+    Override any method on the host model; title falls back to ``name``,
+    ``title``, or ``label`` attributes.
+    """
+
+    def ticket_subject_title(self) -> str:
+        for attribute in ("name", "title", "label"):
+            value = getattr(self, attribute, None)
+            if isinstance(value, str) and value:
+                return value
+        return str(self.pk)
+
+    def ticket_subject_subtitle(self) -> str | None:
+        return None
+
+    def ticket_subject_url(self) -> str | None:
+        return None
+
+    def ticket_subject_color(self) -> str | None:
+        return None
+
+    def ticket_subject_icon(self) -> str | None:
+        return None

--- a/escalated/migrations/0024_ticket_subjects.py
+++ b/escalated/migrations/0024_ticket_subjects.py
@@ -1,0 +1,50 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+from escalated.conf import get_table_name
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("escalated", "0023_host_user_id_string_keys"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TicketSubject",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("object_id", models.CharField(max_length=255)),
+                ("role", models.CharField(blank=True, max_length=255, null=True)),
+                ("position", models.PositiveIntegerField(default=0)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "content_type",
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="contenttypes.contenttype"),
+                ),
+                (
+                    "ticket",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="subjects",
+                        to="escalated.ticket",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": get_table_name("ticket_subjects"),
+                "ordering": ["position", "id"],
+                "indexes": [
+                    models.Index(fields=["content_type", "object_id"], name="escalated_ts_ct_obj_idx"),
+                ],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("ticket", "content_type", "object_id"),
+                        name="escalated_ticket_subject_unique",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/escalated/models.py
+++ b/escalated/models.py
@@ -497,6 +497,55 @@ class Ticket(models.Model):
         """Return the number of followers on this ticket."""
         return self.ticket_followers.count()
 
+    def attach_subject(self, subject, role=None, position=None):
+        """
+        Attach a host model as a subject of this ticket (idempotent on ticket+type+id).
+
+        When ``ESCALATED['TICKET_SUBJECT_TYPES']`` is non-empty, rejects types outside
+        that allowlist.
+        """
+        from escalated.ticket_subjects import assert_subject_type_allowed
+
+        assert_subject_type_allowed(subject)
+
+        content_type = ContentType.objects.get_for_model(subject)
+        object_id = str(subject.pk)
+        if position is None:
+            max_position = self.subjects.aggregate(models.Max("position"))["position__max"]
+            position = (max_position if max_position is not None else -1) + 1
+
+        link, _created = TicketSubject.objects.update_or_create(
+            ticket=self,
+            content_type=content_type,
+            object_id=object_id,
+            defaults={"role": role, "position": position},
+        )
+        return link
+
+    def detach_subject(self, subject) -> int:
+        """Detach a host model from this ticket's subjects (0 or 1 rows removed)."""
+        content_type = ContentType.objects.get_for_model(subject)
+        deleted, _ = TicketSubject.objects.filter(
+            ticket=self,
+            content_type=content_type,
+            object_id=str(subject.pk),
+        ).delete()
+        return deleted
+
+    def sync_subjects(self, subjects):
+        """
+        Replace this ticket's subjects, preserving order.
+
+        Each entry is a model instance or ``(model, role)`` tuple.
+        """
+        self.subjects.all().delete()
+        for position, entry in enumerate(subjects):
+            if isinstance(entry, (list, tuple)):
+                subject, role = entry[0], entry[1] if len(entry) > 1 else None
+            else:
+                subject, role = entry, None
+            self.attach_subject(subject, role=role, position=position)
+
     @property
     def sla_first_response_remaining(self):
         if not self.first_response_due_at or self.first_response_at:
@@ -556,6 +605,40 @@ class Ticket(models.Model):
         self.snoozed_by = None
         self.status_before_snooze = None
         self.save(update_fields=["status", "snoozed_until", "snoozed_by", "status_before_snooze", "updated_at"])
+
+
+class TicketSubject(models.Model):
+    """
+    Join row linking a ticket to one host-app entity it is *about*.
+
+    Distinct from the ticket subject *line* (``Ticket.subject``) and the
+    requester. ``object_id`` is a string so integer, UUID, and string PKs work.
+    """
+
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, related_name="subjects")
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.CharField(max_length=255)
+    subject = GenericForeignKey("content_type", "object_id")
+    role = models.CharField(max_length=255, null=True, blank=True)
+    position = models.PositiveIntegerField(default=0)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = get_table_name("ticket_subjects")
+        ordering = ["position", "id"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["ticket", "content_type", "object_id"],
+                name="escalated_ticket_subject_unique",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["content_type", "object_id"]),
+        ]
+
+    def __str__(self):
+        return f"TicketSubject #{self.pk} on {self.ticket_id}"
 
 
 class Reply(models.Model):

--- a/escalated/serializers.py
+++ b/escalated/serializers.py
@@ -33,6 +33,13 @@ def _user_dict(user):
 
 class TicketSerializer:
     @staticmethod
+    def _serialize_subjects(ticket):
+        from escalated.ticket_subjects import serialize_ticket_subject_link
+
+        links = ticket.subjects.select_related("content_type").all()
+        return [serialize_ticket_subject_link(link) for link in links]
+
+    @staticmethod
     def serialize(ticket, include_replies=False, include_activities=False):
         data = {
             "id": ticket.pk,
@@ -48,6 +55,7 @@ class TicketSerializer:
             "department": (DepartmentSerializer.serialize(ticket.department) if ticket.department else None),
             "sla_policy": (SlaPolicySerializer.serialize_brief(ticket.sla_policy) if ticket.sla_policy else None),
             "tags": [TagSerializer.serialize(tag) for tag in ticket.tags.all()],
+            "subjects": TicketSerializer._serialize_subjects(ticket),
             "is_open": ticket.is_open,
             "first_response_at": _format_dt(ticket.first_response_at),
             "first_response_due_at": _format_dt(ticket.first_response_due_at),

--- a/escalated/ticket_subjects.py
+++ b/escalated/ticket_subjects.py
@@ -1,0 +1,143 @@
+"""Ticket subject allowlist resolution and serialization helpers."""
+
+from __future__ import annotations
+
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.db import models
+
+from escalated.conf import get_setting
+from escalated.contracts.ticket_subject import TicketSubjectProtocol
+
+
+def get_ticket_subject_type_allowlist() -> list[str]:
+    """Flatten ESCALATED['TICKET_SUBJECT_TYPES'] (list or alias dict) to lookup keys."""
+    configured = get_setting("TICKET_SUBJECT_TYPES") or []
+    if isinstance(configured, dict):
+        keys: list[str] = []
+        for key, value in configured.items():
+            keys.append(str(key))
+            keys.append(str(value))
+        return keys
+    return [str(item) for item in configured]
+
+
+def model_type_key(model: models.Model) -> str:
+    """Stable type identifier for a host model (Django app label + model name)."""
+    meta = model._meta
+    if meta.proxy:
+        return meta.concrete_model._meta.label
+    return meta.label
+
+
+def resolve_allowed_model_class(type_key: str) -> type[models.Model]:
+    """
+    Resolve a request-supplied type to a model class when it is allowlisted.
+
+    Raises ValidationError on unknown or disallowed types (422 for API views).
+    """
+    allowed = get_ticket_subject_type_allowlist()
+    if not allowed:
+        raise ValidationError({"type": "Attaching ticket subjects via the API is not configured."})
+
+    if type_key not in allowed:
+        raise ValidationError({"type": f"Subject type [{type_key}] is not an allowed ticket subject."})
+
+    model_class = _resolve_model_class(type_key)
+    if model_class is None:
+        raise ValidationError({"type": f"Subject type [{type_key}] could not be resolved to a model."})
+
+    return model_class
+
+
+def _resolve_model_class(type_key: str) -> type[models.Model] | None:
+    if "." in type_key:
+        try:
+            return apps.get_model(type_key)
+        except (LookupError, ValueError):
+            pass
+
+        try:
+            from django.utils.module_loading import import_string
+
+            candidate = import_string(type_key)
+            if isinstance(candidate, type) and issubclass(candidate, models.Model):
+                return candidate
+        except ImportError:
+            pass
+
+    for model in apps.get_models():
+        if model_type_key(model) == type_key:
+            return model
+    return None
+
+
+def assert_subject_type_allowed(model: models.Model) -> None:
+    """Enforce programmatic allowlist when ESCALATED['TICKET_SUBJECT_TYPES'] is non-empty."""
+    allowed = get_ticket_subject_type_allowlist()
+    if not allowed:
+        return
+
+    key = model_type_key(model)
+    if key not in allowed:
+        raise ValueError(f"Subject type [{key}] is not an allowed ticket subject.")
+
+
+def serialize_ticket_subject_link(link) -> dict:
+    """Serialize a TicketSubject row for ticket JSON payloads."""
+    content_object = None
+    try:
+        content_object = link.subject
+    except Exception:
+        content_object = None
+
+    presents = isinstance(content_object, TicketSubjectProtocol) or (
+        content_object is not None and callable(getattr(content_object, "ticket_subject_title", None))
+    )
+    try:
+        content_type = link.content_type
+    except Exception:
+        content_type = None
+
+    if content_object is not None and hasattr(content_object, "_meta"):
+        type_key = model_type_key(content_object)
+    elif content_type is not None:
+        type_key = _content_type_key(content_type)
+    else:
+        type_key = "unknown"
+
+    missing = content_object is None
+
+    if presents:
+        title = content_object.ticket_subject_title()
+        subtitle = content_object.ticket_subject_subtitle()
+        url = content_object.ticket_subject_url()
+        color = content_object.ticket_subject_color()
+        icon = content_object.ticket_subject_icon()
+    elif content_object is not None:
+        name = getattr(content_object, "name", None)
+        title = name if isinstance(name, str) and name else f"{type_key} #{link.object_id}"
+        subtitle = url = color = icon = None
+    else:
+        title = f"{type_key} #{link.object_id}"
+        subtitle = url = color = icon = None
+
+    return {
+        "type": type_key,
+        "id": link.object_id,
+        "role": link.role,
+        "title": title,
+        "subtitle": subtitle,
+        "url": url,
+        "color": color,
+        "icon": icon,
+        "missing": missing,
+    }
+
+
+def _content_type_key(content_type: ContentType) -> str:
+    model_class = content_type.model_class()
+    if model_class is not None:
+        return model_type_key(model_class)
+    return f"{content_type.app_label}.{content_type.model}"

--- a/escalated/urls.py
+++ b/escalated/urls.py
@@ -44,6 +44,12 @@ agent_patterns = [
     path("agent/tickets/<int:ticket_id>/status/", agent.ticket_status, name="agent_ticket_status"),
     path("agent/tickets/<int:ticket_id>/priority/", agent.ticket_priority, name="agent_ticket_priority"),
     path("agent/tickets/<int:ticket_id>/tags/", agent.ticket_tags, name="agent_ticket_tags"),
+    path("agent/tickets/<int:ticket_id>/subjects/", agent.ticket_subjects_store, name="agent_ticket_subjects_store"),
+    path(
+        "agent/tickets/<int:ticket_id>/subjects/<int:subject_id>/",
+        agent.ticket_subjects_destroy,
+        name="agent_ticket_subjects_destroy",
+    ),
     path("agent/tickets/<int:ticket_id>/department/", agent.ticket_department, name="agent_ticket_department"),
     path("agent/tickets/<int:ticket_id>/macro/", agent.ticket_apply_macro, name="agent_ticket_macro"),
     path(
@@ -74,6 +80,12 @@ admin_patterns = [
     path("admin/tickets/<int:ticket_id>/status/", admin.tickets_status, name="admin_tickets_status"),
     path("admin/tickets/<int:ticket_id>/priority/", admin.tickets_priority, name="admin_tickets_priority"),
     path("admin/tickets/<int:ticket_id>/tags/", admin.tickets_tags, name="admin_tickets_tags"),
+    path("admin/tickets/<int:ticket_id>/subjects/", admin.tickets_subjects_store, name="admin_tickets_subjects_store"),
+    path(
+        "admin/tickets/<int:ticket_id>/subjects/<int:subject_id>/",
+        admin.tickets_subjects_destroy,
+        name="admin_tickets_subjects_destroy",
+    ),
     path("admin/tickets/<int:ticket_id>/department/", admin.tickets_department, name="admin_tickets_department"),
     path("admin/tickets/<int:ticket_id>/macro/", admin.tickets_apply_macro, name="admin_tickets_macro"),
     path("admin/tickets/<int:ticket_id>/follow/", admin.tickets_follow, name="admin_tickets_follow"),

--- a/escalated/views/admin.py
+++ b/escalated/views/admin.py
@@ -528,6 +528,46 @@ def tickets_tags(request, ticket_id):
 
 
 @login_required
+def tickets_subjects_store(request, ticket_id):
+    """Attach a host-app subject to a ticket (admin)."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        ticket = Ticket.objects.get(pk=ticket_id)
+    except Ticket.DoesNotExist:
+        return HttpResponseNotFound(_("Ticket not found"))
+
+    from escalated.views.ticket_subjects import attach_ticket_subject
+
+    return attach_ticket_subject(request, ticket)
+
+
+@login_required
+def tickets_subjects_destroy(request, ticket_id, subject_id):
+    """Detach a ticket subject link (admin)."""
+    check = _require_admin(request)
+    if check:
+        return check
+
+    if request.method != "DELETE":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        ticket = Ticket.objects.get(pk=ticket_id)
+    except Ticket.DoesNotExist:
+        return HttpResponseNotFound(_("Ticket not found"))
+
+    from escalated.views.ticket_subjects import detach_ticket_subject
+
+    return detach_ticket_subject(request, ticket, subject_id)
+
+
+@login_required
 def tickets_department(request, ticket_id):
     """Change ticket department (admin)."""
     check = _require_admin(request)

--- a/escalated/views/agent.py
+++ b/escalated/views/agent.py
@@ -458,6 +458,46 @@ def ticket_tags(request, ticket_id):
 
 
 @login_required
+def ticket_subjects_store(request, ticket_id):
+    """Attach a host-app subject to a ticket."""
+    check = _require_agent(request)
+    if check:
+        return check
+
+    if request.method != "POST":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        ticket = Ticket.objects.get(pk=ticket_id)
+    except Ticket.DoesNotExist:
+        return HttpResponseNotFound(_("Ticket not found"))
+
+    from escalated.views.ticket_subjects import attach_ticket_subject
+
+    return attach_ticket_subject(request, ticket)
+
+
+@login_required
+def ticket_subjects_destroy(request, ticket_id, subject_id):
+    """Detach a ticket subject link."""
+    check = _require_agent(request)
+    if check:
+        return check
+
+    if request.method != "DELETE":
+        return HttpResponseForbidden(_("Method not allowed"))
+
+    try:
+        ticket = Ticket.objects.get(pk=ticket_id)
+    except Ticket.DoesNotExist:
+        return HttpResponseNotFound(_("Ticket not found"))
+
+    from escalated.views.ticket_subjects import detach_ticket_subject
+
+    return detach_ticket_subject(request, ticket, subject_id)
+
+
+@login_required
 def ticket_department(request, ticket_id):
     """Change ticket department."""
     check = _require_agent(request)

--- a/escalated/views/api.py
+++ b/escalated/views/api.py
@@ -85,6 +85,7 @@ def _resolve_ticket(reference):
         "chat_sessions",
         "links_as_parent__child_ticket",
         "links_as_child__parent_ticket",
+        "subjects__content_type",
     )
 
     try:
@@ -639,6 +640,49 @@ def ticket_tags(request, reference):
         service.remove_tags(ticket, request.user, to_remove)
 
     return JsonResponse({"message": "Tags updated."})
+
+
+@csrf_exempt
+@require_POST
+def ticket_subjects_store(request, reference):
+    """
+    POST /tickets/<reference>/subjects
+
+    Attach a host-app entity the ticket is about.
+
+    JSON body:
+        type (required) — allowlisted model label, e.g. ``myapp.Project``
+        id (required) — primary key of the host record
+        role (optional) — label such as ``project`` or ``account``
+    """
+    denied = _require_ability(request, "tickets:update")
+    if denied:
+        return denied
+
+    ticket, resolve_error = _resolve_ticket(reference)
+    if resolve_error:
+        return resolve_error
+
+    from escalated.views.ticket_subjects import attach_ticket_subject
+
+    return attach_ticket_subject(request, ticket)
+
+
+@csrf_exempt
+@require_http_methods(["DELETE"])
+def ticket_subjects_destroy(request, reference, subject_id):
+    """DELETE /tickets/<reference>/subjects/<subject_id> — detach a subject link."""
+    denied = _require_ability(request, "tickets:update")
+    if denied:
+        return denied
+
+    ticket, resolve_error = _resolve_ticket(reference)
+    if resolve_error:
+        return resolve_error
+
+    from escalated.views.ticket_subjects import detach_ticket_subject
+
+    return detach_ticket_subject(request, ticket, subject_id)
 
 
 @csrf_exempt

--- a/escalated/views/ticket_subjects.py
+++ b/escalated/views/ticket_subjects.py
@@ -1,0 +1,74 @@
+"""Attach/detach ticket subject endpoints (agent, admin, REST API)."""
+
+import json
+
+from django.core.exceptions import ValidationError
+from django.http import HttpResponseNotFound, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from escalated.models import Ticket, TicketSubject
+from escalated.ticket_subjects import resolve_allowed_model_class
+
+
+def _parse_subject_payload(request) -> dict:
+    if request.content_type and "json" in request.content_type:
+        return json.loads(request.body or "{}")
+    return {
+        "type": request.POST.get("type"),
+        "id": request.POST.get("id"),
+        "role": request.POST.get("role"),
+    }
+
+
+def attach_ticket_subject(request, ticket: Ticket) -> JsonResponse:
+    """POST body: type (required), id (required), role (optional)."""
+    try:
+        payload = _parse_subject_payload(request)
+    except json.JSONDecodeError:
+        return JsonResponse({"errors": {"_error": "Invalid JSON."}}, status=422)
+
+    type_key = payload.get("type")
+    subject_id = payload.get("id")
+    if not type_key or subject_id is None or subject_id == "":
+        return JsonResponse(
+            {"errors": {"type": "Required.", "id": "Required."}},
+            status=422,
+        )
+
+    try:
+        model_class = resolve_allowed_model_class(str(type_key))
+    except ValidationError as exc:
+        return JsonResponse({"errors": exc.message_dict}, status=422)
+
+    subject = model_class.objects.filter(pk=subject_id).first()
+    if subject is None:
+        return JsonResponse({"errors": {"id": "No matching subject was found."}}, status=422)
+
+    role = payload.get("role")
+    if role is not None:
+        role = str(role)
+
+    link = ticket.attach_subject(subject, role=role or None)
+    return JsonResponse({"id": link.pk, "message": "Subject attached."})
+
+
+def detach_ticket_subject(request, ticket: Ticket, subject_link_id: int) -> JsonResponse:
+    link = TicketSubject.objects.filter(pk=subject_link_id, ticket=ticket).first()
+    if link is None:
+        return HttpResponseNotFound()
+
+    link.delete()
+    return JsonResponse({"message": "Subject detached."})
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def api_ticket_subjects_store(request, ticket: Ticket):
+    return attach_ticket_subject(request, ticket)
+
+
+@csrf_exempt
+@require_http_methods(["DELETE"])
+def api_ticket_subjects_destroy(request, ticket: Ticket, subject_id: int):
+    return detach_ticket_subject(request, ticket, subject_id)

--- a/tests/unit/test_ticket_subjects.py
+++ b/tests/unit/test_ticket_subjects.py
@@ -1,0 +1,206 @@
+"""Ticket subjects — host entities a ticket is *about*."""
+
+import json
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.test import override_settings
+
+from escalated.models import Tag, TicketSubject
+from escalated.serializers import TicketSerializer
+from escalated.ticket_subjects import resolve_allowed_model_class, serialize_ticket_subject_link
+from tests.factories import TagFactory, TicketFactory
+
+TAG_TYPE = "escalated.Tag"
+
+
+@pytest.fixture
+def allow_tags(settings):
+    settings.ESCALATED = {
+        **settings.ESCALATED,
+        "TICKET_SUBJECT_TYPES": [TAG_TYPE],
+    }
+
+
+@pytest.mark.django_db
+class TestTicketSubjectModel:
+    def test_attach_preserves_string_object_id(self, allow_tags):
+        ticket = TicketFactory()
+        tag_ct = ContentType.objects.get_for_model(Tag)
+        link = TicketSubject.objects.create(
+            ticket=ticket,
+            content_type=tag_ct,
+            object_id="prj_9f1c",
+            role="project",
+        )
+
+        assert link.object_id == "prj_9f1c"
+        assert link.role == "project"
+
+    def test_attach_subject_idempotent_and_updates_role(self, allow_tags):
+        ticket = TicketFactory()
+        tag = TagFactory()
+
+        ticket.attach_subject(tag)
+        ticket.attach_subject(tag, role="account")
+
+        assert ticket.subjects.count() == 1
+        assert ticket.subjects.first().role == "account"
+
+    def test_detach_subject(self, allow_tags):
+        ticket = TicketFactory()
+        tag = TagFactory()
+        ticket.attach_subject(tag)
+
+        assert ticket.detach_subject(tag) == 1
+        assert ticket.subjects.count() == 0
+
+    def test_sync_subjects_replaces_and_orders(self, allow_tags):
+        ticket = TicketFactory()
+        a = TagFactory(slug="a")
+        b = TagFactory(slug="b")
+        c = TagFactory(slug="c")
+
+        ticket.attach_subject(a)
+        ticket.sync_subjects([(b, "primary"), c])
+
+        links = list(ticket.subjects.all())
+        assert len(links) == 2
+        assert links[0].object_id == str(b.pk)
+        assert links[0].role == "primary"
+        assert links[0].position == 0
+        assert links[1].object_id == str(c.pk)
+        assert links[1].position == 1
+
+    def test_rejects_type_outside_allowlist(self, settings):
+        settings.ESCALATED = {
+            **settings.ESCALATED,
+            "TICKET_SUBJECT_TYPES": ["auth.User"],
+        }
+        ticket = TicketFactory()
+        tag = TagFactory()
+
+        with pytest.raises(ValueError, match="not an allowed ticket subject"):
+            ticket.attach_subject(tag)
+
+    @override_settings(ESCALATED={"TICKET_SUBJECT_TYPES": []})
+    def test_allows_any_model_when_allowlist_empty(self, settings):
+        settings.ESCALATED = {**settings.ESCALATED, "TICKET_SUBJECT_TYPES": []}
+        ticket = TicketFactory()
+        tag = TagFactory()
+
+        link = ticket.attach_subject(tag)
+        assert isinstance(link, TicketSubject)
+
+
+@pytest.mark.django_db
+class TestTicketSubjectSerialization:
+    def test_serializes_name_fallback(self, allow_tags):
+        ticket = TicketFactory()
+        tag = TagFactory(name="Billing", slug="billing")
+        ticket.attach_subject(tag, role="topic")
+
+        data = TicketSerializer.serialize(ticket)
+
+        assert data["subjects"][0]["title"] == "Billing"
+        assert data["subjects"][0]["type"] == TAG_TYPE
+        assert data["subjects"][0]["missing"] is False
+
+    def test_serializes_presentation_contract(self, allow_tags):
+        from unittest.mock import PropertyMock, patch
+
+        ticket = TicketFactory()
+        tag = TagFactory(name="Billing", slug="billing")
+        link = ticket.attach_subject(tag, role="topic")
+
+        presenter = type(
+            "Presenter",
+            (),
+            {
+                "_meta": tag._meta,
+                "ticket_subject_title": lambda self: "Billing",
+                "ticket_subject_subtitle": lambda self: "Topic · billing",
+                "ticket_subject_url": lambda self: "https://app.test/tags/billing",
+                "ticket_subject_color": lambda self: "#2563eb",
+                "ticket_subject_icon": lambda self: "tag",
+            },
+        )()
+
+        with patch.object(type(link), "subject", new_callable=PropertyMock, return_value=presenter):
+            payload = serialize_ticket_subject_link(link)
+
+        assert payload["subtitle"] == "Topic · billing"
+        assert payload["url"] == "https://app.test/tags/billing"
+        assert payload["color"] == "#2563eb"
+        assert payload["icon"] == "tag"
+
+    def test_missing_subject_graceful_fallback(self, allow_tags):
+        ticket = TicketFactory()
+        tag = TagFactory()
+        link = ticket.attach_subject(tag)
+        tag_id = tag.pk
+        tag.delete()
+
+        payload = serialize_ticket_subject_link(TicketSubject.objects.get(pk=link.pk))
+
+        assert payload["missing"] is True
+        assert payload["id"] == str(tag_id)
+        assert str(tag_id) in payload["title"]
+
+
+@pytest.mark.django_db
+class TestTicketSubjectAllowlistResolution:
+    def test_resolve_allowed_model_class(self, allow_tags):
+        model_class = resolve_allowed_model_class(TAG_TYPE)
+        assert model_class is Tag
+
+    def test_resolve_rejects_unknown_type(self, allow_tags):
+        with pytest.raises(ValidationError):
+            resolve_allowed_model_class("auth.NotAllowed")
+
+    def test_resolve_rejects_when_allowlist_empty(self, settings):
+        settings.ESCALATED = {**settings.ESCALATED, "TICKET_SUBJECT_TYPES": []}
+        with pytest.raises(ValidationError):
+            resolve_allowed_model_class(TAG_TYPE)
+
+
+@pytest.mark.django_db
+class TestTicketSubjectApi:
+    def test_api_attach_and_detach(self, rf, settings):
+        from escalated.views import api
+        from tests.factories import ApiTokenFactory, DepartmentFactory, UserFactory
+        from tests.integration.test_api_views import _api_post
+
+        settings.ESCALATED = {**settings.ESCALATED, "TICKET_SUBJECT_TYPES": [TAG_TYPE]}
+
+        user = UserFactory(username="subj_agent")
+        department = DepartmentFactory()
+        department.agents.add(user)
+        token = ApiTokenFactory(user=user, abilities=["tickets:update"])
+
+        ticket = TicketFactory()
+        tag = TagFactory(name="Billing", slug="billing")
+
+        request = _api_post(
+            rf,
+            f"/api/tickets/{ticket.reference}/subjects/",
+            user,
+            token,
+            {"type": TAG_TYPE, "id": tag.pk, "role": "topic"},
+        )
+        response = api.ticket_subjects_store(request, ticket.reference)
+        assert response.status_code == 200
+        link_id = json.loads(response.content)["id"]
+        assert ticket.subjects.count() == 1
+        assert TicketSubject.objects.filter(pk=link_id, object_id=str(tag.pk)).exists()
+
+        request = rf.delete(
+            f"/api/tickets/{ticket.reference}/subjects/{link_id}/",
+            HTTP_AUTHORIZATION=f"Bearer {token.plain_text}",
+        )
+        request.user = user
+        request.api_token = token
+        response = api.ticket_subjects_destroy(request, ticket.reference, link_id)
+        assert response.status_code == 200
+        assert ticket.subjects.count() == 0


### PR DESCRIPTION
Django port of Ticket Subjects (mirrors escalated-laravel#122 / escalated-nestjs#59; discussion #89). Host entities a ticket is *about* (Project/Customer/asset) — multiple, polymorphic, distinct from the requester.

- `TicketSubject` model with a `GenericForeignKey`: `content_type` + **`object_id = CharField(max_length=255)`** (UUID/string-safe, matching this repo's GFK convention), `role`, `position`; unique `(ticket, content_type, object_id)`; cascade on ticket delete. New migration `0024_ticket_subjects`.
- `TicketSubjectMixin` / `TicketSubjectProtocol` (`ticket_subject_title/subtitle/url/color/icon`; title defaults from name/title/label) for host models.
- `Ticket.subjects` + `attach_subject`/`detach_subject`/`sync_subjects` (idempotent, allowlist via `ESCALATED['TICKET_SUBJECT_TYPES']`).
- `subjects[]` `{type,id,role,title,subtitle,url,color,icon,missing}` on the ticket serializer (graceful fallback when the target row is gone). Agent/admin/REST `POST`/`DELETE` attach/detach (allowlist-only).

`pytest` ✅ **761 passed**; `ruff` clean. (The `makemigrations --check` drift on this machine is the pre-existing Django-6 noise — `Mention` removal/index renames — unrelated to this PR; `0024` is the only feature migration and matches the model.)