### PR TITLE
fix(newsletter): UUID-safe user-id columns on newsletter models

### DIFF
--- a/escalated/migrations/0026_newsletter_uuid_user_columns.py
+++ b/escalated/migrations/0026_newsletter_uuid_user_columns.py
@@ -1,0 +1,43 @@
+"""Make newsletter user-id columns UUID-safe.
+
+created_by/added_by/sent_by were PositiveIntegerField (integer-only), which
+breaks UUID/string-keyed hosts. Switch to CharField (matching Contact.user_id,
+the package's host-user-id storage pattern). The fields are nullable and not
+currently populated, so this is a safe in-place column type change.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("escalated", "0025_merge_newsletter_ticket_subjects"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="newsletter",
+            name="created_by",
+            field=models.CharField(blank=True, db_index=True, max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name="newsletter",
+            name="sent_by",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name="newsletterlist",
+            name="created_by",
+            field=models.CharField(blank=True, db_index=True, max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name="newsletterlistmember",
+            name="added_by",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name="newslettertemplate",
+            name="created_by",
+            field=models.CharField(blank=True, db_index=True, max_length=255, null=True),
+        ),
+    ]

--- a/escalated/models.py
+++ b/escalated/models.py
@@ -2453,7 +2453,7 @@ class NewsletterList(models.Model):
     description = models.TextField(blank=True, null=True)
     kind = models.CharField(max_length=16, choices=KIND_CHOICES, db_index=True)
     filter_json = models.JSONField(blank=True, null=True)
-    created_by = models.PositiveIntegerField(blank=True, null=True, db_index=True)
+    created_by = models.CharField(max_length=255, blank=True, null=True, db_index=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -2468,7 +2468,7 @@ class NewsletterListMember(models.Model):
     list_id = models.PositiveIntegerField()
     contact_id = models.PositiveIntegerField(db_index=True)
     added_at = models.DateTimeField(auto_now_add=True)
-    added_by = models.PositiveIntegerField(blank=True, null=True)
+    added_by = models.CharField(max_length=255, blank=True, null=True)
 
     class Meta:
         db_table = "escalated_newsletter_list_members"
@@ -2484,7 +2484,7 @@ class NewsletterTemplate(models.Model):
     subject_template = models.CharField(max_length=998, blank=True, null=True)
     body_markdown = models.TextField()
     merge_fields_schema = models.JSONField(blank=True, null=True)
-    created_by = models.PositiveIntegerField(blank=True, null=True, db_index=True)
+    created_by = models.CharField(max_length=255, blank=True, null=True, db_index=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -2516,8 +2516,8 @@ class Newsletter(models.Model):
     status = models.CharField(max_length=16, default="draft", choices=STATUS_CHOICES, db_index=True)
     scheduled_at = models.DateTimeField(blank=True, null=True, db_index=True)
     sent_at = models.DateTimeField(blank=True, null=True)
-    created_by = models.PositiveIntegerField(blank=True, null=True, db_index=True)
-    sent_by = models.PositiveIntegerField(blank=True, null=True)
+    created_by = models.CharField(max_length=255, blank=True, null=True, db_index=True)
+    sent_by = models.CharField(max_length=255, blank=True, null=True)
     summary_total = models.PositiveIntegerField(default=0)
     summary_sent = models.PositiveIntegerField(default=0)
     summary_opened = models.PositiveIntegerField(default=0)


### PR DESCRIPTION
Newsletter `created_by`/`added_by`/`sent_by` were `PositiveIntegerField` (integer-only), breaking UUID/string-keyed hosts. Switches them to `CharField` (matching `Contact.user_id`, the package's host-user-id storage pattern). The fields are nullable and not currently populated, so the column type change is safe. Migration `0026` was hand-written (running `makemigrations` would have swept in unrelated pre-existing model drift). Resolver regression test green; ruff clean.