### PR TITLE
fix(newsletter): make django newsletter feature load + run on SQLite

### DIFF
--- a/escalated/migrations/0025_merge_newsletter_ticket_subjects.py
+++ b/escalated/migrations/0025_merge_newsletter_ticket_subjects.py
@@ -1,0 +1,18 @@
+"""Merge the parallel newsletter and ticket-subjects migration branches.
+
+`0023_newsletter_system` (newsletter) and `0024_ticket_subjects` both branched
+from the skills/host-user-key line, leaving two leaf nodes in the migration
+graph. They touch disjoint tables, so an empty merge migration is sufficient
+to linearise the graph.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("escalated", "0023_newsletter_system"),
+        ("escalated", "0024_ticket_subjects"),
+    ]
+
+    operations = []

--- a/escalated/services/newsletter/bounce_suppression_store.py
+++ b/escalated/services/newsletter/bounce_suppression_store.py
@@ -1,11 +1,11 @@
-"""Bounce / complaint suppression store backed by EscalatedSettings JSON."""
+"""Bounce / complaint suppression store backed by EscalatedSetting JSON."""
 
 from __future__ import annotations
 
 import json
 from collections.abc import Iterable
 
-from escalated.models import EscalatedSettings
+from escalated.models import EscalatedSetting
 
 
 class BounceSuppressionStore:
@@ -30,13 +30,14 @@ class BounceSuppressionStore:
         if lower in current:
             return
         current.append(lower)
-        EscalatedSettings.objects.update_or_create(
+        # EscalatedSetting has only key/value columns (no type/group).
+        EscalatedSetting.objects.update_or_create(
             key=self.KEY,
-            defaults={"value": json.dumps(current), "type": "json", "group": "newsletter"},
+            defaults={"value": json.dumps(current)},
         )
 
     def _load(self) -> list[str]:
-        row = EscalatedSettings.objects.filter(key=self.KEY).first()
+        row = EscalatedSetting.objects.filter(key=self.KEY).first()
         if not row or not row.value:
             return []
         try:

--- a/escalated/services/newsletter/contact_segment_resolver.py
+++ b/escalated/services/newsletter/contact_segment_resolver.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from django.db.models import Q
-
 from escalated.models import Contact, NewsletterList, NewsletterListMember
 
 
@@ -26,8 +24,20 @@ class ContactSegmentResolver:
     def count_matches(self, filter_dict: dict) -> int:
         return self._apply_filter(filter_dict).count()
 
+    # op -> ORM lookup suffix. "!=" is handled via .exclude() (Django has no
+    # __ne lookup — the previous mapping raised FieldError).
+    OP_SUFFIX = {
+        "=": "",
+        ">": "__gt",
+        ">=": "__gte",
+        "<": "__lt",
+        "<=": "__lte",
+        "contains": "__icontains",
+    }
+
     def _apply_filter(self, filter_dict: dict, qs=None):
         qs = qs if qs is not None else Contact.objects.all()
+        allowed_fields = {f.name for f in Contact._meta.get_fields()}
         for rule in (filter_dict or {}).get("rules", []):
             field = rule.get("field")
             op = rule.get("op") or "="
@@ -36,21 +46,15 @@ class ContactSegmentResolver:
                 continue
             if field.startswith("metadata."):
                 key = field.split(".", 1)[1]
-                qs = qs.filter(metadata__contains={key: value})
+                # JSON key lookup — metadata__contains is NOT supported on SQLite
+                # and raised NotSupportedError. The key transform works on both.
+                qs = qs.filter(**{f"metadata__{key}": value})
                 continue
-            lookup = self._django_lookup(field, op)
-            qs = qs.filter(Q(**{lookup: value}))
+            # Allowlist the field (avoid FieldError on arbitrary input) and op.
+            if field not in allowed_fields or (op != "=" and op not in self.OP_SUFFIX and op != "!="):
+                continue
+            if op == "!=":
+                qs = qs.exclude(**{field: value})
+                continue
+            qs = qs.filter(**{f"{field}{self.OP_SUFFIX.get(op, '')}": value})
         return qs
-
-    def _django_lookup(self, field: str, op: str) -> str:
-        ops = {
-            "=": "",
-            "!=": "__ne",  # Django uses .exclude — simplified for v1
-            ">": "__gt",
-            ">=": "__gte",
-            "<": "__lt",
-            "<=": "__lte",
-            "contains": "__icontains",
-        }
-        suffix = ops.get(op, "")
-        return f"{field}{suffix}"

--- a/escalated/services/newsletter/planner.py
+++ b/escalated/services/newsletter/planner.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import secrets
 
+from django.db import transaction
+
 from escalated.models import Contact, Newsletter, NewsletterDelivery, NewsletterList
 
 from .bounce_suppression_store import BounceSuppressionStore
@@ -21,42 +23,46 @@ class NewsletterPlanner:
         self.bounces = bounces or BounceSuppressionStore()
 
     def plan(self, newsletter: Newsletter) -> None:
-        newsletter.status = "sending"
-        newsletter.save(update_fields=["status"])
+        # Atomic: status flip + delivery snapshot + summary must all commit
+        # together. Without this, a failure mid-bulk_create left committed
+        # partial deliveries with the newsletter stuck in "sending".
+        with transaction.atomic():
+            newsletter.status = "sending"
+            newsletter.save(update_fields=["status"])
 
-        target_list = NewsletterList.objects.filter(id=newsletter.target_list_id).first()
-        if not target_list:
-            newsletter.summary_total = 0
-            newsletter.save(update_fields=["summary_total"])
-            return
+            target_list = NewsletterList.objects.filter(id=newsletter.target_list_id).first()
+            if not target_list:
+                newsletter.summary_total = 0
+                newsletter.save(update_fields=["summary_total"])
+                return
 
-        contact_ids = self.segments.resolve_sendable(target_list)
-        if not contact_ids:
-            newsletter.summary_total = 0
-            newsletter.save(update_fields=["summary_total"])
-            return
+            contact_ids = self.segments.resolve_sendable(target_list)
+            if not contact_ids:
+                newsletter.summary_total = 0
+                newsletter.save(update_fields=["summary_total"])
+                return
 
-        contacts = list(Contact.objects.filter(id__in=contact_ids).values("id", "email"))
-        sendable = {e.lower() for e in self.bounces.filter_sendable([c["email"] for c in contacts])}
+            contacts = list(Contact.objects.filter(id__in=contact_ids).values("id", "email"))
+            sendable = {e.lower() for e in self.bounces.filter_sendable([c["email"] for c in contacts])}
 
-        rows = []
-        for c in contacts:
-            if c["email"].lower() not in sendable:
-                continue
-            rows.append(
-                NewsletterDelivery(
-                    newsletter_id=newsletter.id,
-                    contact_id=c["id"],
-                    email_at_send=c["email"],
-                    status="pending",
-                    tracking_token=secrets.token_hex(20),
-                    attempt_count=0,
-                    is_test=False,
+            rows = []
+            for c in contacts:
+                if c["email"].lower() not in sendable:
+                    continue
+                rows.append(
+                    NewsletterDelivery(
+                        newsletter_id=newsletter.id,
+                        contact_id=c["id"],
+                        email_at_send=c["email"],
+                        status="pending",
+                        tracking_token=secrets.token_hex(20),
+                        attempt_count=0,
+                        is_test=False,
+                    )
                 )
-            )
 
-        for i in range(0, len(rows), 500):
-            NewsletterDelivery.objects.bulk_create(rows[i : i + 500])
+            for i in range(0, len(rows), 500):
+                NewsletterDelivery.objects.bulk_create(rows[i : i + 500])
 
-        newsletter.summary_total = len(rows)
-        newsletter.save(update_fields=["summary_total"])
+            newsletter.summary_total = len(rows)
+            newsletter.save(update_fields=["summary_total"])

--- a/tests/test_newsletter_segment_resolver.py
+++ b/tests/test_newsletter_segment_resolver.py
@@ -1,0 +1,41 @@
+"""Regression tests for ContactSegmentResolver dynamic-list filtering.
+
+Covers the bugs found in the 2026-05-29 newsletter review:
+- metadata filtering used `metadata__contains`, which raises NotSupportedError
+  on SQLite; it now uses a JSON key transform.
+- `!=` mapped to a nonexistent `__ne` lookup (FieldError); it now uses exclude().
+- arbitrary `field` values are skipped instead of raising FieldError.
+"""
+
+import pytest
+
+from escalated.models import Contact
+from escalated.services.newsletter.contact_segment_resolver import ContactSegmentResolver
+
+
+@pytest.mark.django_db
+class TestContactSegmentResolver:
+    def test_metadata_key_filter_runs_on_sqlite(self):
+        Contact.objects.create(email="gold@example.com", metadata={"tier": "gold"})
+        Contact.objects.create(email="silver@example.com", metadata={"tier": "silver"})
+        resolver = ContactSegmentResolver()
+
+        flt = {"rules": [{"field": "metadata.tier", "op": "=", "value": "gold"}]}
+        assert resolver.count_matches(flt) == 1
+
+    def test_not_equal_uses_exclude(self):
+        Contact.objects.create(email="keep@example.com", name="Keep")
+        Contact.objects.create(email="drop@example.com", name="Drop")
+        resolver = ContactSegmentResolver()
+
+        flt = {"rules": [{"field": "name", "op": "!=", "value": "Drop"}]}
+        emails = set(resolver._apply_filter(flt).values_list("email", flat=True))
+        assert emails == {"keep@example.com"}
+
+    def test_unknown_field_is_skipped(self):
+        Contact.objects.create(email="a@example.com")
+        resolver = ContactSegmentResolver()
+
+        flt = {"rules": [{"field": "id); DROP TABLE", "op": "=", "value": 1}]}
+        # Unknown field is skipped (not a FieldError); all contacts still match.
+        assert resolver.count_matches(flt) == 1


### PR DESCRIPTION
Remediation of the blocking django newsletter bugs from the 2026-05-29 review (after the Wave-3 merge). Newsletters are disabled by default; no live exposure.

## Bugs fixed

1. **App fails to import** — `BounceSuppressionStore` imported `EscalatedSettings` (no such class; it's `EscalatedSetting`, singular) and wrote `type`/`group` columns that don't exist. Importing the newsletter services package raised `ImportError`. Fixed the class name and dropped the phantom columns.

2. **Segment resolver crashed on SQLite / FieldError**:
   - `metadata__contains={...}` raises `NotSupportedError` on SQLite → now a JSON key transform (`metadata__<key>`), supported on SQLite + Postgres.
   - `"!=" → "__ne"` is not a Django lookup (`FieldError`) → now uses `.exclude()`.
   - `field`/`op` are now allowlisted (field against the model's fields), so arbitrary input is skipped instead of raising `FieldError`.

3. **Migration conflict** — `0023_newsletter_system` and `0024_ticket_subjects` were parallel leaf nodes (every test DB build failed with "multiple leaf nodes"). Added empty merge migration `0025_merge_newsletter_ticket_subjects` (they touch disjoint tables).

4. **Non-transactional Plan** — `NewsletterPlanner.plan()` flipped status, bulk-inserted deliveries in batches, and set the summary without a transaction; a mid-insert failure left partial deliveries and a stuck "sending" status. Wrapped in `transaction.atomic()`.

## Tests

`tests/test_newsletter_segment_resolver.py` — metadata key filter runs on SQLite, `!=` excludes correctly, unknown field is skipped. **3 passed.** ruff clean.
